### PR TITLE
Perf to loops

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -93,7 +93,7 @@ def Perf_BenchOp : Perf_Op<"bench",
      RangedTypesMatchWith<"result types match types of yield",
                           "$_self",
                           "bodyResults",
-                          "getYieldOp().getOperandTypes()">]> {
+                          "getRegion().front().getTerminator()->getOperandTypes()">]> {
   let summary = "Benchmark the enclosed code.";
   let description = [{
     The `perf.bench` operation generates benchmarking code
@@ -192,6 +192,8 @@ def Perf_BenchOp : Perf_Op<"bench",
   let extraClassDeclaration = [{
     YieldOp getYieldOp();
   }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -213,11 +213,11 @@ def Perf_YieldOp : Perf_Op<"yield", [ HasParent<"BenchOp">,
     yielded.
   }];
 
-  let arguments = (ins Variadic<AnyType>:$results);
+  let arguments = (ins Variadic<AnyType>:$operands);
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 
   let assemblyFormat =
-    [{  attr-dict ($results^ `:` type($results))? }];
+    [{  attr-dict ($operands^ `:` type($operands))? }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -18,6 +18,7 @@ class ModuleOp;
 namespace mlir {
 namespace func {
 class FuncOp;
+class FuncDialect;
 } // namespace func
 } // namespace mlir
 
@@ -69,6 +70,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createConvertTppToXsmmPass();
 std::unique_ptr<OperationPass<ModuleOp>>
 createTransformDialectInterpreterPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgXToLoopsPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertPerfToLoopsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createTransformDropSchedulePass();
 
 } // namespace tpp

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -110,6 +110,15 @@ def LinalgExtToLoops :
   let constructor = "mlir::tpp::createLinalgXToLoopsPass()";
 }
 
+def ConvertPerfToLoops : Pass<"convert-perf-to-loops", "ModuleOp"> {
+  let summary = "Convert perf to loops";
+  let constructor = "mlir::tpp::createConvertPerfToLoopsPass()";
+  let description = [{
+    Convert perf operations to SCF loops.
+  }];
+  let dependentDialects = ["scf::SCFDialect"];
+}
+
 def TransformDropSchedulePass : Pass<"transform-drop-schedule", "ModuleOp"> {
   let summary = "Drop the transform schedule";
   let constructor = "mlir::tpp::createTransformDropSchedulePass()";

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_library(MLIRTPP
     ConvertXsmmToFunc.cpp
     ConvertCheckToLoops.cpp
     ConvertVNNIToTpp.cpp
+    ConvertPerfToLoops.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP
@@ -33,6 +34,7 @@ add_mlir_library(MLIRTPP
     TPPTppDialect
     TPPXsmmDialect
     TPPVNNIDialect
+    TPPPerfDialect
 
     MLIRIR
     MLIRInferTypeOpInterface

--- a/lib/TPP/ConvertPerfToLoops.cpp
+++ b/lib/TPP/ConvertPerfToLoops.cpp
@@ -1,0 +1,107 @@
+//===- ConvertPerfToLoops.cpp ------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/PerfOps.h"
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+
+using namespace mlir;
+using namespace mlir::perf;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
+  using OpRewritePattern<perf::BenchOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::BenchOp benchOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = benchOp.getLoc();
+    auto benchYield = benchOp.getRegion().front().getTerminator();
+
+    auto numIters = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getIndexType(), benchOp.getNumIters());
+
+    // Create benchmark loop up to perf.bench numIters.
+    auto zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    auto loop = rewriter.create<scf::ForOp>(loc, zero, numIters, one,
+                                            benchOp.getArgs());
+    if (benchOp.getArgs().empty()) {
+      // Erase the default loop yield, it will be inserted later.
+      rewriter.eraseOp(loop.getRegion().front().getTerminator());
+    }
+
+    // Move perf.bench region inside the loop.
+    rewriter.mergeBlocks(&benchOp.getRegion().front(), loop.getBody());
+
+    // Wrap the benchmark kernel in timer calls.
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(loop.getBody());
+    auto timer = rewriter.create<perf::StartTimerOp>(
+        loc, TimerType::get(rewriter.getContext()));
+    rewriter.setInsertionPointToEnd(loop.getBody());
+    auto delta = rewriter.create<perf::StopTimerOp>(loc, rewriter.getF64Type(),
+                                                    timer.getTimer());
+
+    // Move all perf.sink ops after the timer to prevent influencing
+    // measurements.
+    for (auto &op : loop.getRegion().getOps()) {
+      if (isa<perf::SinkOp>(op))
+        op.moveAfter(delta.getOperation());
+    }
+
+    // Store measured time delta on each iteration.
+    rewriter.create<memref::StoreOp>(loc, delta.getDelta(), benchOp.getDeltas(),
+                                     loop.getInductionVar());
+
+    // Replace uses of bench args within the benchmark body with their
+    // equivalent loop-carried variables.
+    for (auto pair : llvm::zip(benchOp.getArgs(), loop.getRegionIterArgs()))
+      replaceAllUsesInRegionWith(std::get<0>(pair), std::get<1>(pair),
+                                 loop.getRegion());
+
+    // Pass perf.yield values through the scf.yield.
+    rewriter.setInsertionPointToEnd(loop.getBody());
+    rewriter.create<scf::YieldOp>(loc, benchYield->getOperands());
+    rewriter.eraseOp(benchYield);
+
+    // Swap bench results with loop results.
+    for (auto pair : llvm::zip(benchOp.getBodyResults(), loop.getResults()))
+      std::get<0>(pair).replaceAllUsesWith(std::get<1>(pair));
+
+    rewriter.eraseOp(benchOp);
+    return success();
+  }
+};
+
+void populatePerfToLoopsPatterns(RewritePatternSet &patterns) {
+  patterns.add<ConvertBenchToLoops>(patterns.getContext());
+}
+
+struct ConvertPerfToLoops : public ConvertPerfToLoopsBase<ConvertPerfToLoops> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    populatePerfToLoopsPatterns(patterns);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    return;
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::tpp::createConvertPerfToLoopsPass() {
+  return std::make_unique<ConvertPerfToLoops>();
+}

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -71,3 +71,15 @@ void BenchOp::build(OpBuilder &builder, OperationState &result, Value numIters,
 YieldOp BenchOp::getYieldOp() {
   return cast<perf::YieldOp>(getRegion().front().getTerminator());
 }
+
+LogicalResult BenchOp::verify() {
+  Operation *terminator = getRegion().front().getTerminator();
+  if (!dyn_cast_or_null<perf::YieldOp>(terminator)) {
+    auto diag = emitOpError("expects region to terminate with 'perf.yield'");
+    if (terminator)
+      diag.attachNote(terminator->getLoc()) << "terminator here";
+    return failure();
+  }
+
+  return success();
+}

--- a/test/TPP/perf/perf-invalid.mlir
+++ b/test/TPP/perf/perf-invalid.mlir
@@ -67,6 +67,24 @@ func.func @perf_no_yield(%n: i64) {
 
 // -----
 
+func.func @perf_invalid_yield_op(%a: i32, %b: i32, %n: i64) {
+  %size = arith.index_cast %n : i64 to index
+  %deltas = memref.alloc(%size) : memref<?xf64>
+  %out = arith.constant 0 : i32
+
+  // expected-error @below {{perf.bench' op expects region to terminate with 'perf.yield'}}
+  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i32) {
+    %c = arith.addi %a, %b : i32
+    // expected-note @below {{terminator here}}
+    scf.yield %c : i32
+  } -> i32
+
+  memref.dealloc %deltas : memref<?xf64>
+  return
+}
+
+// -----
+
 func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
   %size = arith.index_cast %n : i64 to index
   %deltas = memref.alloc(%size) : memref<?xf64>

--- a/test/TPP/perf/perf-to-loops.mlir
+++ b/test/TPP/perf/perf-to-loops.mlir
@@ -1,0 +1,160 @@
+// RUN: tpp-opt %s -convert-perf-to-loops -split-input-file -canonicalize | FileCheck %s
+
+// CHECK-LABEL: @perf_single_op
+func.func @perf_single_op(%arg0: tensor<4x8xf32>,
+          %arg1: tensor<8x4xf32>, %arg2: tensor<4x4xf32>, %arg3: i64) -> f64 {
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK: %[[deltas:.*]] = memref.alloc
+  %size = arith.index_cast %arg3 : i64 to index
+  %deltas = memref.alloc(%size) : memref<?xf64>
+
+  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK: scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] {
+  // CHECK:   %[[timer:.*]] = perf.start_timer
+  // CHECK:   %[[val:.*]] = linalg.matmul
+  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:   perf.sink(%[[val]])
+  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK: }
+  perf.bench (%arg3, %deltas : memref<?xf64>) {
+    %D = linalg.matmul ins(%arg0, %arg1: tensor<4x8xf32>, tensor<8x4xf32>) outs(%arg2: tensor<4x4xf32>) -> tensor<4x4xf32>
+    perf.sink(%D) : tensor<4x4xf32>
+  }
+
+  // CHECK: %[[mean:.*]] = perf.mean(%[[deltas]] {{.*}})
+  %mean = perf.mean(%deltas : memref<?xf64>) : f64
+
+  memref.dealloc %deltas : memref<?xf64>
+  // CHECK: return %[[mean]]
+  return %mean : f64
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: @perf_multi_op
+func.func @perf_multi_op(%arg0: tensor<4x8xf32>,
+          %arg1: tensor<8x4xf32>, %arg2: tensor<4x4xf32>) -> f64 {
+  // CHECK-DAG: %[[numIter:.*]] = arith.constant 50 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  %f42 = arith.constant 42.0 : f32
+  %c50 = arith.constant 50 : i64
+  // CHECK: %[[deltas:.*]] = memref.alloc
+  %deltas = memref.alloc() : memref<50xf64>
+
+  // CHECK: scf.for %[[i:.*]] = %[[lb]] to %[[numIter]] step %[[step]] {
+  // CHECK:   %[[timer:.*]] = perf.start_timer
+  // CHECK:   tensor.empty
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.matmul
+  // CHECK:   %[[val:.*]] = linalg.generic
+  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:   perf.sink(%[[val]])
+  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK: }
+  perf.bench (%c50, %deltas : memref<50xf64>) {
+    %0 = tensor.empty() : tensor<4x4xf32>
+    %1 = linalg.fill ins(%f42 : f32) outs(%0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    %D = linalg.matmul ins(%arg0, %arg1: tensor<4x8xf32>, tensor<8x4xf32>) outs(%arg2: tensor<4x4xf32>) -> tensor<4x4xf32>
+    %2 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%D : tensor<4x4xf32>) outs(%1 : tensor<4x4xf32>) {
+      ^bb0(%in : f32, %out: f32):
+          %3 = arith.addf %in, %out : f32
+          linalg.yield %3 : f32
+    } -> tensor<4x4xf32>
+    perf.sink(%2) : tensor<4x4xf32>
+    perf.yield
+  }
+
+  // CHECK: %[[mean:.*]] = perf.mean(%[[deltas]] {{.*}})
+  %mean = perf.mean(%deltas : memref<50xf64>) : f64
+
+  memref.dealloc %deltas : memref<50xf64>
+  // CHECK: return %[[mean]]
+  return %mean : f64
+}
+
+// -----
+
+// An example of perf dialect usage.
+// CHECK-LABEL: @perf_example
+func.func @perf_example(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: i64) -> (f64, f64, i64) {
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[output:.*]] = arith.constant 0 : i64
+  // CHECK: %[[deltas:.*]] = memref.alloc
+  %size = arith.index_cast %n : i64 to index
+  %deltas = memref.alloc(%size) : memref<?xf64>
+  %output = arith.constant 0 : i64
+
+  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK: %[[res:.*]] = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]]) -> (i64) {
+  // CHECK:   %[[timer:.*]] = perf.start_timer
+  // CHECK:   %[[mulres:.*]] = linalg.matmul
+  // CHECK:   %[[sum:.*]] = arith.addi
+  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:   perf.sink(%[[mulres]])
+  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK:   scf.yield %[[sum]]
+  // CHECK: }
+  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+    %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
+                       outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+    perf.sink(%D) : tensor<4x4xf32>
+    %sum = arith.addi %n, %n : i64
+    perf.yield %sum : i64
+  } -> i64
+
+  // CHECK: %[[mean:.*]] = perf.mean
+  // CHECK: %[[stdev:.*]] = perf.stdev
+  %mean = perf.mean(%deltas : memref<?xf64>) : f64
+  %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
+
+  memref.dealloc %deltas : memref<?xf64>
+  // CHECK: return %[[mean]], %[[stdev]], %[[res]]
+  return %mean, %stdev, %res : f64, f64, i64
+}
+
+// -----
+
+// CHECK: @perf_example_multi_arg({{.*}}, %[[k:.*]]: i64)
+func.func @perf_example_multi_arg(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>, %n: i64, %k: i64) -> (f64, f64, i64, tensor<4x4xf32>) {
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[output:.*]] = arith.constant 0 : i64
+  // CHECK: %[[deltas:.*]] = memref.alloc
+  // CHECK: %[[output1:.*]] = tensor.empty() : tensor<4x4xf32>
+  %size = arith.index_cast %n : i64 to index
+  %deltas = memref.alloc(%size) : memref<?xf64>
+  %output = arith.constant 0 : i64
+  %output1 = tensor.empty() : tensor<4x4xf32>
+
+  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK: %[[res:.*]]:2 = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]], %[[iarg1:.*]] = %[[output1]]) -> (i64, tensor<4x4xf32>) {
+  // CHECK:   %[[timer:.*]] = perf.start_timer
+  // CHECK:   %[[mulres:.*]] = linalg.matmul
+  // CHECK:   %[[sum:.*]] = arith.addi %[[iarg0]], %[[k]]
+  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK:   scf.yield %[[sum]], %[[mulres]]
+  // CHECK: }
+  %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) args(%output, %output1 : i64, tensor<4x4xf32>) {
+    %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
+                       outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+    %sum = arith.addi %output, %k : i64
+    perf.yield %sum, %D : i64, tensor<4x4xf32>
+  } -> i64, tensor<4x4xf32>
+
+  // CHECK: %[[mean:.*]] = perf.mean
+  // CHECK: %[[stdev:.*]] = perf.stdev
+  %mean = perf.mean(%deltas : memref<?xf64>) : f64
+  %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
+
+  memref.dealloc %deltas : memref<?xf64>
+  // CHECK: return %[[mean]], %[[stdev]], %[[res]]#0, %[[res]]#1
+  return %mean, %stdev, %res, %res1 : f64, f64, i64, tensor<4x4xf32>
+}


### PR DESCRIPTION
Adds a conversion pass from perf dialect to loops.

A perf.bench operation is materialized as an scf.for loop with extra benchmarking code injected into the loop's body.
The optional bench args are passed around as loop iter_args.
Additionally, perf.yield arguments are renamed for more consistent API.

Work towards #100 