### PR TITLE
`tpp-opt` default passes

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -23,6 +23,24 @@ class FuncDialect;
 } // namespace mlir
 
 namespace mlir {
+namespace bufferization {
+class BufferizationDialect;
+} // namespace bufferization
+} // namespace mlir
+
+namespace mlir {
+namespace math {
+class MathDialect;
+} // namespace math
+} // namespace mlir
+
+namespace mlir {
+namespace arith {
+class ArithDialect;
+} // namespace arith
+} // namespace mlir
+
+namespace mlir {
 namespace vector {
 class VectorDialect;
 } // namespace vector
@@ -41,9 +59,21 @@ class SCFDialect;
 } // namespace mlir
 
 namespace mlir {
+namespace tensor {
+class TensorDialect;
+} // namespace tensor
+} // namespace mlir
+
+namespace mlir {
 namespace memref {
 class MemRefDialect;
 } // namespace memref
+} // namespace mlir
+
+namespace mlir {
+namespace tpp {
+class TppDialect;
+} // namespace tpp
 } // namespace mlir
 
 namespace mlir {
@@ -90,7 +120,7 @@ createTileConsumerAndFuseProducersPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createDecomposeConvToMatmulOrBrgemmPass();
 
-ModulePass *createDefaultTppPass();
+std::unique_ptr<OperationPass<ModuleOp>> createDefaultTppPass();
 } // namespace tpp
 } // namespace mlir
 

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -89,6 +89,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createTileConsumerAndFuseProducersPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createDecomposeConvToMatmulOrBrgemmPass();
+
+ModulePass *createDefaultTppPass();
 } // namespace tpp
 } // namespace mlir
 

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -13,83 +13,54 @@
 
 namespace mlir {
 class ModuleOp;
-} // namespace mlir
 
-namespace mlir {
 namespace func {
 class FuncOp;
 class FuncDialect;
 } // namespace func
-} // namespace mlir
 
-namespace mlir {
 namespace bufferization {
 class BufferizationDialect;
 } // namespace bufferization
-} // namespace mlir
 
-namespace mlir {
 namespace math {
 class MathDialect;
 } // namespace math
-} // namespace mlir
 
-namespace mlir {
 namespace arith {
 class ArithDialect;
 } // namespace arith
-} // namespace mlir
 
-namespace mlir {
 namespace vector {
 class VectorDialect;
 } // namespace vector
-} // namespace mlir
 
-namespace mlir {
 namespace linalg {
 class LinalgDialect;
 } // namespace linalg
-} // namespace mlir
 
-namespace mlir {
 namespace scf {
 class SCFDialect;
 } // namespace scf
-} // namespace mlir
 
-namespace mlir {
 namespace tensor {
 class TensorDialect;
 } // namespace tensor
-} // namespace mlir
 
-namespace mlir {
 namespace memref {
 class MemRefDialect;
 } // namespace memref
-} // namespace mlir
 
-namespace mlir {
-namespace tpp {
-class TppDialect;
-} // namespace tpp
-} // namespace mlir
-
-namespace mlir {
 namespace xsmm {
 class XsmmDialect;
 } // namespace xsmm
-} // namespace mlir
 
-namespace mlir {
 namespace vnni {
 class VNNIDialect;
 } // namespace vnni
-} // namespace mlir
 
-namespace mlir {
 namespace tpp {
+class TppDialect;
 
 // RETIRE
 std::unique_ptr<OperationPass<func::FuncOp>> createMapLinalgToTppPass();

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -244,7 +244,12 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     A collection of passes that lower everything TPP-related
     to standard low-level dialects.
   }];
-  let dependentDialects = ["scf::SCFDialect"];
+  let dependentDialects = ["tpp::TppDialect", "xsmm::XsmmDialect",
+                           "vnni::VNNIDialect", "linalg::LinalgDialect",
+                           "math::MathDialect", "arith::ArithDialect", 
+                           "scf::SCFDialect", "func::FuncDialect",
+                           "bufferization::BufferizationDialect",
+                           "tensor::TensorDialect", "memref::MemRefDialect"];
 }
 
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -237,4 +237,14 @@ def DecomposeConvToMatmulOrBrgemm : Pass<"decompose-conv-to-matmul-or-brgemm",
   let constructor = "mlir::tpp::createDecomposeConvToMatmulOrBrgemmPass()";
 }
 
+def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
+  let summary = "Convert perf to loops";
+  let constructor = "mlir::tpp::createDefaultTppPass()";
+  let description = [{
+    A collection of passes that lower everything TPP-related
+    to standard low-level dialects.
+  }];
+  let dependentDialects = ["scf::SCFDialect"];
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -244,6 +244,11 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     A collection of passes that lower everything TPP-related
     to standard low-level dialects.
   }];
