### PR TITLE
Perf to func

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -43,6 +43,12 @@ def Perf_StartTimerOp : Perf_Op<"start_timer", []> {
   let assemblyFormat = [{
     attr-dict `:` type($timer)
   }];
+
+  let extraClassDeclaration = [{
+    static std::string getLibraryCallName() {
+      return "perf_start_timer";
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -75,6 +81,12 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
   let assemblyFormat = [{
     `(` $timer `:` type($timer) `)` attr-dict
     `:` type($delta)
+  }];
+
+  let extraClassDeclaration = [{
+    static std::string getLibraryCallName() {
+      return "perf_stop_timer";
+    }
   }];
 
   let hasVerifier = 1;
@@ -252,6 +264,12 @@ def Perf_MeanOp : Perf_Op<"mean", []> {
     `(` $input `:` type($input) `)` attr-dict
     `:` type($mean)
   }];
+
+  let extraClassDeclaration = [{
+    static std::string getLibraryCallName() {
+      return "perf_mean";
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -285,6 +303,12 @@ def Perf_StdevOp : Perf_Op<"stdev", []> {
     `(` $input `:` type($input) `,` $mean `:` type($mean) `)` attr-dict
     `:` type($stdev)
   }];
+
+  let extraClassDeclaration = [{
+    static std::string getLibraryCallName() {
+      return "perf_stdev";
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -317,6 +341,12 @@ def Perf_SinkOp : Perf_Op<"sink", [ConditionallySpeculatable]> {
   }];
 
   let extraClassDeclaration = [{
+    static std::string applyTypeMangling(std::string name, Type type);
+
+    std::string getLibraryCallName() {
+      return applyTypeMangling("perf_sink", getInput().getType());
+    }
+
     ::mlir::Speculation::Speculatability getSpeculatability() {
       return ::mlir::Speculation::NotSpeculatable;
     }

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -77,6 +77,7 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createTransformDialectInterpreterPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgXToLoopsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertPerfToLoopsPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertPerfToFuncPass();
 std::unique_ptr<OperationPass<ModuleOp>> createTransformDropSchedulePass();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createPackVNNIPass();

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -119,6 +119,15 @@ def ConvertPerfToLoops : Pass<"convert-perf-to-loops", "ModuleOp"> {
   let dependentDialects = ["scf::SCFDialect"];
 }
 
+def ConvertPerfToFunc : Pass<"convert-perf-to-func", "ModuleOp"> {
+  let summary = "Convert perf to func";
+  let constructor = "mlir::tpp::createConvertPerfToFuncPass()";
+  let description = [{
+    Convert perf operations to function calls.
+  }];
+  let dependentDialects = ["func::FuncDialect"];
+}
+
 def TransformDropSchedulePass : Pass<"transform-drop-schedule", "ModuleOp"> {
   let summary = "Drop the transform schedule";
   let constructor = "mlir::tpp::createTransformDropSchedulePass()";

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -23,6 +23,7 @@ add_mlir_library(MLIRTPP
     ConvertCheckToLoops.cpp
     ConvertVNNIToTpp.cpp
     ConvertPerfToLoops.cpp
+    ConvertPerfToFunc.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/ConvertPerfToFunc.cpp
+++ b/lib/TPP/ConvertPerfToFunc.cpp
@@ -1,0 +1,231 @@
+//===- ConvertPerfToFunc.cpp -------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/PerfOps.h"
+#include "TPP/Passes.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::perf;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+// Perf dialect type normalization helper function.
+// Cast memref and tensor to their unranked versions and convert
+// custom perf types into default primitive types.
+// Leave all the other operands as they are.
+static SmallVector<Type> extractNormalizedTypes(OpBuilder &b,
+                                                ValueRange values) {
+  SmallVector<Type> results;
+  results.reserve(values.size());
+
+  for (Value val : values) {
+    TypeSwitch<Type>(val.getType())
+        .Case<MemRefType>([&](Type t) {
+          auto memrefType = cast<MemRefType>(t);
+          auto unrankedMemref = UnrankedMemRefType::get(
+              memrefType.getElementType(), memrefType.getMemorySpace());
+          results.push_back(unrankedMemref);
+        })
+        .Case<TensorType>([&](Type t) {
+          auto tensorType = cast<TensorType>(t);
+          auto unrankedTensor =
+              UnrankedTensorType::get(tensorType.getElementType());
+          results.push_back(unrankedTensor);
+        })
+        .Case<TimerType>([&](Type t) {
+          auto i64 = IntegerType::get(b.getContext(), 64);
+          results.push_back(i64);
+        })
+        .Default([&](Type t) { results.push_back(t); });
+  }
+
+  return results;
+}
+
+// Similar to 'extractNormalizedTypes' but inserts conversions from original
+// types to normalized ones when possible.
+// The conversions aim to simplify runtime function signature generation by, for
+// example, erasing explicit memref and tensor shapes.
+static SmallVector<Value> getNormalizedOperands(OpBuilder &b, Location loc,
+                                                ValueRange operands) {
+  SmallVector<Value> res;
+  res.reserve(operands.size());
+
+  for (Value op : operands) {
+    auto type = extractNormalizedTypes(b, op);
+    TypeSwitch<Type>(op.getType())
+        .Case<MemRefType>([&](Type t) {
+          Value cast = b.create<memref::CastOp>(loc, type, op);
+          res.push_back(cast);
+        })
+        .Case<TensorType>([&](Type t) {
+          Value cast = b.create<tensor::CastOp>(loc, type, op);
+          res.push_back(cast);
+        })
+        .Default([&](Type t) { res.push_back(op); });
+  }
+
+  return res;
+}
+
+// Apply custom function name mangling for various data types.
+// It is assumed that all relevant perf operations accept only unranked memory
+// types. This allows for simpler name mangling and leaner perf runtime.
+static void applyTypeMangling(std::string &name, Type type) {
+  llvm::raw_string_ostream mangledName(name);
+
+  TypeSwitch<Type>(type)
+      .Case<MemRefType>([&](Type t) {
+        mangledName << "_memref"
+                    << "_" << cast<MemRefType>(t).getElementType();
+      })
+      .Case<TensorType>([&](Type t) {
+        mangledName << "_tensor"
+                    << "_" << cast<TensorType>(t).getElementType();
+      })
+      .Default([&](Type t) { mangledName << "_" << t; });
+}
+
+// Creates function prototypes and insert calls to the perf runtime functions.
+static LogicalResult buildPerfFuncCall(Location loc, std::string funcName,
+                                       Operation *op,
+                                       PatternRewriter &rewriter) {
+  if (op->getNumResults() > 1)
+    return op->emitError(
+               "expected operation to have 0 or 1 result, but provided ")
+           << op->getNumResults();
+
+  FlatSymbolRefAttr fnName = SymbolRefAttr::get(op->getContext(), funcName);
+  ModuleOp module = op->getParentOfType<ModuleOp>();
+  auto libFnType = rewriter.getFunctionType(
+      extractNormalizedTypes(rewriter, op->getOperands()),
+      extractNormalizedTypes(rewriter, op->getResults()));
+
+  // Create function prototype if it is not available yet.
+  if (!module.lookupSymbol(fnName.getAttr())) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    // Insert before module terminator.
+    rewriter.setInsertionPoint(module.getBody(),
+                               std::prev(module.getBody()->end()));
+    func::FuncOp funcOp =
+        rewriter.create<func::FuncOp>(loc, fnName.getValue(), libFnType);
+    funcOp->setAttr(LLVM::LLVMDialect::getEmitCWrapperAttrName(),
+                    UnitAttr::get(rewriter.getContext()));
+    funcOp.setPrivate();
+  }
+
+  // Insert a function call to the perf runtime.
+  auto funcCall = rewriter.create<func::CallOp>(
+      loc, fnName.getValue(), libFnType.getResults(),
+      getNormalizedOperands(rewriter, loc, op->getOperands()));
+  op->replaceAllUsesWith(funcCall.getResults());
+
+  return success();
+}
+
+struct ConvertStartTimerOp : public OpRewritePattern<perf::StartTimerOp> {
+  using OpRewritePattern<perf::StartTimerOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::StartTimerOp startTimerOp,
+                                PatternRewriter &rewriter) const override {
+    auto res = buildPerfFuncCall(startTimerOp.getLoc(), "perf_start_timer",
+                                 startTimerOp, rewriter);
+    if (succeeded(res))
+      rewriter.eraseOp(startTimerOp);
+    return res;
+  }
+};
+
+struct ConvertStopTimerOp : public OpRewritePattern<perf::StopTimerOp> {
+  using OpRewritePattern<perf::StopTimerOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::StopTimerOp stopTimerOp,
+                                PatternRewriter &rewriter) const override {
+    auto res = buildPerfFuncCall(stopTimerOp.getLoc(), "perf_stop_timer",
+                                 stopTimerOp, rewriter);
+    if (succeeded(res))
+      rewriter.eraseOp(stopTimerOp);
+    return res;
+  }
+};
+
+struct ConvertMeanOp : public OpRewritePattern<perf::MeanOp> {
+  using OpRewritePattern<perf::MeanOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::MeanOp meanOp,
+                                PatternRewriter &rewriter) const override {
+    auto res =
+        buildPerfFuncCall(meanOp.getLoc(), "perf_mean", meanOp, rewriter);
+    if (succeeded(res))
+      rewriter.eraseOp(meanOp);
+    return res;
+  }
+};
+
+struct ConvertStdevOp : public OpRewritePattern<perf::StdevOp> {
+  using OpRewritePattern<perf::StdevOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::StdevOp stdevOp,
+                                PatternRewriter &rewriter) const override {
+    auto res =
+        buildPerfFuncCall(stdevOp.getLoc(), "perf_stdev", stdevOp, rewriter);
+    if (succeeded(res))
+      rewriter.eraseOp(stdevOp);
+    return res;
+  }
+};
+
+struct ConvertSinkOp : public OpRewritePattern<perf::SinkOp> {
+  using OpRewritePattern<perf::SinkOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::SinkOp sinkOp,
+                                PatternRewriter &rewriter) const override {
+    std::string funcName("perf_sink");
+    // perf.sink relies on the perf runtime to prevent complier from
+    // optimizing away marked data. Name mangling is required as the op
+    // accepts any kind of data. For simplicity, the mangling makes some
+    // assumptions on data types supported by the perf dialect.
+    applyTypeMangling(funcName, sinkOp.getInput().getType());
+
+    auto res = buildPerfFuncCall(sinkOp.getLoc(), funcName, sinkOp, rewriter);
+    if (succeeded(res))
+      rewriter.eraseOp(sinkOp);
+    return res;
+  }
+};
+
+void populatePerfToFuncPatterns(RewritePatternSet &patterns) {
+  patterns.add<ConvertStartTimerOp, ConvertStopTimerOp, ConvertMeanOp,
+               ConvertStdevOp, ConvertSinkOp>(patterns.getContext());
+}
+
+struct ConvertPerfToFunc : public ConvertPerfToFuncBase<ConvertPerfToFunc> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    populatePerfToFuncPatterns(patterns);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    return;
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::tpp::createConvertPerfToFuncPass() {
+  return std::make_unique<ConvertPerfToFunc>();
+}

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -83,3 +83,27 @@ LogicalResult BenchOp::verify() {
 
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// SinkOp
+//===----------------------------------------------------------------------===//
+
+// Apply custom function name mangling for various data types.
+// It is assumed that all relevant perf operations accept only unranked memory
+// types. This allows for simpler name mangling and leaner perf runtime.
+std::string SinkOp::applyTypeMangling(std::string name, Type type) {
+  llvm::raw_string_ostream mangledName(name);
+
+  TypeSwitch<Type>(type)
+      .Case<MemRefType>([&](Type t) {
+        mangledName << "_memref"
+                    << "_" << cast<MemRefType>(t).getElementType();
+      })
+      .Case<TensorType>([&](Type t) {
+        mangledName << "_tensor"
+                    << "_" << cast<TensorType>(t).getElementType();
+      })
+      .Default([&](Type t) { mangledName << "_" << t; });
+
+  return mangledName.str();
+}

--- a/test/TPP/perf/perf-to-func.mlir
+++ b/test/TPP/perf/perf-to-func.mlir
@@ -23,7 +23,7 @@ func.func @func_stop_timer() {
 
 // -----
 
-// CHECK-DAG: func.func private @perf_mean(memref<*xf64>) -> f64 attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_mean({{.*}}: memref<*xf64>) -> f64
 // CHECK-LABEL: @func_mean
 func.func @func_mean(%arg0: memref<?xf64>) {
   // CHECK: call @perf_mean({{.*}})
@@ -33,7 +33,7 @@ func.func @func_mean(%arg0: memref<?xf64>) {
 
 // -----
 
-// CHECK-DAG: func.func private @perf_stdev(memref<*xf64>, f64) -> f64 attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_stdev({{.*}}: memref<*xf64>, {{.*}}: f64) -> f64
 // CHECK-LABEL: @func_stdev
 func.func @func_stdev(%arg0: memref<?xf64>, %mean: f64) {
   // CHECK: call @perf_stdev({{.*}})
@@ -79,8 +79,8 @@ func.func @func_sink(%arg0: memref<?xi64>, %arg1: memref<?xi32>,
 // -----
 
 // An example of perf dialect usage.
-// CHECK-DAG: func.func private @perf_stdev(memref<*xf64>, f64) -> f64 attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_mean(memref<*xf64>) -> f64 attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_stdev({{.*}}: memref<*xf64>, {{.*}}: f64) -> f64
+// CHECK-DAG: func.func private @perf_mean({{.*}}: memref<*xf64>) -> f64
 // CHECK-DAG: func.func private @perf_sink_tensor_f32(tensor<*xf32>) attributes {llvm.emit_c_interface}
 // CHECK-DAG: func.func private @perf_stop_timer(i64) -> f64 attributes {llvm.emit_c_interface}
 // CHECK-DAG: func.func private @perf_start_timer() -> i64 attributes {llvm.emit_c_interface}

--- a/test/TPP/perf/perf-to-func.mlir
+++ b/test/TPP/perf/perf-to-func.mlir
@@ -1,0 +1,77 @@
+// RUN: tpp-opt %s -convert-perf-to-func -split-input-file -canonicalize | FileCheck %s
+
+// CHECK-DAG: func.func private @perf_start_timer() -> {{.*}} attributes {llvm.emit_c_interface}
+// CHECK-LABEL: @func_start_timer
+func.func @func_start_timer() {
+  // CHECK: call @perf_start_timer()
+  %t = perf.start_timer : !perf.timer
+  return
+}
+
+// -----
+
+// CHECK-DAG: func.func private @perf_start_timer() -> {{.*}} attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_stop_timer({{.*}}) -> {{.*}} attributes {llvm.emit_c_interface}
+// CHECK-LABEL: @func_stop_timer
+func.func @func_stop_timer() {
+  // CHECK: %[[timer:.*]] = call @perf_start_timer()
+  %t = perf.start_timer : !perf.timer
+  // CHECK: call @perf_stop_timer(%[[timer]])
+  %delta = perf.stop_timer(%t : !perf.timer) : f64
+  return
+}
+
+// -----
+
+// CHECK-DAG: func.func private @perf_mean(memref<*xf64>) -> f64 attributes {llvm.emit_c_interface}
+// CHECK-LABEL: @func_mean
+func.func @func_mean(%arg0: memref<?xf64>) {
+  // CHECK: call @perf_mean({{.*}})
+  %mean = perf.mean(%arg0 : memref<?xf64>) : f64
+  return
+}
+
+// -----
+
+// CHECK-DAG: func.func private @perf_stdev(memref<*xf64>, f64) -> f64 attributes {llvm.emit_c_interface}
+// CHECK-LABEL: @func_stdev
+func.func @func_stdev(%arg0: memref<?xf64>, %mean: f64) {
+  // CHECK: call @perf_stdev({{.*}})
+  %stdev = perf.stdev(%arg0 : memref<?xf64>, %mean : f64) : f64
+  return
+}
+
+// -----
+
+// CHECK-DAG: func.func private @perf_sink_memref_i64(memref<*xi64>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_memref_i32(memref<*xi32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_tensor_f64(tensor<*xf64>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_tensor_f32(tensor<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_i32(i32) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_i16(i16) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_f32(f32) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_f16(f16) attributes {llvm.emit_c_interface}
+// CHECK-LABEL: @func_sink
+func.func @func_sink(%arg0: memref<?xi64>, %arg1: memref<?xi32>,
+                            %arg2: tensor<?xf64>, %arg3: tensor<?xf32>,
+                            %arg4: i32, %arg5: i16,
+                            %arg6: f32, %arg7: f16 ) {
+  // CHECK: call @perf_sink_memref_i64({{.*}})
+  // CHECK: call @perf_sink_memref_i32({{.*}})
+  perf.sink(%arg0) : memref<?xi64>
+  perf.sink(%arg1) : memref<?xi32>
+  // CHECK: call @perf_sink_tensor_f64({{.*}})
+  // CHECK: call @perf_sink_tensor_f32({{.*}})
+  perf.sink(%arg2) : tensor<?xf64>
+  perf.sink(%arg3) : tensor<?xf32>
+  // CHECK: call @perf_sink_i32({{.*}})
+  // CHECK: call @perf_sink_i16({{.*}})
+  perf.sink(%arg4) : i32
+  perf.sink(%arg5) : i16
+  // CHECK: call @perf_sink_f32({{.*}})
+  // CHECK: call @perf_sink_f16({{.*}})
+  perf.sink(%arg6) : f32
+  perf.sink(%arg7) : f16
+
+  return
+}


### PR DESCRIPTION
Converts perf operations into function calls to a runtime
environment that provides required functionality.
    
The perf dialect is materialized through an external runtime as
the core operations such as access to timers are commonly platform
dependent and can vary greatly between different targets.

Work towards #100

First lowering pass to a "fat" runtime. It will allow for initial testing with the benchmark infrastructure.
Later, we can reduce the number of dependencies on custom runtime functions.