### PR TITLE
Change how loggers are created in benchmark harness

### DIFF
--- a/benchmarks/harness/Execute/__init__.py
+++ b/benchmarks/harness/Execute/__init__.py
@@ -8,11 +8,13 @@
 
 import subprocess
 
+from Logger import Logger
+
 class Execute(object):
     """Executes commands, returns out/err"""
 
-    def __init__(self, logger):
-        self.logger = logger
+    def __init__(self, loglevel):
+        self.logger = Logger("execute", loglevel)
 
     def run(self, program, input=''):
         """Execute Commands, return out/err"""

--- a/benchmarks/harness/FileCheckParser/__init__.py
+++ b/benchmarks/harness/FileCheckParser/__init__.py
@@ -14,12 +14,14 @@
 
 import re
 
+from Logger import Logger
+
 class FileCheckParser(object):
     """Parsers IR files for FileCheck lines to extract informatio
        about the execution of the kernel"""
 
-    def __init__(self, logger):
-        self.logger = logger
+    def __init__(self, loglevel):
+        self.logger = Logger("filecheck.parser", loglevel)
         # FileCheck line style
         self.runRE = re.compile("^\/\/\s*RUN: (.*)$");
         self.flopsRE = re.compile("^\/\/\s*BENCH_TOTAL_FLOPS: ([\d\.\-e]+)")

--- a/benchmarks/harness/Logger/__init__.py
+++ b/benchmarks/harness/Logger/__init__.py
@@ -17,20 +17,16 @@ import logging
 import coloredlogs
 
 class Logger(object):
-    def __init__(self, name, parser, verbosity):
+    def __init__(self, name, verbosity):
         self.logger = logging.getLogger(name)
 
         # Default level is WARNING (no output other than warnings and errors)
         start = logging.WARNING
-        silent = min(verbosity*10, 20)
+        silent = min(verbosity*10, logging.INFO)
         coloredlogs.install(level=start-silent, logger=self.logger)
-        self.parser = parser
 
-    def error(self, err, print_help=False):
+    def error(self, err):
         self.logger.error(err)
-        if print_help:
-            print('\n\n')
-            self.parser.print_help()
 
     def warning(self, warning):
         self.logger.warning(warning)

--- a/benchmarks/harness/TPPHelper/__init__.py
+++ b/benchmarks/harness/TPPHelper/__init__.py
@@ -13,11 +13,13 @@ import re
 import shlex
 import argparse
 
+from Logger import Logger
+
 class TPPHelper(object):
     """ Detects paths, libraries, executables, LLVM variables, etc. """
 
-    def __init__(self, logger):
-        self.logger = logger
+    def __init__(self, loglevel):
+        self.logger = Logger("tpp.helper", loglevel)
 
     def findGitRoot(self, path):
         """ Find the git root directory, if any, or return the input """


### PR DESCRIPTION
Before, all log lines were from the same place ("__main__") because they were being passed as an object. A better approach is to get a new logger for each class so it's clear where the logs are coming from. But that also means we need to pass the loglevel to all classes, instead of the logger itself.

Fixes #198