### PR TITLE
Benchmark driver for MLIR kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib/.DS_Store
 lib/TPP/.DS_Store
 compile_commands.json
 *.swp
+__pycache__

--- a/benchmarks/harness/Execute/__init__.py
+++ b/benchmarks/harness/Execute/__init__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+ Execute Commands, return out/err, accepts parser plugins
+
+ Usage:
+  out, err = Execute(logger).run(['myapp', '-flag', 'etc'])
+"""
+
+import subprocess
+
+class Execute(object):
+    """Executes commands, returns out/err"""
+
+    def __init__(self, logger=None):
+        self.logger = logger
+
+    def run(self, program, input=''):
+        """Execute Commands, return out/err"""
+
+        if program and not isinstance(program, list):
+            raise TypeError("Program needs to be a list of arguments")
+        if not program:
+            raise ValueError("Need program arguments to execute")
+
+        if self.logger:
+            self.logger.debug('Executing: %s' % repr(program))
+
+        # Call the program, capturing stdout/stderr
+        result = subprocess.run(program,
+                                input=bytes(input, encoding='utf-8'),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+        # Collect stdout, stderr as UTF-8 strings
+        result.stdout = result.stdout.decode('utf-8')
+        result.stderr = result.stderr.decode('utf-8')
+
+        # Return
+        return result

--- a/benchmarks/harness/Execute/__init__.py
+++ b/benchmarks/harness/Execute/__init__.py
@@ -11,7 +11,7 @@ import subprocess
 class Execute(object):
     """Executes commands, returns out/err"""
 
-    def __init__(self, logger=None):
+    def __init__(self, logger):
         self.logger = logger
 
     def run(self, program, input=''):

--- a/benchmarks/harness/FileCheckParser/__init__.py
+++ b/benchmarks/harness/FileCheckParser/__init__.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""
+ Parse IR files for comments indicating metadata that we can actually use.
+
+ Usage:
+  params = FileCheckParser(self.logger).parse('kernel.mlir')
+
+ Params: A dictionary containing the following fields, if found
+    - 'iters': Iterations, from a RUN line
+    - 'entry': Kernel function name, from a RUN line
+    - 'libs': Shared library argument, from a RUN line
+    - 'expected_mean': From a BENCH_EXPECTED_MEAN line
+    - 'expected_stdev': From a BENCH_EXPECTED_STDEV line
+"""
+
+import re
+
+class FileCheckParser(object):
+    """Parsers IR files for FileCheck lines to extract informatio
+       about the execution of the kernel"""
+
+    def __init__(self, logger=None):
+        self.logger = logger
+        # FileCheck line style
+        self.runRE = re.compile("^\/\/\s*RUN: (.*)$");
+        self.expectMeanRE = re.compile("^\/\/\s*BENCH_EXPECT_MEAN: ([\d\.\-e]+)")
+        self.expectStdevRE = re.compile("^\/\/\s*BENCH_EXPECT_STDEV: ([\d\.\-e]+)")
+        # Arguments in the RUN lines for tpp-opt
+        self.optArgs = re.compile("tpp-opt (%\w+)\s+(.*?)\s*\|")
+        # Arguments in the RUN lines for tpp-run
+        self.entryRE = re.compile("-e\s+(\w+)\s")
+        self.itersRE = re.compile("-n\s+(\d+)\s")
+        self.libsRE = re.compile("-shared-libs=([^\s]+)\s")
+        # All matches
+        self.result = {}
+
+    def _parseLines(self, file):
+        """ Scan the file for FileCheck lines and update the results cache """
+
+        runLine = ""
+        for line in file.readlines():
+            # First the easy ones: mean/stdev
+            m = self.expectMeanRE.match(line)
+            if m:
+                self.logger.debug("MEAN line detected: " + m.group(1))
+                if 'mean' in self.result:
+                    self.logger.warning("Multiple mean lines detected, using last one")
+                self.result['mean'] = float(m.group(1))
+
+            m = self.expectStdevRE.match(line)
+            if m:
+                self.logger.debug("STDEV line detected: " + m.group(1))
+                if 'stdev' in self.result:
+                    self.logger.warning("Multiple stdev lines detected, using last one")
+                self.result['stdev'] = float(m.group(1))
+
+            # Now, concatenate all RUN lines, to make sure we can match
+            # arguments through line breaks
+            m = self.runRE.match(line)
+            if m:
+                runLine += m.group(1)
+
+        # If we found any RUN line, clean it up
+        if runLine:
+            runLine = re.sub('\\\\', '', runLine)
+        self.logger.debug("RUN line detected: " + runLine)
+
+        # Now we match the remaining args in the RUN lines
+        m = self.optArgs.search(runLine)
+        if m:
+            self.result['opt-args'] = m.group(2)
+            self.logger.debug("Opt args detected: " + m.group(2))
+
+        m = self.entryRE.search(runLine)
+        if m:
+            self.result['entry'] = m.group(1)
+            self.logger.debug("Entry point detected: " + m.group(1))
+        else:
+            self.logger.info("Did not find the entry point argument in RUN lines")
+
+        m = self.itersRE.search(runLine)
+        if m:
+            self.result['iters'] = int(m.group(1))
+            self.logger.debug("Number of iterations detected: " + m.group(1))
+        else:
+            self.logger.info("Did not find the iterations argument in RUN lines")
+
+        m = self.libsRE.search(runLine)
+        if m:
+            self.result['shared-libs'] = m.group(1)
+            self.logger.debug("Shared libraries detected: " + m.group(1))
+        else:
+            self.logger.info("Did not find the shared libs argument in RUN lines")
+
+    def parse(self, filename):
+        """Parses an IR file, returns a dictsionary with the data found"""
+
+        try:
+            with open(filename) as file:
+                self._parseLines(file)
+        except IOError as err:
+            self.logger.error("Cannot open file '" + filename + "': " + err.strerror)
+            return {}
+        except ValueError as err:
+            self.logger.error("Cannot convert string into int/float: " + err.strerror)
+            return {}
+        except NameError as err:
+            self.logger.error("Name error while parsing IR file: " + err.args)
+            return {}
+        except Exception as err:
+            self.logger.error("Uncaught error while parsing IR file: " + err.strerror)
+            return {}
+
+        # Return
+        return self.result

