### PR TITLE
Use the default pipeline for Resnet50

### DIFF
--- a/test/Benchmarks/resnet50_bottleneck.mlir
+++ b/test/Benchmarks/resnet50_bottleneck.mlir
@@ -1,15 +1,3 @@
-// RUN: tpp-opt %s -decompose-conv-to-matmul-or-brgemm -empty-tensor-to-alloc-tensor \
-// RUN: -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
-// RUN: -drop-equivalent-buffer-results -finalizing-bufferize \
-// RUN: -buffer-results-to-out-params -buffer-deallocation -canonicalize \
-// RUN: -convert-linalg-to-tpp="use-parallel-loops=false" \
-// RUN: -convert-tpp-to-xsmm -convert-xsmm-to-func \
-// RUN: -expand-strided-metadata -lower-affine | \
-// RUN: tpp-run -n 10 -print \
-// RUN: -e resnet50_bottleneck_block -entry-point-result=void \
-// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
-// RUN: FileCheck %s
-
 // RUN: tpp-opt %s -default-tpp-passes -expand-strided-metadata -lower-affine | \
 // RUN: tpp-run -n 10 -print \
 // RUN: -e resnet50_bottleneck_block -entry-point-result=void \

--- a/test/Benchmarks/resnet50_bottleneck.mlir
+++ b/test/Benchmarks/resnet50_bottleneck.mlir
@@ -9,7 +9,12 @@
 // RUN: -e resnet50_bottleneck_block -entry-point-result=void \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
-//
+
+// RUN: tpp-opt %s -default-tpp-passes -expand-strided-metadata -lower-affine | \
+// RUN: tpp-run -n 10 -print \
+// RUN: -e resnet50_bottleneck_block -entry-point-result=void \
+// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3) -> (d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>


### PR DESCRIPTION
Adds an extra test run with the default pipeline to the ResNet50 model test.
The original manually built lowering pipeline is left for comparison and ease of future experimentation with different passes.
ResNet50 integration test is moved fully to the default pipeline.

Small changes to the `CHECK`s are needed due to: LICM in the default pipeline which wasn't present in the original manual pipeline and use of parallel loops for linalg to tpp conversion is enabled.