### PR TITLE
Rename check-tpp-opt to check-all (NFC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cmake -G Ninja .. \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DMLIR_DIR=$CUSTOM_LLVM_ROOT/lib/cmake/mlir \
    -DLLVM_EXTERNAL_LIT=$CUSTOM_LLVM_ROOT/bin/llvm-lit
-cmake --build . --target check-tpp-opt
+cmake --build . --target check-all
 
 popd
 ```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,10 +11,10 @@ set(TPP_OPT_TEST_DEPENDS
         tpp-run
         )
 
-add_lit_testsuite(check-tpp-opt "Running the tpp-opt regression tests"
+add_lit_testsuite(check-all "Running the tpp-opt regression tests"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${TPP_OPT_TEST_DEPENDS}
         )
-set_target_properties(check-tpp-opt PROPERTIES FOLDER "Tests")
+set_target_properties(check-all PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(TPP_OPT ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TPP_OPT_TEST_DEPENDS})


### PR DESCRIPTION
Our tests don't just check tpp-opt anymore, and we don't have a split like LLVM, so it's easier to standardise it to check-all.