### PR TITLE
Perf dialect (#100)

### DIFF
--- a/include/TPP/Dialect/CMakeLists.txt
+++ b/include/TPP/Dialect/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Check)
 add_subdirectory(LinalgX)
+add_subdirectory(Perf)
 add_subdirectory(Tpp)
 add_subdirectory(Transform)
 add_subdirectory(VNNI)

--- a/include/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h
+++ b/include/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h
@@ -1,0 +1,22 @@
+//===- BufferizableOpInterfaceImpl.h - Impl. of BufferizableOpInterface ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_PERF_BUFFERIZABLEOPINTERFACEIMPL_H
+#define MLIR_DIALECT_PERF_BUFFERIZABLEOPINTERFACEIMPL_H
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir {
+namespace perf {
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry);
+} // namespace perf
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PERF_BUFFERIZABLEOPINTERFACEIMPL_H

--- a/include/TPP/Dialect/Perf/CMakeLists.txt
+++ b/include/TPP/Dialect/Perf/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_mlir_dialect(PerfOps perf)
+add_mlir_doc(PerfDialect PerfDialect Perf/ -gen-dialect-doc)
+add_mlir_doc(PerfOps PerfOps Perf/ -gen-op-doc)

--- a/include/TPP/Dialect/Perf/PerfDialect.h
+++ b/include/TPP/Dialect/Perf/PerfDialect.h
@@ -1,0 +1,17 @@
+//===- TppDialect.h - Tpp dialect -------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_PERF_DIALECT_H
+#define TPP_PERF_DIALECT_H
+
+// clang-format off
+#include "mlir/IR/Dialect.h"
+#include "TPP/Dialect/Perf/PerfOpsDialect.h.inc"
+// clang-format on
+
+#endif // TPP_PERF_DIALECT_H

--- a/include/TPP/Dialect/Perf/PerfDialect.h
+++ b/include/TPP/Dialect/Perf/PerfDialect.h
@@ -1,4 +1,4 @@
-//===- TppDialect.h - Tpp dialect -------------------------------*- C++ -*-===//
+//===- PerfDialect.h - Perf dialect -----------------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/TPP/Dialect/Perf/PerfDialect.td
+++ b/include/TPP/Dialect/Perf/PerfDialect.td
@@ -23,6 +23,8 @@ def Perf_Dialect : Dialect {
         for code performance benchmarking.
     }];
     let cppNamespace = "::mlir::perf";
+
+    let useDefaultTypePrinterParser = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/TPP/Dialect/Perf/PerfDialect.td
+++ b/include/TPP/Dialect/Perf/PerfDialect.td
@@ -1,0 +1,35 @@
+//===- PerfDialect.td - Perf dialect ------------------------*- tablegen -*--===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_PERF_DIALECT
+#define TPP_PERF_DIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Perf dialect definition.
+//===----------------------------------------------------------------------===//
+
+def Perf_Dialect : Dialect {
+    let name = "perf";
+    let summary = "Performance benchmarking dialect.";
+    let description = [{
+        This dialect provides basic primitives suitable
+        for code performance benchmarking.
+    }];
+    let cppNamespace = "::mlir::perf";
+}
+
+//===----------------------------------------------------------------------===//
+// Base operation definition.
+//===----------------------------------------------------------------------===//
+
+class Perf_Op<string mnemonic, list<Trait> traits = []> :
+        Op<Perf_Dialect, mnemonic, traits>;
+
+#endif // TPP_PERF_DIALECT

--- a/include/TPP/Dialect/Perf/PerfDialect.td
+++ b/include/TPP/Dialect/Perf/PerfDialect.td
@@ -1,4 +1,4 @@
-//===- PerfDialect.td - Perf dialect ------------------------*- tablegen -*--===//
+//===- PerfDialect.td - Perf dialect ----------------------*- tablegen -*--===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/TPP/Dialect/Perf/PerfOps.h
+++ b/include/TPP/Dialect/Perf/PerfOps.h
@@ -9,6 +9,7 @@
 #ifndef TPP_DIALECT_PERF_PERFOPS_H
 #define TPP_DIALECT_PERF_PERFOPS_H
 
+#include "TPP/Dialect/Perf/PerfTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/TPP/Dialect/Perf/PerfOps.h
+++ b/include/TPP/Dialect/Perf/PerfOps.h
@@ -1,0 +1,23 @@
+//===- TppOps.h - Tpp dialect ops -------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_DIALECT_PERF_PERFOPS_H
+#define TPP_DIALECT_PERF_PERFOPS_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "TPP/Dialect/Perf/PerfOps.h.inc"
+
+#endif // TPP_DIALECT_PERF_PERFOPS_H

