### PR TITLE
Perf dialect runtime

### DIFF
--- a/include/Utils/Perf.h
+++ b/include/Utils/Perf.h
@@ -43,7 +43,7 @@ class PerfResults {
   }
 
   /// Zero a time_point
-  void zero(std::chrono::high_resolution_clock::time_point& point) {
+  void zero(std::chrono::high_resolution_clock::time_point &point) {
     point = std::chrono::high_resolution_clock::time_point();
   }
 
@@ -56,7 +56,7 @@ public:
   }
 
   /// Stops the timer, accumulates, clears state
-  void stopTimer() {
+  double stopTimer() {
     assert(!locked && "Stop called after stats produced");
     assert(!isZero(start) && "Stop called before start");
     assert(isZero(stop) && "Stop called twice");
@@ -67,6 +67,8 @@ public:
     timings.push_back(val);
     zero(start);
     zero(stop);
+
+    return val;
   }
 
   /// Get mean of timings. Locks the timer, only calculate stats once.

--- a/include/Utils/Perf.h
+++ b/include/Utils/Perf.h
@@ -56,7 +56,7 @@ public:
   }
 
   /// Stops the timer, accumulates, clears state
-  double stopTimer() {
+  void stopTimer() {
     assert(!locked && "Stop called after stats produced");
     assert(!isZero(start) && "Stop called before start");
     assert(isZero(stop) && "Stop called twice");
@@ -67,8 +67,6 @@ public:
     timings.push_back(val);
     zero(start);
     zero(stop);
-
-    return val;
   }
 
   /// Get mean of timings. Locks the timer, only calculate stats once.

--- a/include/Utils/Perf.h
+++ b/include/Utils/Perf.h
@@ -43,7 +43,7 @@ class PerfResults {
   }
 
   /// Zero a time_point
-  void zero(std::chrono::high_resolution_clock::time_point &point) {
+  void zero(std::chrono::high_resolution_clock::time_point& point) {
     point = std::chrono::high_resolution_clock::time_point();
   }
 

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -76,16 +76,27 @@ func.func @func_stdev(%arg0: memref<?xf64>, %mean: f64) {
 
 // -----
 
-// CHECK-DAG: func.func private @perf_sink_memref_i64(memref<*xi64>) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_memref_i32(memref<*xi32>) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_tensor_f64(tensor<*xf64>) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_tensor_f32(tensor<*xf32>) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_i32(i32) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_i16(i16) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_f32(f32) attributes {llvm.emit_c_interface}
-// CHECK-DAG: func.func private @perf_sink_f16(f16) attributes {llvm.emit_c_interface}
-// CHECK-LABEL: @func_sink
-func.func @func_sink(%arg0: memref<?xi64>, %arg1: memref<?xi32>,
+// CHECK: func.func private @perf_sink_memref_f64({{.*}}: memref<*xf64>) attributes {passthrough = ["optnone", "noinline"]} {
+// CHECK:   return
+// CHECK: }
+func.func @func_sink(%arg0: memref<?xf64>) {
+  // CHECK: call @perf_sink_memref_f64({{.*}})
+  perf.sink(%arg0) : memref<?xf64>
+  return
+}
+
+// -----
+
+// CHECK-DAG: func.func private @perf_sink_memref_i64({{.*}}: memref<*xi64>) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_memref_i32({{.*}}: memref<*xi32>) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_tensor_f64({{.*}}: tensor<*xf64>) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_tensor_f32({{.*}}: tensor<*xf32>) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_i32({{.*}}: i32) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_i16({{.*}}: i16) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_f32({{.*}}: f32) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-DAG: func.func private @perf_sink_f16({{.*}}: f16) attributes {passthrough = ["optnone", "noinline"]}
+// CHECK-LABEL: @func_sink_variants
+func.func @func_sink_variants(%arg0: memref<?xi64>, %arg1: memref<?xi32>,
                             %arg2: tensor<?xf64>, %arg3: tensor<?xf32>,
                             %arg4: i32, %arg5: i16,
                             %arg6: f32, %arg7: f16 ) {
@@ -114,7 +125,7 @@ func.func @func_sink(%arg0: memref<?xi64>, %arg1: memref<?xi32>,
 // An example of perf dialect usage.
 // CHECK-DAG: func.func private @perf_stdev({{.*}}: memref<*xf64>, {{.*}}: f64) -> f64
 // CHECK-DAG: func.func private @perf_mean({{.*}}: memref<*xf64>) -> f64
-// CHECK-DAG: func.func private @perf_sink_tensor_f32(tensor<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @perf_sink_tensor_f32({{.*}}: tensor<*xf32>) attributes {passthrough = ["optnone", "noinline"]}
 // CHECK-DAG: func.func private @perf_stop_timer(i64) -> f64 attributes {llvm.emit_c_interface}
 // CHECK-DAG: func.func private @perf_start_timer() -> i64 attributes {llvm.emit_c_interface}
 // CHECK-LABEL: @perf_example

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -16,45 +16,6 @@
 #include "PerfRunnerUtils.h"
 #include "Utils/Perf.h"
 
-/// Vector with all results
-/// Using memref/vector in MLIR is too much of a pain.
-static std::vector<PerfResults> timerResults;
-
-//===----------------------------------------------------------------------===//
-// Benchamrk perf utils
-//===----------------------------------------------------------------------===//
-
-/// Returns the index of the result in the local vector that can be
-/// used as an ID to time, accumulate and get stats.
-int64_t _mlir_ciface_timer_alloc() {
-  timerResults.push_back({});
-  return timerResults.size() - 1;
-}
-
-void _mlir_ciface_timer_start(int64_t acc) {
-  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto &perfResults = timerResults[acc];
-  perfResults.startTimer();
-}
-
-void _mlir_ciface_timer_stop(int64_t acc) {
-  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto &perfResults = timerResults[acc];
-  perfResults.stopTimer();
-}
-
-double _mlir_ciface_timer_average(int64_t acc) {
-  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto &perfResults = timerResults[acc];
-  return perfResults.getMean();
-}
-
-double _mlir_ciface_timer_deviation(int64_t acc) {
-  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto &perfResults = timerResults[acc];
-  return perfResults.getStdev();
-}
-
 //===----------------------------------------------------------------------===//
 // Perf dialect utils
 //===----------------------------------------------------------------------===//

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -34,33 +34,3 @@ double _mlir_ciface_perf_stop_timer(int64_t startTimestamp) {
   return std::chrono::duration_cast<std::chrono::duration<double>>(stop - start)
       .count();
 }
-
-// A generic sink function.
-// Its aim is to ensure that the passed data and its producers cannot be
-// optimized away such that the time measured by a benchmark loop correctly
-// represents the full workload.
-static void __attribute__((optnone)) perf_sink(void *data) { (void)data; }
-
-/*
-  Perf dialect runtime bindings for common perf.sink op argument types.
-*/
-void _mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *val) {
-  perf_sink((void *)&val);
-}
-void _mlir_ciface_perf_sink_memref_i16(UnrankedMemRefType<int16_t> *val) {
-  perf_sink((void *)&val);
-}
-void _mlir_ciface_perf_sink_memref_i32(UnrankedMemRefType<int32_t> *val) {
-  perf_sink((void *)&val);
-}
-void _mlir_ciface_perf_sink_memref_i64(UnrankedMemRefType<int64_t> *val) {
-  perf_sink((void *)&val);
-}
-
-void _mlir_ciface_perf_sink_i8(int8_t val) { perf_sink((void *)&val); }
-void _mlir_ciface_perf_sink_i16(int16_t val) { perf_sink((void *)&val); }
-void _mlir_ciface_perf_sink_i32(int32_t val) { perf_sink((void *)&val); }
-void _mlir_ciface_perf_sink_i64(int64_t val) { perf_sink((void *)&val); }
-
-void _mlir_ciface_perf_sink_f32(float val) { perf_sink((void *)&val); }
-void _mlir_ciface_perf_sink_f64(double val) { perf_sink((void *)&val); }

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -60,17 +60,19 @@ double _mlir_ciface_timer_deviation(int64_t acc) {
 // Perf dialect utils
 //===----------------------------------------------------------------------===//
 
+// Return current timestamp.
 int64_t _mlir_ciface_perf_start_timer() {
-  auto timer = _mlir_ciface_timer_alloc();
-  _mlir_ciface_timer_start(timer);
-  return timer;
+  auto timestamp = std::chrono::high_resolution_clock::now();
+  return timestamp.time_since_epoch().count();
 }
 
-double _mlir_ciface_perf_stop_timer(int64_t timer) {
-  assert(timer >= 0 && (int64_t)timerResults.size() > timer &&
-         "Invalid timer ID");
-  auto &perfResults = timerResults[timer];
-  return perfResults.stopTimer();
+// Compute time delta between the starting time and now.
+double _mlir_ciface_perf_stop_timer(int64_t timestamp) {
+  auto stop = std::chrono::high_resolution_clock::now();
+  std::chrono::system_clock::time_point start{
+      std::chrono::system_clock::duration{timestamp}};
+  return std::chrono::duration_cast<std::chrono::duration<double>>(stop - start)
+      .count();
 }
 
 static void __attribute__((optnone)) perf_sink(void *data) { (void)data; }

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <chrono>
-#include <cmath>
 #include <ctime>
 
 #include "PerfRunnerUtils.h"
@@ -77,8 +76,8 @@ double _mlir_ciface_perf_stop_timer(int64_t startTimestamp) {
 
 // A generic sink function.
 // Its aim is to ensure that the passed data and its producers cannot be
-// optimized away to ensure that the time measured by a benchmark loop
-// represents the full workload correctly.
+// optimized away such that the time measured by a benchmark loop correctly
+// represents the full workload.
 static void __attribute__((optnone)) perf_sink(void *data) { (void)data; }
 
 /*

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <chrono>
+#include <cmath>
 #include <ctime>
 
 #include "PerfRunnerUtils.h"
@@ -19,6 +20,10 @@
 /// Vector with all results
 /// Using memref/vector in MLIR is too much of a pain.
 static std::vector<PerfResults> timerResults;
+
+//===----------------------------------------------------------------------===//
+// Benchamrk perf utils
+//===----------------------------------------------------------------------===//
 
 /// Returns the index of the result in the local vector that can be
 /// used as an ID to time, accumulate and get stats.
@@ -29,25 +34,89 @@ int64_t _mlir_ciface_timer_alloc() {
 
 void _mlir_ciface_timer_start(int64_t acc) {
   assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto& perfResults = timerResults[acc];
+  auto &perfResults = timerResults[acc];
   perfResults.startTimer();
 }
 
 void _mlir_ciface_timer_stop(int64_t acc) {
   assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto& perfResults = timerResults[acc];
+  auto &perfResults = timerResults[acc];
   perfResults.stopTimer();
 }
 
 double _mlir_ciface_timer_average(int64_t acc) {
   assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto& perfResults = timerResults[acc];
+  auto &perfResults = timerResults[acc];
   return perfResults.getMean();
 }
 
 double _mlir_ciface_timer_deviation(int64_t acc) {
   assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
-  auto& perfResults = timerResults[acc];
+  auto &perfResults = timerResults[acc];
   return perfResults.getStdev();
 }
 
+//===----------------------------------------------------------------------===//
+// Perf dialect utils
+//===----------------------------------------------------------------------===//
+
+int64_t _mlir_ciface_perf_start_timer() {
+  auto timer = _mlir_ciface_timer_alloc();
+  _mlir_ciface_timer_start(timer);
+  return timer;
+}
+
+double _mlir_ciface_perf_stop_timer(int64_t timer) {
+  assert(timer >= 0 && (int64_t)timerResults.size() > timer &&
+         "Invalid timer ID");
+  auto &perfResults = timerResults[timer];
+  return perfResults.stopTimer();
+}
+
+double _mlir_ciface_perf_mean(UnrankedMemRefType<double> *deltasBuff) {
+  auto deltas = DynamicMemRefType<double>(*deltasBuff);
+  assert(deltas.rank == 1 && "Invalid deltas buffer");
+
+  const int size = deltas.sizes[0];
+  double sum = 0.0;
+  for (auto it = deltas.begin(); it != deltas.end(); ++it)
+    sum += *it;
+  return sum / size;
+}
+
+double _mlir_ciface_perf_stdev(UnrankedMemRefType<double> *deltasBuff,
+                               double mean) {
+  auto deltas = DynamicMemRefType<double>(*deltasBuff);
+  assert(deltas.rank == 1 && "Invalid deltas buffer");
+
+  const int size = deltas.sizes[0];
+  double sum = 0.0;
+  for (auto it = deltas.begin(); it != deltas.end(); ++it) {
+    double delta = *it - mean;
+    sum += delta * delta;
+  }
+  return std::sqrt(sum / size);
+}
+
+static void __attribute__((optnone)) perf_sink(void *data) { (void)data; }
+
+void _mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *val) {
+  perf_sink((void *)&val);
+}
+void _mlir_ciface_perf_sink_memref_i16(UnrankedMemRefType<int16_t> *val) {
+  perf_sink((void *)&val);
+}
+void _mlir_ciface_perf_sink_memref_i32(UnrankedMemRefType<int32_t> *val) {
+  perf_sink((void *)&val);
+}
+void _mlir_ciface_perf_sink_memref_i64(UnrankedMemRefType<int64_t> *val) {
+  perf_sink((void *)&val);
+}
+
+void _mlir_ciface_perf_sink_i8(int8_t val) { perf_sink((void *)&val); }
+void _mlir_ciface_perf_sink_i16(int16_t val) { perf_sink((void *)&val); }
+void _mlir_ciface_perf_sink_i32(int32_t val) { perf_sink((void *)&val); }
+void _mlir_ciface_perf_sink_i64(int64_t val) { perf_sink((void *)&val); }
+
+void _mlir_ciface_perf_sink_f32(float val) { perf_sink((void *)&val); }
+void _mlir_ciface_perf_sink_f64(double val) { perf_sink((void *)&val); }

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -60,23 +60,30 @@ double _mlir_ciface_timer_deviation(int64_t acc) {
 // Perf dialect utils
 //===----------------------------------------------------------------------===//
 
-// Return current timestamp.
+// Return the current timestamp.
 int64_t _mlir_ciface_perf_start_timer() {
   auto timestamp = std::chrono::high_resolution_clock::now();
   return timestamp.time_since_epoch().count();
 }
 
 // Compute time delta between the starting time and now.
-double _mlir_ciface_perf_stop_timer(int64_t timestamp) {
+double _mlir_ciface_perf_stop_timer(int64_t startTimestamp) {
   auto stop = std::chrono::high_resolution_clock::now();
   std::chrono::system_clock::time_point start{
-      std::chrono::system_clock::duration{timestamp}};
+      std::chrono::system_clock::duration{startTimestamp}};
   return std::chrono::duration_cast<std::chrono::duration<double>>(stop - start)
       .count();
 }
 
+// A generic sink function.
+// Its aim is to ensure that the passed data and its producers cannot be
+// optimized away to ensure that the time measured by a benchmark loop
+// represents the full workload correctly.
 static void __attribute__((optnone)) perf_sink(void *data) { (void)data; }
 
+/*
+  Perf dialect runtime bindings for common perf.sink op argument types.
+*/
 void _mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *val) {
   perf_sink((void *)&val);
 }

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -73,31 +73,6 @@ double _mlir_ciface_perf_stop_timer(int64_t timer) {
   return perfResults.stopTimer();
 }
 
-double _mlir_ciface_perf_mean(UnrankedMemRefType<double> *deltasBuff) {
-  auto deltas = DynamicMemRefType<double>(*deltasBuff);
-  assert(deltas.rank == 1 && "Invalid deltas buffer");
-
-  const int size = deltas.sizes[0];
-  double sum = 0.0;
-  for (auto it = deltas.begin(); it != deltas.end(); ++it)
-    sum += *it;
-  return sum / size;
-}
-
-double _mlir_ciface_perf_stdev(UnrankedMemRefType<double> *deltasBuff,
-                               double mean) {
-  auto deltas = DynamicMemRefType<double>(*deltasBuff);
-  assert(deltas.rank == 1 && "Invalid deltas buffer");
-
-  const int size = deltas.sizes[0];
-  double sum = 0.0;
-  for (auto it = deltas.begin(); it != deltas.end(); ++it) {
-    double delta = *it - mean;
-    sum += delta * delta;
-  }
-  return std::sqrt(sum / size);
-}
-
 static void __attribute__((optnone)) perf_sink(void *data) { (void)data; }
 
 void _mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *val) {

--- a/tpp-rt/PerfRunnerUtils.h
+++ b/tpp-rt/PerfRunnerUtils.h
@@ -39,12 +39,6 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_perf_start_timer();
 
 extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_perf_stop_timer(int64_t);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT double
-_mlir_ciface_perf_mean(UnrankedMemRefType<double> *);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT double
-_mlir_ciface_perf_stdev(UnrankedMemRefType<double> *, double);
-
 extern "C" MLIR_RUNNERUTILS_EXPORT void
 _mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *);
 extern "C" MLIR_RUNNERUTILS_EXPORT void

--- a/tpp-rt/PerfRunnerUtils.h
+++ b/tpp-rt/PerfRunnerUtils.h
@@ -16,22 +16,6 @@
 #include "mlir/ExecutionEngine/RunnerUtils.h"
 
 //===----------------------------------------------------------------------===//
-// Benchamrk perf utils
-//===----------------------------------------------------------------------===//
-
-extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_timer_alloc();
-
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_start(int64_t);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_stop(int64_t);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_accumulate(int64_t);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_average(int64_t);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_deviation(int64_t);
-
-//===----------------------------------------------------------------------===//
 // Perf dialect utils
 //===----------------------------------------------------------------------===//
 

--- a/tpp-rt/PerfRunnerUtils.h
+++ b/tpp-rt/PerfRunnerUtils.h
@@ -23,20 +23,4 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_perf_start_timer();
 
 extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_perf_stop_timer(int64_t);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *);
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_perf_sink_memref_i16(UnrankedMemRefType<int16_t> *);
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_perf_sink_memref_i32(UnrankedMemRefType<int32_t> *);
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_perf_sink_memref_i64(UnrankedMemRefType<int64_t> *);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i8(int8_t);
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i16(int16_t);
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i32(int32_t);
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i64(int64_t);
-
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_f32(float);
-extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_f64(double);
 #endif // TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H

--- a/tpp-rt/PerfRunnerUtils.h
+++ b/tpp-rt/PerfRunnerUtils.h
@@ -15,6 +15,10 @@
 
 #include "mlir/ExecutionEngine/RunnerUtils.h"
 
+//===----------------------------------------------------------------------===//
+// Benchamrk perf utils
+//===----------------------------------------------------------------------===//
+
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_timer_alloc();
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_start(int64_t);
@@ -27,4 +31,34 @@ extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_average(int64_t);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_deviation(int64_t);
 
+//===----------------------------------------------------------------------===//
+// Perf dialect utils
+//===----------------------------------------------------------------------===//
+
+extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_perf_start_timer();
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_perf_stop_timer(int64_t);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double
+_mlir_ciface_perf_mean(UnrankedMemRefType<double> *);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double
+_mlir_ciface_perf_stdev(UnrankedMemRefType<double> *, double);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT void
+_mlir_ciface_perf_sink_memref_i8(UnrankedMemRefType<int8_t> *);
+extern "C" MLIR_RUNNERUTILS_EXPORT void
+_mlir_ciface_perf_sink_memref_i16(UnrankedMemRefType<int16_t> *);
+extern "C" MLIR_RUNNERUTILS_EXPORT void
+_mlir_ciface_perf_sink_memref_i32(UnrankedMemRefType<int32_t> *);
+extern "C" MLIR_RUNNERUTILS_EXPORT void
+_mlir_ciface_perf_sink_memref_i64(UnrankedMemRefType<int64_t> *);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i8(int8_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i16(int16_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i32(int32_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_i64(int64_t);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_f32(float);
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_perf_sink_f64(double);
 #endif // TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H

--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -290,8 +290,8 @@ LogicalResult MLIRBench::finalize() {
   // Minimal passes to make it work
   // We don't want TPP passes here, as that's the job of tpp-opt
   // The IR here should be free of TPP/XSMM or any TPP extensions
-  // Perf passes are an exception as they provide necessary generic lowering
-  // to materialize benchmarking code
+  // Perf passes are an exception as they provide necessary generic
+  // lowering to materialize benchmarking code
   PassManager passManager(module->getContext());
   applyPassManagerCLOptions(passManager);
 

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -60,9 +60,6 @@ class MLIRBench {
   /// Create a random global based on the memref type
   llvm::StringRef createGlobal(MemRefType);
 
-  /// Declare some required global functions
-  /// TODO: This won't be needed after the perf dialect is used
-  void declareGlobalFunctions();
   struct {
     func::FuncOp alloc;
     func::FuncOp start;
@@ -102,12 +99,11 @@ public:
   /// the return value (if any) or the last argument (outs).
   Value callKernel(llvm::SmallVector<llvm::StringRef> &);
 
-  /// Create a loop with a timer around the kernel call
-  /// Returns the memref containing the timings
-  /// TODO: Move this to create a perf.timer op
+  /// Create a benchmarking region around the kernel call
+  /// Returns the memref containing measured time deltas
   Value createTimerLoop(llvm::SmallVector<llvm::StringRef> &, unsigned);
 
-  /// Get the timer average/deviation (from the vector accumulation)
+  /// Get the timer average/deviation
   Value getTimerStats(Value);
 
   /// Prints a float value (used for mean/dev)

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -35,6 +35,9 @@
 #include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 
+#include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+
 using namespace mlir;
 
 // Number of loops for benchmarks
@@ -43,9 +46,10 @@ llvm::cl::opt<unsigned>
                   llvm::cl::value_desc("int"), llvm::cl::init(1));
 
 // Print result
-llvm::cl::opt<bool>
-    printResultMemRef("print", llvm::cl::desc("Print result memref"),
-                  llvm::cl::value_desc("true/false"), llvm::cl::init(false));
+llvm::cl::opt<bool> printResultMemRef("print",
+                                      llvm::cl::desc("Print result memref"),
+                                      llvm::cl::value_desc("true/false"),
+                                      llvm::cl::init(false));
 
 // This function will be called by the pass manager after parsing,
 // so we can modify the IR with the needed wrappers
@@ -114,6 +118,8 @@ int main(int argc, char **argv) {
   // include what you need like above. You only need to register dialects that
   // will be *parsed* by the tool, not the one generated
   DialectRegistry registry;
+  registry.insert<mlir::perf::PerfDialect>();
+  mlir::perf::registerBufferizableOpInterfaceExternalModels(registry);
   registerAllDialects(registry);
   registerAllToLLVMIRTranslations(registry);
 


### PR DESCRIPTION
Adds runtime bindings required to execute perf dialect operations.
The existing manual MLIR benchmarking loop is now moved to rely on the perf dialect ops.
Also, necessary lowering passes are added to the `tpp-run`.

Work toward #100 