### PR TITLE
Fixing issue 246

### DIFF
--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -144,7 +144,7 @@ Value MLIRBench::callKernel(llvm::SmallVector<llvm::StringRef> &list) {
   // Call the Kernel, making sure to set the result to either the return value
   // or the last argument, if the return is void.
   Value result;
-  auto funcType = main.getFunctionType();
+  auto funcType = kernel.getFunctionType();
   if (funcType.getNumResults() == 0) {
     builder.create<func::CallOp>(unkLoc, kernel, kernelArgs);
     result = kernelArgs.back();


### PR DESCRIPTION
Issue #246. The return value from a kernel was getting ignored with -print option of tpp-run.