+  let options= [
+    Option<"tppToLoops", "tpp-to-loops",
+           "bool", /*default=*/"0",
+           "By default TPP ops are lowered to XSMM. Lower TPP to loops instead.">,
+  ];
 }
 
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -244,12 +244,6 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     A collection of passes that lower everything TPP-related
     to standard low-level dialects.
   }];
-  let dependentDialects = ["tpp::TppDialect", "xsmm::XsmmDialect",
-                           "vnni::VNNIDialect", "linalg::LinalgDialect",
-                           "math::MathDialect", "arith::ArithDialect", 
-                           "scf::SCFDialect", "func::FuncDialect",
-                           "bufferization::BufferizationDialect",
-                           "tensor::TensorDialect", "memref::MemRefDialect"];
 }
 
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -238,7 +238,7 @@ def DecomposeConvToMatmulOrBrgemm : Pass<"decompose-conv-to-matmul-or-brgemm",
 }
 
 def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
-  let summary = "Convert perf to loops";
+  let summary = "Collection of default TPP passes";
   let constructor = "mlir::tpp::createDefaultTppPass()";
   let description = [{
     A collection of passes that lower everything TPP-related

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_library(MLIRTPP
     MapConvToMatmul.cpp
     TileConsumerAndFuseProducers.cpp
     DecomposeConvsToMatmulOrBrgemm.cpp
+    DefaultTppPasses.cpp
 
   # Utils
     TransformUtils.cpp

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -1,0 +1,71 @@
+//===- DefaultTppPasses.cpp --------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Tpp/TppDialect.h"
+#include "TPP/Dialect/VNNI/VNNIDialect.h"
+#include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
+#include "mlir/Dialect/Bufferization/Transforms/Transforms.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+struct DefaultTppPasses : public DefaultTppPassesBase<DefaultTppPasses> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    PassManager pm(module.getContext());
+
+    pm.addNestedPass<func::FuncOp>(createMapLinalgToTppPass());
+
+    bufferization::OneShotBufferizationOptions buffOpts;
+    buffOpts.allowReturnAllocs = true;
+    buffOpts.bufferizeFunctionBoundaries = true;
+    buffOpts.functionBoundaryTypeConversion =
+        bufferization::LayoutMapOption::IdentityLayoutMap;
+    pm.addPass(bufferization::createOneShotBufferizePass(buffOpts));
+    pm.addPass(bufferization::createDropEquivalentBufferResultsPass());
+    pm.addNestedPass<func::FuncOp>(
+        bufferization::createFinalizingBufferizePass());
+    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+
+    pm.addNestedPass<func::FuncOp>(createConvertLinalgToTppPass());
+    pm.addNestedPass<func::FuncOp>(createConvertTppToXsmmPass());
+
+    if (failed(pm.run(module)))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> mlir::tpp::createDefaultTppPass() {
+  return std::make_unique<DefaultTppPasses>();
+}

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -70,7 +70,7 @@ struct DefaultTppPasses : public DefaultTppPassesBase<DefaultTppPasses> {
     perf::registerBufferizableOpInterfaceExternalModels(registry);
 
     // Add all core MLIR dialects as the default TPP passes may contain any
-    // combination of the existing passes.
+    // combination of other passes.
     registerAllDialects(registry);
   }
 

--- a/test/Benchmarks/matmul_48x64x96.mlir
+++ b/test/Benchmarks/matmul_48x64x96.mlir
@@ -1,8 +1,4 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
-// RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
-// RUN: -convert-xsmm-to-func | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/matmul_64x48x96.mlir
+++ b/test/Benchmarks/matmul_64x48x96.mlir
@@ -1,8 +1,4 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
-// RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
-// RUN: -convert-xsmm-to-func | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/matmul_64x64x64.mlir
+++ b/test/Benchmarks/matmul_64x64x64.mlir
@@ -1,8 +1,4 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
-// RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
-// RUN: -convert-xsmm-to-func | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/mlp.mlir
+++ b/test/Benchmarks/mlp.mlir
@@ -1,9 +1,4 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
-// RUN: -map-linalg-to-tpp -convert-linalg-to-tpp="use-parallel-loops=false" \
-// RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
-// RUN: -convert-xsmm-to-func | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -1,8 +1,4 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
-// RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
-// RUN: -convert-xsmm-to-func | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -1,8 +1,4 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
-// RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
-// RUN: -convert-xsmm-to-func | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \


### PR DESCRIPTION
Creates a new pass `-default-tpp-passes` which acts as a default `tpp-opt` pre-pass i.e., a collection of different conversions, lowerings, and other preprocessing steps, that ensures none of the custom TPP ops exist after the pass runs.

Work towards #234 

The existing test benchmarks were moved to use the new pass as they already utilize `tpp-run`,

Next steps:
- create test cases with progressive lowering and mixed levels of IR
- move from `mlir-cpu-runner` to `tpp-run`
- try adding more specialized passes e.g., packing and tiling with some default values, brgemm stuff etc.