--- a/benchmarks/harness/FileCheckParser/__init__.py
+++ b/benchmarks/harness/FileCheckParser/__init__.py
@@ -19,7 +19,7 @@ class FileCheckParser(object):
     """Parsers IR files for FileCheck lines to extract informatio
        about the execution of the kernel"""
 
-    def __init__(self, logger=None):
+    def __init__(self, logger):
         self.logger = logger
         # FileCheck line style
         self.runRE = re.compile("^\/\/\s*RUN: (.*)$");

--- a/benchmarks/harness/Logger/__init__.py
+++ b/benchmarks/harness/Logger/__init__.py
@@ -21,7 +21,7 @@ class Logger(object):
         self.logger = logging.getLogger(name)
 
         # Default level is WARNING (no output other than warnings and errors)
-        start = 30
+        start = logging.WARNING
         silent = min(verbosity*10, 20)
         coloredlogs.install(level=start-silent, logger=self.logger)
         self.parser = parser

--- a/benchmarks/harness/Logger/__init__.py
+++ b/benchmarks/harness/Logger/__init__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+    Verbosity levels
+    https://pypi.org/project/verboselogs/#overview-of-logging-levels
+
+    Useful levels:
+    DEBUG  10       -vv
+    INFO  20        -v
+
+    The following two we don't want to filter:
+    WARNING  30
+    ERROR  40
+    CRITICAL  50
+"""
+
+import logging
+import coloredlogs
+
+class Logger(object):
+    def __init__(self, name, parser, verbosity):
+        self.logger = logging.getLogger(name)
+
+        # Default level is WARNING (no output other than warnings and errors)
+        start = 30
+        silent = min(verbosity*10, 20)
+        coloredlogs.install(level=start-silent, logger=self.logger)
+        self.parser = parser
+
+    def error(self, err, print_help=False):
+        self.logger.error(err)
+        if print_help:
+            print('\n\n')
+            self.parser.print_help()
+
+    def warning(self, warning):
+        self.logger.warning(warning)
+
+    def info(self, info):
+        self.logger.info(info)
+
+    def debug(self, trace):
+        self.logger.debug(trace)
+
+    def silent(self):
+        return self.logger.getEffectiveLevel() > logging.INFO

--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    TPP-MLIR Benchmark Driver
+
+    Runs an MLIR kernel multiple times and takes the statistics, comparing to
+    a known-good result, checking if any difference is statistically significant.
+
+    Arguments:
+     * filename: kernel to run on
+     * -n N: Number of times to run (default 1000)
+     * -e ENTRY: Entry point name (default "entry")
+     * -mean MEAN: Expected mean
+     * -stdev STDEV: Expected standard deviation
+     * -shared-libs=PATH: MLIR/TPP runtime paths
+
+    Like LLVM's FileCheck, we try to get information from comments on the MLIR
+    file (//).
+
+    We can look at RUN lines, for details on how to process the file, like entry
+    point, shared-libs, tpp-opt args.
+
+    We also support new ones:
+     * BENCH_EXPECTED_MEAN: FP -> Expected value for mean
+     * BENCH_EXPECTED_STDIV: FP -> Expected value for standard deviation
+
+    Much of the code was shamelessly stolen from my previous harness:
+    https://github.com/Linaro/benchmark_harness/
+"""
+
+import os
+import sys
+import re
+import shlex
+import argparse
+
+from Logger import Logger
+from Execute import Execute
+from FileCheckParser import FileCheckParser
+
+class BenchmarkController(object):
+    """ Entry point of the benchmark harness"""
+
+    def __init__(self, args, logger):
+        self.args = args
+        self.logger = logger
+        # If we're in a git repo, find the base dir, otherwise, this is the base dir
+        self.baseDir = self._findGitRoot(os.path.dirname(__file__))
+        self.logger.debug("Base dir: " + self.baseDir)
+        self.programs = self._findTPPProgs()
+        self.variables = self._getLLVMVariables(self.baseDir)
+        self.output = ''
+        self.mean = 0.0
+        self.stdev = 0.0
+
+    def _findGitRoot(self, path):
+        """ Find the git root directory, if any, or return the input """
+
+        temp = path
+        while temp:
+            if (os.path.exists(os.path.join(temp, ".git"))):
+                return temp
+            temp = os.path.abspath(os.path.join(temp, os.pardir))
+        return path
+
+    def _findTPPProgs(self):
+        """ Find the necessary TPP programs to run the benchmarks """
+
+        programs = { 'tpp-opt': '', 'tpp-run': '' }
+        found = 0
+        maxProgs = len(programs.keys())
+        for root, dirs, files in os.walk(self.baseDir):
+            for prog in programs.keys():
+                if prog in files:
+                    programs[prog] = os.path.join(root, prog)
+                    self.logger.debug(prog + ": " + programs[prog])
+                    found += 1
+            if found == maxProgs:
+                break
+
+        if found < maxProgs:
+            self.logger.error("Cannot find all TPP programs")
+            self.logger.error("Found: " + programs)
+            return {}
+        return programs
+
+    def _getLLVMVariables(self, path):
+        """ Find config values in the LIT config in the build dir """
+
+        # Some variables are not in the LIT config and are known
+        nonConfig = {}
+        if 'tpp-run' in self.programs:
+            nonConfig['tpplibdir'] = os.path.abspath(
+                                        os.path.join(
+                                        os.path.dirname(
+                                            self.programs['tpp-run']),
+                                            '../lib'))
+        # Others we need to find in the config in the build dir
+        variables = { 'llvmlibdir': 'config.llvm_lib_dir',
+                      'shlibext': 'config.llvm_shlib_ext' }
+        # Merge the two and count how many we need to match
+        variables.update(nonConfig)
+        maxMatches = len(variables.keys()) - len(nonConfig.keys())
+        matches = 0
+        for root, dirs, files in os.walk(self.baseDir):
+            if "lit.site.cfg.py" in files:
+                filename = os.path.join(root, "lit.site.cfg.py")
+                with open(filename) as file:
+                    for line in file.readlines():
+                        for key, val in variables.items():
+                            # Skip the ones found already
+                            if not val.startswith('config.'):
+                                continue
+                            # Find the config and replace with the value
+                            m = re.match(val + " = \"([^\\\"]+)\"", line)
+                            if m:
+                                variables[key] = m.group(1)
+                                self.logger.debug("Found " + key + ": " + variables[key])
+                                matches += 1
+                        # Leave if found everything
+                        if matches == maxMatches:
+                            return variables
+
+    def verifyArgs(self):
+        """ Verify cmd-line and IR file arguments, update defaults, etc """
+
+        # Parse the IR file for user arguments
+        self.logger.info("Parsing FileCheck lines, updating arguments")
+        fileArgs = FileCheckParser(self.logger).parse(args.benchmark_name)
+
+        # Command line arguments have preference
+        if (not self.args.n and 'iters' in fileArgs):
+            self.args.n = fileArgs['iters']
+        if (not self.args.entry and 'entry' in fileArgs):
+            self.args.entry = fileArgs['entry']
+        if (not self.args.shared_libs and 'shared-libs' in fileArgs):
+            self.args.shared_libs = fileArgs['shared-libs']
+        if (not self.args.mean and 'mean' in fileArgs):
+            self.args.mean = fileArgs['mean']
+        if (not self.args.stdev and 'stdev' in fileArgs):
+            self.args.stdev = fileArgs['stdev']
+        if (not self.args.opt_args and 'opt-args' in fileArgs):
+            self.args.opt_args = fileArgs['opt-args']
+
+        # Make sure we get all we need
+        self.logger.info("Validating arguments")
+        if (not self.args.n):
+            logger.warning("Number of iterations not found, default to 1000")
+            self.args.n = 1000
+
+        if (not self.args.entry):
+            logger.error("No entry point defined, bailing")
+            return False
+
+        if (not self.args.shared_libs):
+            logger.warning("No shared library path, benchmark may not run correctly")
+        else:
+            # Make sure the line doesn't have %vars% which can't be resolved
+            m = re.search("%", self.args.shared_libs)
+            if m:
+                for key, val in self.variables.items():
+                    self.args.shared_libs = re.sub("%" + key, val, self.args.shared_libs)
+                self.logger.debug("Shared libraries updated: " + self.args.shared_libs)
+
+            # Check again, to make sure we replaced everything
+            m = re.search("%", self.args.shared_libs)
+            if m:
+                self.logger.error("Shared libs argument contain %variables, won't be able to resolve")
+                return False
+
+        # We don't need mean/stdev for running, but we also can't judge results without them
+        if (not self.args.mean or not self.args.stdev):
+            self.logger.warning("Need both mean/stdev to compare against a known good value")
+
+        return True
+
+    def run(self):
+        """ Run tpp-opt and tpp-run to get the timings """
+
+        irContents = ""
+        executor = Execute(self.logger)
+
+        # Only run tpp-opt if we have the arguments
+        if self.args.opt_args:
+            self.logger.info("Running optimiser, to prepare the IR file")
+            optCmd = [ self.programs['tpp-opt'], self.args.benchmark_name ]
+            optCmd.extend(shlex.split(self.args.opt_args))
+
+            # Run tpp-opt and capture the output IR
+            optResult = executor.run(optCmd)
+            if optResult.stderr:
+                self.logger.error("Error executing tpp-opt: " + optResult.stderr)
+                return False
+            irContents = optResult.stdout
+        else:
+            # Bypass tpp-opt and just dump the file
+            with open(self.args.benchmark_name) as file:
+                irContents = file.readall()
+
+        # Actually run the file in benchmark mode, no output
+        self.logger.info("Running the kernel with the arguments provided")
+        runCmd = [ self.programs['tpp-run'], '-n', str(self.args.n),
+                                             '-e', self.args.entry,
+                                             '--entry-point-result=void',
+                                             '--shared-libs=' + self.args.shared_libs,
+                                             '--print=0',
+                  ]
+        runResult = executor.run(runCmd, irContents)
+        if runResult.stderr:
+            self.logger.error("Error executing tpp-run: " + runResult.stderr)
+            return False
+        self.output = runResult.stdout
+
+        return True
+
+    def verifyStats(self):
+        """ Verify the results, should be in format '( mean, stdev )' """
+
+        if not self.output:
+            self.logger.error("Benchmark produced no output, can't verify results")
+            return False
+
+        # Parse results
+        m = re.search("([\d\.\-e]+), ([\d\.\-e]+)", self.output)
+        if m:
+            self.mean = float(m.group(1))
+            self.stdev = float(m.group(2))
+            self.logger.info("Mean time: " + str(self.mean) + "s (" + str(self.stdev) + "s)")
+        else:
+            self.logger.error("Cannot find mean/stdev in output")
+            return False
+
+        # Check against expected output, if any
+        self.logger.info("Validate statistics against expected values")
+        if self.args.mean and self.args.stdev:
+            em = float(self.args.mean)
+            es = float(self.args.stdev)
+            if self.mean > (em - es) and self.mean < (em + es):
+                self.logger.info("Result mean compatible with expected")
+            else:
+                self.logger.error("Result mean not compatible with expected")
+                return False
+
+            if self.stdev > es:
+                self.logger.error("Result deviation too large: " + str(self.stdev) + " > " + str(es))
+                return False
+
+        return True
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='TPP-MLIR Benchmark Harness')
+
+    # Required argument: benchmark name (can be a file or a directory)
+    parser.add_argument('benchmark_name', type=str,
+                        help='MLIR file or directory containing MLIR files')
+
+    # Required, but auto-detected if omitted
+    parser.add_argument('-n', type=int,
+                        help='Number of times to execute the kernel (checks BENCH_N line)')
+    parser.add_argument('-mean', type=float,
+                        help='Expected mean to compare to (checks BENCH_EXPECTED_MEAN line)')
+    parser.add_argument('-stdev', type=float,
+                        help='Expected stdev to compare to (checks BENCH_EXPECTED_STDEV line)')
+    parser.add_argument('-entry', type=str,
+                        help='Name of the entry point (checks RUN line)')
+    parser.add_argument('-shared-libs', type=str,
+                        help='Path of the runtime libraries (checks RUN line)')
+    parser.add_argument('-opt-args', type=str,
+                        help='tpp-opt arguments (checks RUN line)')
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='The verbosity of logging output')
+    parser.add_argument('-q', '--quiet', action='count', default=0,
+                        help='Suppress warnings')
+    args = parser.parse_args()
+
+    # Creates the logger object
+    logger = Logger(__name__, parser, args.verbose - (args.quiet > 0))
+
+    # Creates a controller from command line arguments
+    controller = BenchmarkController(args, logger)
+
+    # Checks all parameters are good
+    if (not controller.verifyArgs()):
+        logger.error("Argument verification error", print_help=True)
+        sys.exit(1)
+
+    # Runs the benchmark
+    if (not controller.run()):
+        logger.error("Error executing the benchmark")
+        sys.exit(1)
+
+    # Checks stats
+    if (not controller.verifyStats()):
+        logger.error("Error verifying the statistics")
+        sys.exit(1)
+
+    # Success prints basic stats
+    print(f'{args.benchmark_name}: {(controller.mean*1000):3.6f} ms ({(controller.stdev*1000):3.6f} ms)')
+

--- a/benchmarks/harness/requirements.txt
+++ b/benchmarks/harness/requirements.txt
@@ -1,0 +1,1 @@
+coloredlogs==15.0.1


### PR DESCRIPTION
This change adds a benchmark harness to drive `tpp-run` through MLIR kernels, auto-detecting arguments so that we can just call them on select files or use it as an actual benchmark driver.

We still need to replace the existing benchmarks with calling the harness.

Working towards #175 