### PR TITLE
Benchmarks memory leak fix

### DIFF
--- a/benchmarks/include/Tensor.h
+++ b/benchmarks/include/Tensor.h
@@ -63,6 +63,9 @@ public:
   Tensor<T> &operator=(const Tensor<T> &other) {
     dims = other.dims;
     size = other.size;
+    /// Release current data before copying a new buffer
+    if (data)
+      free(data);
     alloc();
     std::memcpy(data, other.data, dataSize);
     return *this;

--- a/test/Benchmarks/matmul_48x64x96.mlir
+++ b/test/Benchmarks/matmul_48x64x96.mlir
@@ -1,4 +1,5 @@
-// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-opt %s -default-tpp-passes \
+// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/matmul_64x48x96.mlir
+++ b/test/Benchmarks/matmul_64x48x96.mlir
@@ -1,4 +1,5 @@
-// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-opt %s -default-tpp-passes \
+// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/matmul_64x64x64.mlir
+++ b/test/Benchmarks/matmul_64x64x64.mlir
@@ -1,4 +1,5 @@
-// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-opt %s -default-tpp-passes \
+// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/mlp.mlir
+++ b/test/Benchmarks/mlp.mlir
@@ -1,4 +1,5 @@
-// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-opt %s -default-tpp-passes \
+// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -1,4 +1,5 @@
-// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-opt %s -default-tpp-passes \
+// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
 // RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -1,4 +1,5 @@
-// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-opt %s -default-tpp-passes \
+// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print \
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \


### PR DESCRIPTION
Adds missing memory deallocation in the benchmarks Tensor helper copy assignment operator.

For completeness, all benchmarks now perform conversion of memref function results to out-params and deallocation cleanup to prevent potential memory leaks.

Work towards #234 