--- a/include/TPP/Dialect/Perf/PerfOps.h
+++ b/include/TPP/Dialect/Perf/PerfOps.h
@@ -1,4 +1,4 @@
-//===- TppOps.h - Tpp dialect ops -------------------------------*- C++ -*-===//
+//===- PerfOps.h - Perf dialect ops -----------------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -1,0 +1,261 @@
+//===- TppOps.td - Tpp dialect ops -------------------------*- tablegen -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_PERF_OPS
+#define TPP_PERF_OPS
+
+include "PerfDialect.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
+
+def PerfTimer : AnyTypeOf<[I64]>;
+
+//===----------------------------------------------------------------------===//
+// BenchOp
+//===----------------------------------------------------------------------===//
+def Perf_BenchOp : Perf_Op<"bench",
+    [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">]> {
+  let summary = "Benchmark the enclosed code.";
+  let description = [{
+    The `perf.bench` operation generates benchmarking code
+    around the enclosed region.
+    The performance results are gathered over the specified
+    number of iterations.
+
+    The operation allocates memory to store the results.
+    The lifetime of the returned results has to be managed by the user.
+
+    Example:
+
+    ```mlir
+
+    %deltas = perf.bench (%n) {
+      ... // ops under measurement
+    } -> memref<?xf64>
+
+    ```
+
+    Optionally, a yield op can be added:
+
+    ```mlir
+
+    %deltas = perf.bench (%n) {
+      ... // ops under measurement
+      perf.yield
+    } -> memref<?xf64>
+
+    ```
+  }];
+
+  let arguments = (ins I64:$numIters);
+  let results = (outs RankedOrUnrankedMemRefOf<[F64]>:$deltas,
+            Variadic<AnyType>:$bodyResults);
+  let regions = (region SizedRegion<1>:$region);
+
+  let assemblyFormat = [{
+    `(` $numIters `)`
+    $region attr-dict
+    `->` type($deltas) (`,` type($bodyResults)^)?
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// YieldOp
+//===----------------------------------------------------------------------===//
+
+def Perf_YieldOp : Perf_Op<"yield", [ HasParent<"BenchOp">,
+              Pure, Terminator, ReturnLike]> {
+  let summary = "Yield values to parent operation.";
+  let description = [{
+    The `perf.yield` operation yields an SSA value from the perf dialect op
+    region and terminates the regions. The semantics of how the values are
+    yielded is defined by the parent operation.
+    If `perf.yield` has any operands, the operands must match the parent
+    operation's results.
+    If the parent operation defines no values, then the `perf.yield` may be
+    left out in the custom syntax and the builders will insert one implicitly.
+    Otherwise, it has to be present in the syntax to indicate which values are
+    yielded.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$results);
+  let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
+
+  let assemblyFormat =
+    [{  attr-dict ($results^ `:` type($results))? }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// StartTimerOp
+//===----------------------------------------------------------------------===//
+
+def Perf_StartTimerOp : Perf_Op<"start_timer", []> {
+  let summary = "Start a timer.";
+  let description = [{
+    The `perf.start_timer` operation creates a new timer
+    which begins time measurement.
+
+    See `perf.stop_timer` for timer termination.
+
+    Example:
+
+    ```mlir
+
+    %timer = perf.start_timer : i64
+    ... // ops under measurement
+
+    ```
+  }];
+
+  let arguments = (ins);
+  let results = (outs PerfTimer:$timer);
+
+  let assemblyFormat = [{
+    attr-dict `:` type($timer)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// StopTimerOp
+//===----------------------------------------------------------------------===//
+
+def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
+  let summary = "Stops a timer.";
+  let description = [{
+    The `perf.stop_timer` operation stops the specified
+    timer and returns elapsed time delta.
+
+    See `perf.start_timer` for timer creation.
+
+    Example:
+
+    ```mlir
+
+    %timer = perf.start_timer : i64
+    ... // ops under measurement
+    %delta = perf.stop_timer(%timer : i64) : f64
+
+    ```
+  }];
+
+  let arguments = (ins PerfTimer:$timer);
+  let results = (outs F64:$delta);
+
+  let assemblyFormat = [{
+    `(` $timer `:` type($timer) `)` attr-dict
+    `:` type($delta)
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// MeanOp
+//===----------------------------------------------------------------------===//
+
+def Perf_MeanOp : Perf_Op<"mean", []> {
+  let summary = "Compute mean value.";
+  let description = [{
+    The `perf.mean` operation computes mean value of the provided
+    time deltas.
+
+    Example:
+
+    ```mlir
+
+    %deltas = perf.bench (%n) {
+      ... // benchmarked code
+    } -> memref<?xf64>
+
+    %mean = perf.mean(%deltas : memref<?xf64>) : f64
+
+    ```
+  }];
+
+  let arguments = (ins RankedOrUnrankedMemRefOf<[F64]>:$input);
+  let results = (outs F64:$mean);
+
+  let assemblyFormat = [{
+    `(` $input `:` type($input) `)` attr-dict
+    `:` type($mean)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// StdevOp
+//===----------------------------------------------------------------------===//
+
+def Perf_StdevOp : Perf_Op<"stdev", []> {
+  let summary = "Compute standard deviation.";
+  let description = [{
+    The `perf.stdev` operation computes standard deviation of the provided
+    time deltas.
+
+    Example:
+
+    ```mlir
+
+    %deltas = perf.bench (%n) {
+      ... // benchmarked code
+    } -> memref<?xf64>
+
+    %mean = perf.mean(%deltas : memref<?xf64>) : f64
+    %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
+
+    ```
+  }];
+
+  let arguments = (ins RankedOrUnrankedMemRefOf<[F64]>:$input, F64:$mean);
+  let results = (outs F64:$stdev);
+
+  let assemblyFormat = [{
+    `(` $input `:` type($input) `,` $mean `:` type($mean) `)` attr-dict
+    `:` type($stdev)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// DoNotOptOp
+//===----------------------------------------------------------------------===//
+
+def Perf_DoNotOptOp : Perf_Op<"do_not_opt", [ConditionallySpeculatable]> {
+  let summary = "Prevent removal of unused values.";
+  let description = [{
+    The `perf.do_not_opt` operation acts as a dummy, not speculatable
+    operation that prevents removal of unused values and their defining ops
+    by optimization passes.
+
+    Example:
+
+    ```mlir
+
+    %deltas = perf.bench (%n) {
+      %a = arith.addi %b, %c : i64
+      perf.do_not_opt(%a) : i64 // make sure that 'addi' is not optimized away
+    } -> memref<?xf64>
+
+    ```
+  }];
+
+  let arguments = (ins AnyType:$input);
+
+  let assemblyFormat = [{
+    `(` $input `)` attr-dict `:` type($input)
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::Speculation::Speculatability getSpeculatability() {
+    return ::mlir::Speculation::NotSpeculatable;
+    }
+  }];
+}
+
+#endif // TPP_PERF_OPS

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -9,12 +9,11 @@
 #ifndef TPP_PERF_OPS
 #define TPP_PERF_OPS
 
-include "PerfDialect.td"
+include "TPP/Dialect/Perf/PerfDialect.td"
+include "TPP/Dialect/Perf/PerfTypes.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
-
-def PerfTimer : AnyTypeOf<[I64]>;
 
 //===----------------------------------------------------------------------===//
 // BenchOp
@@ -167,7 +166,7 @@ def Perf_StartTimerOp : Perf_Op<"start_timer", []> {
   }];
 
   let arguments = (ins);
-  let results = (outs PerfTimer:$timer);
+  let results = (outs Perf_TimerType:$timer);
 
   let assemblyFormat = [{
     attr-dict `:` type($timer)
@@ -197,7 +196,7 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
     ```
   }];
 
-  let arguments = (ins PerfTimer:$timer);
+  let arguments = (ins Perf_TimerType:$timer);
   let results = (outs F64:$delta);
 
   let assemblyFormat = [{

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -1,4 +1,4 @@
-//===- TppOps.td - Tpp dialect ops -------------------------*- tablegen -*-===//
+//===- PerfOps.td - Perf dialect ops -----------------------*- tablegen -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -31,23 +31,15 @@ def Perf_BenchOp : Perf_Op<"bench",
     The operation allocates memory to store the results.
     The lifetime of the returned results has to be managed by the user.
 
+    If no extra return values are defined, then the yield terminator may be
+    left out in the custom syntax and the builders will insert one implicitly.
+
     Example:
 
     ```mlir
 
     %deltas = perf.bench (%n) {
       ... // ops under measurement
-    } -> memref<?xf64>
-
-    ```
-
-    Optionally, a yield op can be added:
-
-    ```mlir
-
-    %deltas = perf.bench (%n) {
-      ... // ops under measurement
-      perf.yield
     } -> memref<?xf64>
 
     ```

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -20,7 +20,11 @@ def PerfTimer : AnyTypeOf<[I64]>;
 // BenchOp
 //===----------------------------------------------------------------------===//
 def Perf_BenchOp : Perf_Op<"bench",
-    [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">]> {
+    [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
+     RangedTypesMatchWith<"result type matches type of dest",
+                          "$_self",
+                          "bodyResults",
+                          "getYieldOp().getOperandTypes()">]> {
   let summary = "Benchmark the enclosed code.";
   let description = [{
     The `perf.bench` operation generates benchmarking code
@@ -55,6 +59,10 @@ def Perf_BenchOp : Perf_Op<"bench",
     $region attr-dict
     `->` type($deltas) (`,` type($bodyResults)^)?
   }];
+
+  let extraClassDeclaration = [{
+    YieldOp getYieldOp();
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -81,8 +89,6 @@ def Perf_YieldOp : Perf_Op<"yield", [ HasParent<"BenchOp">,
 
   let assemblyFormat =
     [{  attr-dict ($results^ `:` type($results))? }];
-
-  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -245,7 +251,7 @@ def Perf_DoNotOptOp : Perf_Op<"do_not_opt", [ConditionallySpeculatable]> {
 
   let extraClassDeclaration = [{
     ::mlir::Speculation::Speculatability getSpeculatability() {
-    return ::mlir::Speculation::NotSpeculatable;
+      return ::mlir::Speculation::NotSpeculatable;
     }
   }];
 }

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -22,7 +22,7 @@ include "mlir/IR/OpAsmInterface.td"
 def Perf_StartTimerOp : Perf_Op<"start_timer", []> {
   let summary = "Start a timer.";
   let description = [{
-    The `perf.start_timer` operation creates a new timer
+    The `perf.start_timer` operation creates a new unique timer
     which begins time measurement.
 
     See `perf.stop_timer` for timer termination.
@@ -83,6 +83,7 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
 //===----------------------------------------------------------------------===//
 // BenchOp
 //===----------------------------------------------------------------------===//
+
 def Perf_BenchOp : Perf_Op<"bench",
     [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
      RangedTypesMatchWith<"result types match types of args",
@@ -121,6 +122,11 @@ def Perf_BenchOp : Perf_Op<"bench",
     are passed to the `perf.bench` results.
     The types of the arguments and the results must match, and the benchmarking
     region must be terminated with a matching `perf.yield` operation.
+
+    When arguments are present, the region must terminate with `perf.yield`.
+    Note, that in this case, calling BenchOp::build will not insert the terminator
+    implicitly. The caller must insert `perf.yield` separately with intended
+    return values.
 
     An example of a benchmark with an output result:
 
@@ -176,6 +182,12 @@ def Perf_BenchOp : Perf_Op<"bench",
     $region attr-dict
     (`->` type($bodyResults)^)?
   }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "Value":$numIters, "Value":$deltas,
+      CArg<"ValueRange", "std::nullopt">:$args)>
+  ];
 
   let extraClassDeclaration = [{
     YieldOp getYieldOp();

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -286,10 +286,10 @@ def Perf_StdevOp : Perf_Op<"stdev", []> {
 }
 
 //===----------------------------------------------------------------------===//
-// Sink
+// SinkOp
 //===----------------------------------------------------------------------===//
 
-def Perf_Sink : Perf_Op<"sink", [ConditionallySpeculatable]> {
+def Perf_SinkOp : Perf_Op<"sink", [ConditionallySpeculatable]> {
   let summary = "Prevent removal of unused values.";
   let description = [{
     The `perf.sink` operation acts as a dummy, not speculatable

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -16,6 +16,71 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 
 //===----------------------------------------------------------------------===//
+// StartTimerOp
+//===----------------------------------------------------------------------===//
+
+def Perf_StartTimerOp : Perf_Op<"start_timer", []> {
+  let summary = "Start a timer.";
+  let description = [{
+    The `perf.start_timer` operation creates a new timer
+    which begins time measurement.
+
+    See `perf.stop_timer` for timer termination.
+
+    Example:
+
+    ```mlir
+
+    %timer = perf.start_timer : !perf.timer
+    ... // ops under measurement
+
+    ```
+  }];
+
+  let arguments = (ins);
+  let results = (outs Perf_TimerType:$timer);
+
+  let assemblyFormat = [{
+    attr-dict `:` type($timer)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// StopTimerOp
+//===----------------------------------------------------------------------===//
+
+def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
+  let summary = "Stops a timer.";
+  let description = [{
+    The `perf.stop_timer` operation stops the specified
+    timer and returns elapsed time delta.
+    Once a timer is stopped, it cannot be used again.
+
+    See `perf.start_timer` for timer creation.
+
+    Example:
+
+    ```mlir
+
+    %timer = perf.start_timer : !perf.timer
+    ... // ops under measurement
+    %delta = perf.stop_timer(%timer : !perf.timer) : f64
+
+    ```
+  }];
+
+  let arguments = (ins Perf_TimerType:$timer);
+  let results = (outs F64:$delta);
+
+  let assemblyFormat = [{
+    `(` $timer `:` type($timer) `)` attr-dict
+    `:` type($delta)
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // BenchOp
 //===----------------------------------------------------------------------===//
 def Perf_BenchOp : Perf_Op<"bench",
@@ -41,7 +106,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     If no extra return values are defined, then the yield terminator may be
     left out in the custom syntax and the builders will insert one implicitly.
 
-    Simple benchmarking example:
+    For example - a simple benchmark:
 
     ```mlir
     %deltas = memref.alloc(%size) : memref<?xf64>
@@ -57,7 +122,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     The types of the arguments and the results must match, and the benchmarking
     region must be terminated with a matching `perf.yield` operation.
 
-    Example of a benchmark with an output:
+    An example of a benchmark with an output result:
 
     ```mlir
     %sum = perf.bench (%n, %deltas : memref<?xf64>) args(%val : i32) {
@@ -141,70 +206,6 @@ def Perf_YieldOp : Perf_Op<"yield", [ HasParent<"BenchOp">,
 
   let assemblyFormat =
     [{  attr-dict ($results^ `:` type($results))? }];
-}
-
-//===----------------------------------------------------------------------===//
-// StartTimerOp
-//===----------------------------------------------------------------------===//
-
-def Perf_StartTimerOp : Perf_Op<"start_timer", []> {
-  let summary = "Start a timer.";
-  let description = [{
-    The `perf.start_timer` operation creates a new timer
-    which begins time measurement.
-
-    See `perf.stop_timer` for timer termination.
-
-    Example:
-
-    ```mlir
-
-    %timer = perf.start_timer : i64
-    ... // ops under measurement
-
-    ```
-  }];
-
-  let arguments = (ins);
-  let results = (outs Perf_TimerType:$timer);
-
-  let assemblyFormat = [{
-    attr-dict `:` type($timer)
-  }];
-}
-
-//===----------------------------------------------------------------------===//
-// StopTimerOp
-//===----------------------------------------------------------------------===//
-
-def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
-  let summary = "Stops a timer.";
-  let description = [{
-    The `perf.stop_timer` operation stops the specified
-    timer and returns elapsed time delta.
-
-    See `perf.start_timer` for timer creation.
-
-    Example:
-
-    ```mlir
-
-    %timer = perf.start_timer : i64
-    ... // ops under measurement
-    %delta = perf.stop_timer(%timer : i64) : f64
-
-    ```
-  }];
-
-  let arguments = (ins Perf_TimerType:$timer);
-  let results = (outs F64:$delta);
-
-  let assemblyFormat = [{
-    `(` $timer `:` type($timer) `)` attr-dict
-    `:` type($delta)
-  }];
-
-  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -21,7 +21,11 @@ def PerfTimer : AnyTypeOf<[I64]>;
 //===----------------------------------------------------------------------===//
 def Perf_BenchOp : Perf_Op<"bench",
     [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
-     RangedTypesMatchWith<"result type matches type of dest",
+     RangedTypesMatchWith<"result types match types of args",
+                          "args",
+                          "bodyResults",
+                          "$_self">,
+     RangedTypesMatchWith<"result types match types of yield",
                           "$_self",
                           "bodyResults",
                           "getYieldOp().getOperandTypes()">]> {
@@ -29,35 +33,84 @@ def Perf_BenchOp : Perf_Op<"bench",
   let description = [{
     The `perf.bench` operation generates benchmarking code
     around the enclosed region.
-    The performance results are gathered over the specified
-    number of iterations.
 
-    The operation allocates memory to store the results.
-    The lifetime of the returned results has to be managed by the user.
+    The performance results are gathered over the specified
+    number of iterations and stored in the user provided memory.
+    The operation assumes that the provided memory space is large
+    enough to store results from all benchmarking iterations.
 
     If no extra return values are defined, then the yield terminator may be
     left out in the custom syntax and the builders will insert one implicitly.
 
-    Example:
+    Simple benchmarking example:
 
     ```mlir
+    %deltas = memref.alloc(%size) : memref<?xf64>
+    perf.bench (%n, %deltas : memref<?xf64>) {
+      ... // body - ops under measurement
+    }
+    ```
 
-    %deltas = perf.bench (%n) {
-      ... // ops under measurement
-    } -> memref<?xf64>
+    `perf.bench` also accepts optional arguments. The initial argument values
+    are bound to the benchmarked region and the their values are carried over
+    between benchmarking iterations. On the last iteration, their final values
+    are passed to the `perf.bench` results.
+    The types of the arguments and the results must match, and the benchmarking
+    region must be terminated with a matching `perf.yield` operation.
 
+    Example of a benchmark with an output:
+
+    ```mlir
+    %sum = perf.bench (%n, %deltas : memref<?xf64>) args(%val : i32) {
+      %sum_next = arith.addi %val, %cst : i32
+      perf.yield %sum_next : i32
+    } -> i32
+    memref.store %sum, %buff[] : memref<i32>
+    ```
+
+    `perf.bench` is essentially a utility operation that generates
+    a benchmarking loop.
+    For example, the following input:
+    ```mlir
+    %res, ... = perf.bench (%n, %deltas : memref<?xf64>) args(%x, ... : ...) {
+      ... // body - ops under measurement
+
+      // Yield current iteration values to the next iteration args (%x, ...)
+      // or to the bench op results (%res, ...) if it is the final iteration.
+      perf.yield %x, ...
+    } -> type(%res), ...
+    ```
+    is materialized as:
+    ```mlir
+    %res, ... = loop %iv from 0 to %n step 1
+        iter_args(%x, ...) -> type(%res), ... {
+      // Begin time measurement.
+      start_timer
+      ... // body - ops under measurement
+      // Capture elapsed time.
+      %delta = stop_timer
+
+      // Store measured time delta.
+      store %delta, %deltas[%iv]
+
+      // Yield current iteration values to the next iteration args (%x, ...)
+      // or to the loop results (%res, ...) if it is the final iteration.
+      yield %x, ...
+    }
     ```
   }];
 
-  let arguments = (ins I64:$numIters);
-  let results = (outs RankedOrUnrankedMemRefOf<[F64]>:$deltas,
-            Variadic<AnyType>:$bodyResults);
+  let arguments = (ins I64:$numIters,
+                       RankedOrUnrankedMemRefOf<[F64]>:$deltas,
+                       Variadic<AnyType>:$args);
+  let results = (outs Variadic<AnyType>:$bodyResults);
   let regions = (region SizedRegion<1>:$region);
 
   let assemblyFormat = [{
-    `(` $numIters `)`
+    `(` $numIters `,` $deltas `:` type($deltas) `)`
+    (`args` `(` $args^ `:` type($args) `)`)?
     $region attr-dict
-    `->` type($deltas) (`,` type($bodyResults)^)?
+    (`->` type($bodyResults)^)?
   }];
 
   let extraClassDeclaration = [{

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -273,13 +273,13 @@ def Perf_StdevOp : Perf_Op<"stdev", []> {
 }
 
 //===----------------------------------------------------------------------===//
-// DoNotOptOp
+// Sink
 //===----------------------------------------------------------------------===//
 
-def Perf_DoNotOptOp : Perf_Op<"do_not_opt", [ConditionallySpeculatable]> {
+def Perf_Sink : Perf_Op<"sink", [ConditionallySpeculatable]> {
   let summary = "Prevent removal of unused values.";
   let description = [{
-    The `perf.do_not_opt` operation acts as a dummy, not speculatable
+    The `perf.sink` operation acts as a dummy, not speculatable
     operation that prevents removal of unused values and their defining ops
     by optimization passes.
 
@@ -289,7 +289,7 @@ def Perf_DoNotOptOp : Perf_Op<"do_not_opt", [ConditionallySpeculatable]> {
 
     %deltas = perf.bench (%n) {
       %a = arith.addi %b, %c : i64
-      perf.do_not_opt(%a) : i64 // make sure that 'addi' is not optimized away
+      perf.sink(%a) : i64 // make sure that 'addi' is not optimized away
     } -> memref<?xf64>
 
     ```

--- a/include/TPP/Dialect/Perf/PerfTypes.h
+++ b/include/TPP/Dialect/Perf/PerfTypes.h
@@ -1,0 +1,25 @@
+//===- PerfTypes.h - Perf Dialect Types -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the types for the Perf dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_DIALECT_PERF_PERFTYPES_H
+#define TPP_DIALECT_PERF_PERFTYPES_H
+
+#include "mlir/IR/Types.h"
+
+//===----------------------------------------------------------------------===//
+// Perf Dialect Types
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "TPP/Dialect/Perf/PerfOpsTypes.h.inc"
+
+#endif // TPP_DIALECT_PERF_PERFTYPES_H

--- a/include/TPP/Dialect/Perf/PerfTypes.td
+++ b/include/TPP/Dialect/Perf/PerfTypes.td
@@ -1,0 +1,41 @@
+//===- PerfTypes.td - Perf dialect types -------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the Perf dialect types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_PERF_TYPES
+#define TPP_PERF_TYPES
+
+include "mlir/IR/AttrTypeBase.td"
+include "TPP/Dialect/Perf/PerfDialect.td"
+
+//===----------------------------------------------------------------------===//
+// Perf Types
+//===----------------------------------------------------------------------===//
+
+class Perf_Type<string name, string typeMnemonic> : TypeDef<Perf_Dialect,
+                                                             name> {
+  let mnemonic = typeMnemonic;
+}
+
+def Perf_TimerType : Perf_Type<"Timer", "timer"> {
+  let summary = "perf timer type";
+  let description = [{
+    `perf.timer` is a type returned by timer operations.
+    A timer is a platform-specific object that allows to measure time
+    elapsed between `start` and `stop` events e.g., getting two timestamps
+    and computing a delta between them.
+
+    The type represents unique timer instances. Once a timer is stopped,
+    it cannot be used anymore.
+  }];
+}
+
+#endif // TPP_PERF_TYPES

--- a/lib/TPP/Dialect/CMakeLists.txt
+++ b/lib/TPP/Dialect/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Check)
 add_subdirectory(LinalgX)
+add_subdirectory(Perf)
 add_subdirectory(Tpp)
 add_subdirectory(Transform)
 add_subdirectory(VNNI)

--- a/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
@@ -1,0 +1,76 @@
+//===- BufferizableOpInterfaceImpl.cpp - Impl. of BufferizableOpInterface -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Perf/PerfOps.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/IR/Operation.h"
+
+using namespace mlir;
+using namespace mlir::bufferization;
+using namespace mlir::perf;
+
+namespace mlir {
+namespace perf {
+namespace {
+
+// TODO: bufferization interface for check ops
+struct DoNotOptLayoutInterface
+    : public BufferizableOpInterface::ExternalModel<DoNotOptLayoutInterface,
+                                                    perf::DoNotOptOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return false;
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return false;
+  }
+
+  bool mustBufferizeInPlace(Operation *op, OpOperand &opOperand,
+                            const AnalysisState &state) const {
+    return true;
+  }
+
+  SmallVector<OpResult> getAliasingOpResult(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) const {
+    return {};
+  }
+
+  BufferRelation bufferRelation(Operation *op, OpResult opResult,
+                                const AnalysisState &state) const {
+    return BufferRelation::Equivalent;
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    auto doNotOptOp = cast<perf::DoNotOptOp>(op);
+
+    FailureOr<Value> srcBuffer =
+        getBuffer(rewriter, doNotOptOp.getInput(), options);
+    if (failed(srcBuffer))
+      return failure();
+
+    // Swap the current op with a new one using buffered operand
+    rewriter.replaceOpWithNewOp<perf::DoNotOptOp>(doNotOptOp, *srcBuffer);
+    return success();
+  }
+};
+
+} // namespace
+} // namespace perf
+} // namespace mlir
+
+void mlir::perf::registerBufferizableOpInterfaceExternalModels(
+    DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, perf::PerfDialect *dialect) {
+    DoNotOptOp::attachInterface<perf::DoNotOptLayoutInterface>(*ctx);
+  });
+}

--- a/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
@@ -22,7 +22,7 @@ namespace {
 
 struct DoNotOptLayoutInterface
     : public BufferizableOpInterface::ExternalModel<DoNotOptLayoutInterface,
-                                                    perf::DoNotOptOp> {
+                                                    perf::Sink> {
   bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
                               const AnalysisState &state) const {
     // The operation should only prevent some compiler optimizations.
@@ -56,15 +56,14 @@ struct DoNotOptLayoutInterface
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const BufferizationOptions &options) const {
-    auto doNotOptOp = cast<perf::DoNotOptOp>(op);
+    auto Sink = cast<perf::Sink>(op);
 
-    FailureOr<Value> srcBuffer =
-        getBuffer(rewriter, doNotOptOp.getInput(), options);
+    FailureOr<Value> srcBuffer = getBuffer(rewriter, Sink.getInput(), options);
     if (failed(srcBuffer))
       return failure();
 
     // Swap the current op with a new one using buffered operand.
-    rewriter.replaceOpWithNewOp<perf::DoNotOptOp>(doNotOptOp, *srcBuffer);
+    rewriter.replaceOpWithNewOp<perf::Sink>(Sink, *srcBuffer);
     return success();
   }
 };
@@ -76,6 +75,6 @@ struct DoNotOptLayoutInterface
 void mlir::perf::registerBufferizableOpInterfaceExternalModels(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, perf::PerfDialect *dialect) {
-    DoNotOptOp::attachInterface<perf::DoNotOptLayoutInterface>(*ctx);
+    Sink::attachInterface<perf::DoNotOptLayoutInterface>(*ctx);
   });
 }

--- a/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
@@ -20,17 +20,22 @@ namespace mlir {
 namespace perf {
 namespace {
 
-// TODO: bufferization interface for check ops
 struct DoNotOptLayoutInterface
     : public BufferizableOpInterface::ExternalModel<DoNotOptLayoutInterface,
                                                     perf::DoNotOptOp> {
   bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
                               const AnalysisState &state) const {
+    // The operation should only prevent some compiler optimizations.
+    // It is assumed that there are no memory side effects to avoid potential
+    // out-of-place bufferization.
     return false;
   }
 
   bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
                                const AnalysisState &state) const {
+    // The operation should only prevent some compiler optimizations.
+    // It is assumed that there are no memory side effects to avoid potential
+    // out-of-place bufferization.
     return false;
   }
 
@@ -58,7 +63,7 @@ struct DoNotOptLayoutInterface
     if (failed(srcBuffer))
       return failure();
 
-    // Swap the current op with a new one using buffered operand
+    // Swap the current op with a new one using buffered operand.
     rewriter.replaceOpWithNewOp<perf::DoNotOptOp>(doNotOptOp, *srcBuffer);
     return success();
   }

--- a/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
@@ -56,14 +56,14 @@ struct DoNotOptLayoutInterface
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const BufferizationOptions &options) const {
-    auto Sink = cast<perf::Sink>(op);
+    auto sink = cast<perf::Sink>(op);
 
-    FailureOr<Value> srcBuffer = getBuffer(rewriter, Sink.getInput(), options);
+    FailureOr<Value> srcBuffer = getBuffer(rewriter, sink.getInput(), options);
     if (failed(srcBuffer))
       return failure();
 
     // Swap the current op with a new one using buffered operand.
-    rewriter.replaceOpWithNewOp<perf::Sink>(Sink, *srcBuffer);
+    rewriter.replaceOpWithNewOp<perf::Sink>(sink, *srcBuffer);
     return success();
   }
 };

--- a/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
@@ -20,9 +20,9 @@ namespace mlir {
 namespace perf {
 namespace {
 
-struct DoNotOptLayoutInterface
-    : public BufferizableOpInterface::ExternalModel<DoNotOptLayoutInterface,
-                                                    perf::Sink> {
+struct SinkLayoutInterface
+    : public BufferizableOpInterface::ExternalModel<SinkLayoutInterface,
+                                                    perf::SinkOp> {
   bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
                               const AnalysisState &state) const {
     // The operation should only prevent some compiler optimizations.
@@ -56,14 +56,14 @@ struct DoNotOptLayoutInterface
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const BufferizationOptions &options) const {
-    auto sink = cast<perf::Sink>(op);
+    auto sink = cast<perf::SinkOp>(op);
 
     FailureOr<Value> srcBuffer = getBuffer(rewriter, sink.getInput(), options);
     if (failed(srcBuffer))
       return failure();
 
     // Swap the current op with a new one using buffered operand.
-    rewriter.replaceOpWithNewOp<perf::Sink>(sink, *srcBuffer);
+    rewriter.replaceOpWithNewOp<perf::SinkOp>(sink, *srcBuffer);
     return success();
   }
 };
@@ -75,6 +75,6 @@ struct DoNotOptLayoutInterface
 void mlir::perf::registerBufferizableOpInterfaceExternalModels(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, perf::PerfDialect *dialect) {
-    Sink::attachInterface<perf::DoNotOptLayoutInterface>(*ctx);
+    SinkOp::attachInterface<perf::SinkLayoutInterface>(*ctx);
   });
 }

--- a/lib/TPP/Dialect/Perf/CMakeLists.txt
+++ b/lib/TPP/Dialect/Perf/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_mlir_dialect_library(TPPPerfDialect
+  # Ops and dialects
+    BufferizableOpInterfaceImpl.cpp
+    PerfDialect.cpp
+    PerfOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/TPP
+
+  DEPENDS
+    # add_mlir_dialect macro force-prefixes with MLIR
+    MLIRPerfOpsIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
+
+target_include_directories(TPPPerfDialect
+  PUBLIC
+  $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/TPP/Dialect/Perf/PerfDialect.cpp
+++ b/lib/TPP/Dialect/Perf/PerfDialect.cpp
@@ -1,0 +1,26 @@
+//===- PerfDialect.cpp - Perf dialect ---------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Perf/PerfOps.h"
+
+using namespace mlir;
+using namespace mlir::perf;
+
+//===----------------------------------------------------------------------===//
+// Perf dialect.
+//===----------------------------------------------------------------------===//
+
+void PerfDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "TPP/Dialect/Perf/PerfOps.cpp.inc"
+      >();
+}
+
+#include "TPP/Dialect/Perf/PerfOpsDialect.cpp.inc"

--- a/lib/TPP/Dialect/Perf/PerfDialect.cpp
+++ b/lib/TPP/Dialect/Perf/PerfDialect.cpp
@@ -21,6 +21,10 @@ void PerfDialect::initialize() {
 #define GET_OP_LIST
 #include "TPP/Dialect/Perf/PerfOps.cpp.inc"
       >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "TPP/Dialect/Perf/PerfOpsTypes.cpp.inc"
+      >();
 }
 
 #include "TPP/Dialect/Perf/PerfOpsDialect.cpp.inc"

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -32,19 +32,6 @@ LogicalResult StopTimerOp::verify() {
   return success();
 }
 
-LogicalResult YieldOp::verify() {
-  // Get the parent operation to check its return values.
-  auto benchOp = (*this)->getParentOfType<BenchOp>();
-  if (!benchOp)
-    return emitOpError("invalid parent operation");
-
-  // Check that body results match the yield operands.
-  auto types =
-      llvm::map_range(benchOp.getBodyResults(),
-                      [](const OpResult &result) { return result.getType(); });
-  if (getOperandTypes() != types)
-    return emitOpError("operand types do not match the types returned from "
-                       "the parent BenchOp");
-
-  return success();
+YieldOp BenchOp::getYieldOp() {
+  return cast<perf::YieldOp>(getRegion().front().getTerminator());
 }

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -1,0 +1,49 @@
+//===- PerfOps.cpp - Perf dialect ops ---------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/PerfOps.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+
+#define GET_OP_CLASSES
+#include "TPP/Dialect/Perf/PerfOps.cpp.inc"
+
+using namespace mlir;
+using namespace mlir::perf;
+
+LogicalResult StopTimerOp::verify() {
+  auto timerSrc = getTimer().getDefiningOp();
+  if (!timerSrc || !isa<StartTimerOp>(timerSrc))
+    return emitOpError("invalid timer input");
+
+  int numStopTimers = 0;
+  for (auto user : timerSrc->getUsers()) {
+    if (isa<StopTimerOp>(*user))
+      ++numStopTimers;
+  }
+  if (numStopTimers != 1)
+    return emitOpError("timer stopped multiple times");
+
+  return success();
+}
+
+LogicalResult YieldOp::verify() {
+  // Get the parent operation to check its return values
+  auto benchOp = (*this)->getParentOfType<BenchOp>();
+  if (!benchOp)
+    return emitOpError("invalid parent operation");
+
+  // Check that body results match the yield operands
+  auto types =
+      llvm::map_range(benchOp.getBodyResults(),
+                      [](const OpResult &result) { return result.getType(); });
+  if (getOperandTypes() != types)
+    return emitOpError("operand types do not match the types returned from "
+                       "the parent BenchOp");
+
+  return success();
+}

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -8,9 +8,14 @@
 
 #include "TPP/Dialect/Perf/PerfOps.h"
 #include "TPP/Dialect/Perf/PerfDialect.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #define GET_OP_CLASSES
 #include "TPP/Dialect/Perf/PerfOps.cpp.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "TPP/Dialect/Perf/PerfOpsTypes.cpp.inc"
 
 using namespace mlir;
 using namespace mlir::perf;

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -20,6 +20,7 @@ LogicalResult StopTimerOp::verify() {
   if (!timerSrc || !isa<StartTimerOp>(timerSrc))
     return emitOpError("invalid timer input");
 
+  // Any timer can only be stopped once. It is unusable afterwards.
   int numStopTimers = 0;
   for (auto user : timerSrc->getUsers()) {
     if (isa<StopTimerOp>(*user))
@@ -32,12 +33,12 @@ LogicalResult StopTimerOp::verify() {
 }
 
 LogicalResult YieldOp::verify() {
-  // Get the parent operation to check its return values
+  // Get the parent operation to check its return values.
   auto benchOp = (*this)->getParentOfType<BenchOp>();
   if (!benchOp)
     return emitOpError("invalid parent operation");
 
-  // Check that body results match the yield operands
+  // Check that body results match the yield operands.
   auto types =
       llvm::map_range(benchOp.getBodyResults(),
                       [](const OpResult &result) { return result.getType(); });

--- a/test/TPP/perf/perf-invalid.mlir
+++ b/test/TPP/perf/perf-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: tpp-opt %s -split-input-file -verify-diagnostics
 
 func.func @perf_no_yield(%n: i64) {
-  // expected-error @below {{'perf.yield' op operand types do not match the types returned from the parent BenchOp}}
+  // expected-error @below {{'perf.bench' op failed to verify that result type matches type of dest}}
   %deltas, %val = perf.bench (%n) {
     perf.do_not_opt(%n) : i64
   } -> memref<?xf64>, i64
@@ -11,9 +11,9 @@ func.func @perf_no_yield(%n: i64) {
 // -----
 
 func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
+  // expected-error @below {{'perf.bench' op failed to verify that result type matches type of dest}}
   %deltas, %val = perf.bench (%n) {
     %c = arith.addi %a, %b : i32
-    // expected-error @below {{'perf.yield' op operand types do not match the types returned from the parent BenchOp}}
     perf.yield %c : i32
   } -> memref<?xf64>, i64
   return
@@ -22,9 +22,9 @@ func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
 // -----
 
 func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
+  // expected-error @below {{'perf.bench' op failed to verify that result type matches type of dest}}
   %deltas, %val, %val1 = perf.bench (%n) {
     %c = arith.addi %a, %b : i32
-    // expected-error @below {{'perf.yield' op operand types do not match the types returned from the parent BenchOp}}
     perf.yield %n, %c : i64, i32
   } -> memref<?xf64>, i32, i64
   return

--- a/test/TPP/perf/perf-invalid.mlir
+++ b/test/TPP/perf/perf-invalid.mlir
@@ -7,7 +7,7 @@ func.func @perf_no_outs(%n: i64) {
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
   %val = perf.bench (%n, %deltas : memref<?xf64>) {
-    perf.do_not_opt(%n) : i64
+    perf.sink(%n) : i64
   } -> i64
 
   memref.dealloc %deltas : memref<?xf64>
@@ -58,7 +58,7 @@ func.func @perf_no_yield(%n: i64) {
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
   %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
-    perf.do_not_opt(%n) : i64
+    perf.sink(%n) : i64
   } -> i64
 
   memref.dealloc %deltas : memref<?xf64>

--- a/test/TPP/perf/perf-invalid.mlir
+++ b/test/TPP/perf/perf-invalid.mlir
@@ -32,6 +32,21 @@ func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
 
 // -----
 
+func.func @perf_invalid_yield_parent(%a: i32) -> i32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %out = scf.for %it = %c0 to %c4 step %c1 iter_args(%arg0 = %a) -> i32 {
+    %val = arith.index_cast %it : index to i32
+    %res = arith.addi %arg0, %val : i32
+    // expected-error @below {{'perf.yield' op expects parent op 'perf.bench'}}
+    perf.yield %res : i32
+  }
+  return %out : i32
+}
+
+// -----
+
 func.func @perf_timer_multi_stop() {
   %t = perf.start_timer : i64
   // expected-error @below {{'perf.stop_timer' op timer stopped multiple times}}

--- a/test/TPP/perf/perf-invalid.mlir
+++ b/test/TPP/perf/perf-invalid.mlir
@@ -1,0 +1,58 @@
+// RUN: tpp-opt %s -split-input-file -verify-diagnostics
+
+func.func @perf_no_yield(%n: i64) {
+  // expected-error @below {{'perf.yield' op operand types do not match the types returned from the parent BenchOp}}
+  %deltas, %val = perf.bench (%n) {
+    perf.do_not_opt(%n) : i64
+  } -> memref<?xf64>, i64
+  return
+}
+
+// -----
+
+func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
+  %deltas, %val = perf.bench (%n) {
+    %c = arith.addi %a, %b : i32
+    // expected-error @below {{'perf.yield' op operand types do not match the types returned from the parent BenchOp}}
+    perf.yield %c : i32
+  } -> memref<?xf64>, i64
+  return
+}
+
+// -----
+
+func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
+  %deltas, %val, %val1 = perf.bench (%n) {
+    %c = arith.addi %a, %b : i32
+    // expected-error @below {{'perf.yield' op operand types do not match the types returned from the parent BenchOp}}
+    perf.yield %n, %c : i64, i32
+  } -> memref<?xf64>, i32, i64
+  return
+}
+
+// -----
+
+func.func @perf_timer_multi_stop() {
+  %t = perf.start_timer : i64
+  // expected-error @below {{'perf.stop_timer' op timer stopped multiple times}}
+  %del = perf.stop_timer(%t : i64) : f64
+  %del1 = perf.stop_timer(%t : i64) : f64
+  return
+}
+
+// -----
+
+func.func @perf_invalid_timer(%n: i64) {
+  // expected-error @below {{'perf.stop_timer' op invalid timer input}}
+  %del = perf.stop_timer(%n : i64) : f64
+  return
+}
+
+// -----
+
+func.func @perf_invalid_timer_1() {
+  %c0 = arith.constant 0 : i64
+  // expected-error @below {{'perf.stop_timer' op invalid timer input}}
+  %del = perf.stop_timer(%c0 : i64) : f64
+  return
+}

--- a/test/TPP/perf/perf-invalid.mlir
+++ b/test/TPP/perf/perf-invalid.mlir
@@ -118,18 +118,18 @@ func.func @perf_invalid_yield_parent(%a: i32) -> i32 {
 // -----
 
 func.func @perf_timer_multi_stop() {
-  %t = perf.start_timer : i64
+  %t = perf.start_timer : !perf.timer
   // expected-error @below {{'perf.stop_timer' op timer stopped multiple times}}
-  %del = perf.stop_timer(%t : i64) : f64
-  %del1 = perf.stop_timer(%t : i64) : f64
+  %del = perf.stop_timer(%t : !perf.timer) : f64
+  %del1 = perf.stop_timer(%t : !perf.timer) : f64
   return
 }
 
 // -----
 
-func.func @perf_invalid_timer(%n: i64) {
+func.func @perf_invalid_timer(%n: !perf.timer) {
   // expected-error @below {{'perf.stop_timer' op invalid timer input}}
-  %del = perf.stop_timer(%n : i64) : f64
+  %del = perf.stop_timer(%n : !perf.timer) : f64
   return
 }
 
@@ -137,7 +137,7 @@ func.func @perf_invalid_timer(%n: i64) {
 
 func.func @perf_invalid_timer_1() {
   %c0 = arith.constant 0 : i64
-  // expected-error @below {{'perf.stop_timer' op invalid timer input}}
+  // expected-error @below {{custom op 'perf.stop_timer' invalid kind of type specified}}
   %del = perf.stop_timer(%c0 : i64) : f64
   return
 }

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -3,11 +3,11 @@
 // CHECK-LABEL: @perf_timer
 func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
   // CHECK: perf.start_timer
-  %t = perf.start_timer : i64
+  %t = perf.start_timer : !perf.timer
   // CHECK: arith.addi
   %c = arith.addi %a, %b : i32
   // CHECK: perf.stop_timer
-  perf.stop_timer(%t : i64) : f64
+  perf.stop_timer(%t : !perf.timer) : f64
 
   return %c : i32
 }
@@ -62,13 +62,13 @@ func.func @perf_matmul_loops(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%n) : memref<?xf64>
   scf.for %arg0 = %c0 to %n step %c1 {
     // CHECK: perf.start_timer
-    %t = perf.start_timer : i64
+    %t = perf.start_timer : !perf.timer
     // CHECK: linalg.matmul
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     // CHECK: perf.do_not_opt
     perf.do_not_opt(%D) : tensor<4x4xf32>
     // CHECK: perf.stop_timer
-    %del = perf.stop_timer(%t : i64) : f64
+    %del = perf.stop_timer(%t : !perf.timer) : f64
     memref.store %del, %deltas[%arg0] : memref<?xf64>
   }
 

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -1,0 +1,107 @@
+// RUN: tpp-opt %s -split-input-file -canonicalize | FileCheck %s
+
+// CHECK-LABEL: @perf_matmul_bench
+func.func @perf_matmul_bench(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: i64) {
+  // CHECK: perf.bench
+  %deltas = perf.bench (%n) {
+    // CHECK: linalg.matmul
+    %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+    // CHECK: perf.do_not_opt
+    perf.do_not_opt(%D) : tensor<4x4xf32>
+  } -> memref<?xf64>
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @perf_yield
+func.func @perf_yield(%a: i32, %b: i32, %n: i64) {
+  // CHECK: perf.bench
+  %deltas = perf.bench (%n) {
+    // CHECK: arith.addi
+    %c = arith.addi %a, %b : i32
+    // CHECK: perf.do_not_opt
+    perf.do_not_opt(%c) : i32
+    perf.yield
+  } -> memref<?xf64>
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @perf_timer
+func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
+  // CHECK: perf.start_timer
+  %t = perf.start_timer : i64
+  // CHECK: arith.addi
+  %c = arith.addi %a, %b : i32
+  // CHECK: perf.stop_timer
+  perf.stop_timer(%t : i64) : f64
+
+  return %c : i32
+}
+
+// -----
+
+// CHECK-LABEL: @perf_timer
+func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
+  // CHECK: perf.start_timer
+  %t = perf.start_timer : i64
+  // CHECK: arith.addi
+  %c = arith.addi %a, %b : i32
+  // CHECK: perf.stop_timer
+  perf.stop_timer(%t : i64) : f64
+
+  return %c : i32
+}
+
+// -----
+
+// CHECK-LABEL: @perf_mean
+func.func @perf_mean(%arg0: memref<?xf64>) -> f64 {
+  // CHECK: perf.mean
+  %mean = perf.mean(%arg0 : memref<?xf64>) : f64
+  return %mean : f64
+}
+
+// -----
+
+// CHECK-LABEL: @perf_stdev
+func.func @perf_stdev(%arg0: memref<?xf64>, %mean: f64) -> f64 {
+  // CHECK: perf.stdev
+  %stdev = perf.stdev(%arg0 : memref<?xf64>, %mean : f64) : f64
+  return %stdev : f64
+}
+
+// -----
+
+// CHECK-LABEL: @perf_matmul_loops
+func.func @perf_matmul_loops(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: memref.alloc
+  %deltas = memref.alloc(%n) : memref<?xf64>
+  scf.for %arg0 = %c0 to %n step %c1 {
+    // CHECK: perf.start_timer
+    %t = perf.start_timer : i64
+    // CHECK: linalg.matmul
+    %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+    // CHECK: perf.do_not_opt
+    perf.do_not_opt(%D) : tensor<4x4xf32>
+    // CHECK: perf.stop_timer
+    %del = perf.stop_timer(%t : i64) : f64
+    memref.store %del, %deltas[%arg0] : memref<?xf64>
+  }
+
+  // CHECK: perf.mean
+  %mean = perf.mean(%deltas : memref<?xf64>) : f64
+  // CHECK: perf.stdev
+  %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
+
+  return
+}

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -42,8 +42,8 @@ func.func @perf_matmul_bench(%A: tensor<4x8xf32>,
   perf.bench (%n, %deltas : memref<?xf64>) {
     // CHECK: linalg.matmul
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
-    // CHECK: perf.do_not_opt
-    perf.do_not_opt(%D) : tensor<4x4xf32>
+    // CHECK: perf.sink
+    perf.sink(%D) : tensor<4x4xf32>
   }
 
   memref.dealloc %deltas : memref<?xf64>
@@ -65,8 +65,8 @@ func.func @perf_matmul_loops(%A: tensor<4x8xf32>,
     %t = perf.start_timer : !perf.timer
     // CHECK: linalg.matmul
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
-    // CHECK: perf.do_not_opt
-    perf.do_not_opt(%D) : tensor<4x4xf32>
+    // CHECK: perf.sink
+    perf.sink(%D) : tensor<4x4xf32>
     // CHECK: perf.stop_timer
     %del = perf.stop_timer(%t : !perf.timer) : f64
     memref.store %del, %deltas[%arg0] : memref<?xf64>
@@ -92,8 +92,8 @@ func.func @perf_yield_empty(%a: i32, %b: i32, %n: i64) {
   perf.bench (%n, %deltas : memref<?xf64>) {
     // CHECK: arith.addi
     %c = arith.addi %a, %b : i32
-    // CHECK: perf.do_not_opt
-    perf.do_not_opt(%c) : i32
+    // CHECK: perf.sink
+    perf.sink(%c) : i32
     perf.yield
   }
 

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -65,20 +65,6 @@ func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
 
 // -----
 
-// CHECK-LABEL: @perf_timer
-func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
-  // CHECK: perf.start_timer
-  %t = perf.start_timer : i64
-  // CHECK: arith.addi
-  %c = arith.addi %a, %b : i32
-  // CHECK: perf.stop_timer
-  perf.stop_timer(%t : i64) : f64
-
-  return %c : i32
-}
-
-// -----
-
 // CHECK-LABEL: @perf_mean
 func.func @perf_mean(%arg0: memref<?xf64>) -> f64 {
   // CHECK: perf.mean

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -129,7 +129,7 @@ func.func @perf_yield_result(%a: i32, %b: i32, %n: i64) -> i32 {
 
 // -----
 
-// An example of perf dialect usage
+// An example of perf dialect usage.
 // CHECK-LABEL: @perf_example
 func.func @perf_example(%A: tensor<4x8xf32>,
           %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: i64) -> (f64, f64, i64) {
@@ -164,7 +164,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
 
 // -----
 
-// Intended lowering of the perf dialect based on the above example
+// Intended lowering of the perf dialect based on the above example.
 func.func private @perf_start_timer() -> i64 attributes {llvm.emit_c_interface}
 func.func private @perf_stop_timer(i64) -> f64 attributes {llvm.emit_c_interface}
 func.func private @perf_sink_tensor_f32(tensor<*xf32>) attributes {llvm.emit_c_interface}

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -129,6 +129,7 @@ func.func @perf_yield_result(%a: i32, %b: i32, %n: i64) -> i32 {
 
 // -----
 
+// An example of perf dialect usage
 // CHECK-LABEL: @perf_example
 func.func @perf_example(%A: tensor<4x8xf32>,
           %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: i64) -> (f64, f64, i64) {
@@ -163,6 +164,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
 
 // -----
 
+// Intended lowering of the perf dialect based on the above example
 func.func private @perf_start_timer() -> i64 attributes {llvm.emit_c_interface}
 func.func private @perf_stop_timer(i64) -> f64 attributes {llvm.emit_c_interface}
 func.func private @perf_sink_tensor_f32(tensor<*xf32>) attributes {llvm.emit_c_interface}

--- a/test/TPP/perf/perf-ops.mlir
+++ b/test/TPP/perf/perf-ops.mlir
@@ -1,6 +1,38 @@
 // RUN: tpp-opt %s -split-input-file -canonicalize | FileCheck %s
 
-// CHECK-LABEL: @perf_matmul_bench
+// CHECK-LABEL: @perf_timer
+func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
+  // CHECK: perf.start_timer
+  %t = perf.start_timer : i64
+  // CHECK: arith.addi
+  %c = arith.addi %a, %b : i32
+  // CHECK: perf.stop_timer
+  perf.stop_timer(%t : i64) : f64
+
+  return %c : i32
+}
+
+// -----
+
+// CHECK-LABEL: @perf_mean
+func.func @perf_mean(%arg0: memref<?xf64>) -> f64 {
+  // CHECK: perf.mean
+  %mean = perf.mean(%arg0 : memref<?xf64>) : f64
+  return %mean : f64
+}
+
+// -----
+
+// CHECK-LABEL: @perf_stdev
+func.func @perf_stdev(%arg0: memref<?xf64>, %mean: f64) -> f64 {
+  // CHECK: perf.stdev
+  %stdev = perf.stdev(%arg0 : memref<?xf64>, %mean : f64) : f64
+  return %stdev : f64
+}
+
+// -----
+
+/// CHECK-LABEL: @perf_matmul_bench
 func.func @perf_matmul_bench(%A: tensor<4x8xf32>,
           %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: i64) {
   // CHECK: perf.bench
@@ -10,6 +42,37 @@ func.func @perf_matmul_bench(%A: tensor<4x8xf32>,
     // CHECK: perf.do_not_opt
     perf.do_not_opt(%D) : tensor<4x4xf32>
   } -> memref<?xf64>
+
+  memref.dealloc %deltas : memref<?xf64>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @perf_matmul_loops
+func.func @perf_matmul_loops(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+
+  // CHECK: memref.alloc
+  %deltas = memref.alloc(%n) : memref<?xf64>
+  scf.for %arg0 = %c0 to %n step %c1 {
+    // CHECK: perf.start_timer
+    %t = perf.start_timer : i64
+    // CHECK: linalg.matmul
+    %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+    // CHECK: perf.do_not_opt
+    perf.do_not_opt(%D) : tensor<4x4xf32>
+    // CHECK: perf.stop_timer
+    %del = perf.stop_timer(%t : i64) : f64
+    memref.store %del, %deltas[%arg0] : memref<?xf64>
+  }
+
+  // CHECK: perf.mean
+  %mean = perf.mean(%deltas : memref<?xf64>) : f64
+  // CHECK: perf.stdev
+  %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -47,67 +110,4 @@ func.func @perf_yield_result(%a: i32, %b: i32, %n: i64) -> i32 {
   memref.dealloc %deltas : memref<?xf64>
   // CHECK: return %[[out]]
   return %out : i32
-}
-
-// -----
-
-// CHECK-LABEL: @perf_timer
-func.func @perf_timer(%a: i32, %b: i32, %n: i64) -> i32 {
-  // CHECK: perf.start_timer
-  %t = perf.start_timer : i64
-  // CHECK: arith.addi
-  %c = arith.addi %a, %b : i32
-  // CHECK: perf.stop_timer
-  perf.stop_timer(%t : i64) : f64
-
-  return %c : i32
-}
-
-// -----
-
-// CHECK-LABEL: @perf_mean
-func.func @perf_mean(%arg0: memref<?xf64>) -> f64 {
-  // CHECK: perf.mean
-  %mean = perf.mean(%arg0 : memref<?xf64>) : f64
-  return %mean : f64
-}
-
-// -----
-
-// CHECK-LABEL: @perf_stdev
-func.func @perf_stdev(%arg0: memref<?xf64>, %mean: f64) -> f64 {
-  // CHECK: perf.stdev
-  %stdev = perf.stdev(%arg0 : memref<?xf64>, %mean : f64) : f64
-  return %stdev : f64
-}
-
-// -----
-
-// CHECK-LABEL: @perf_matmul_loops
-func.func @perf_matmul_loops(%A: tensor<4x8xf32>,
-          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: index) {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-
-  // CHECK: memref.alloc
-  %deltas = memref.alloc(%n) : memref<?xf64>
-  scf.for %arg0 = %c0 to %n step %c1 {
-    // CHECK: perf.start_timer
-    %t = perf.start_timer : i64
-    // CHECK: linalg.matmul
-    %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
-    // CHECK: perf.do_not_opt
-    perf.do_not_opt(%D) : tensor<4x4xf32>
-    // CHECK: perf.stop_timer
-    %del = perf.stop_timer(%t : i64) : f64
-    memref.store %del, %deltas[%arg0] : memref<?xf64>
-  }
-
-  // CHECK: perf.mean
-  %mean = perf.mean(%deltas : memref<?xf64>) : f64
-  // CHECK: perf.stdev
-  %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
-
-  memref.dealloc %deltas : memref<?xf64>
-  return
 }

--- a/tpp-opt/tpp-opt.cpp
+++ b/tpp-opt/tpp-opt.cpp
@@ -23,11 +23,13 @@
 #include "TPP/Dialect/Check/CheckDialect.h"
 #include "TPP/Dialect/LinalgX/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/LinalgX/LinalgXDialect.h"
-#include "TPP/Dialect/Transform/LinalgXTransformOps.h"
+#include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Tpp/TppDialect.h"
+#include "TPP/Dialect/Transform/LinalgXTransformOps.h"
 #include "TPP/Dialect/VNNI/BufferizableOpInterfaceImpl.h"
-#include "TPP/Dialect/VNNI/VNNIDialect.h"
 #include "TPP/Dialect/VNNI/TransformOps/VNNITransformOps.h"
+#include "TPP/Dialect/VNNI/VNNIDialect.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
 #include "TPP/Passes.h"
 
@@ -41,12 +43,13 @@ int main(int argc, char **argv) {
   registry.insert<mlir::linalgx::LinalgXDialect>();
   registry.insert<mlir::check::CheckDialect>();
   registry.insert<mlir::vnni::VNNIDialect>();
+  registry.insert<mlir::perf::PerfDialect>();
   mlir::linalgx::registerTransformDialectExtension(registry);
   mlir::linalgx::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::check::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::vnni::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::vnni::registerTransformDialectExtension(registry);
-
+  mlir::perf::registerBufferizableOpInterfaceExternalModels(registry);
   // Add the following to include *all* MLIR Core dialects, or selectively
   // include what you need like above. You only need to register dialects that
   // will be *parsed* by the tool, not the one generated


### PR DESCRIPTION
Adds a new infrastructure dialect that facilitates code performance benchmarking directly at the IR level.

The perf dialect introduces a set of operations that allows to collect and process basic code runtime statistics.
The dialect positions itself as a high-level generic utility which relies on support of a runtime that supplies platform dependent functionality such as timers.

Work towards #100 

This PR introduces just core operations and basic utilities.
Lowering to loops and func will follow separately.