### PR TITLE
Move CheckToLoopPass to be a function pass

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -67,7 +67,7 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertLinalgToTppPass(bool, bool, ArrayRef<int64_t> tiles = {});
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTppToLoopsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertXsmmToFuncPass();
-std::unique_ptr<OperationPass<ModuleOp>> createConvertCheckToLoopsPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertCheckToLoopsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertVNNIToTppPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTppToXsmmPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -66,7 +66,7 @@ def ConvertXsmmToFunc : Pass<"convert-xsmm-to-func", "ModuleOp"> {
   let dependentDialects = ["func::FuncDialect"];
 }
 
-def ConvertCheckToLoops : Pass<"convert-check-to-loops", "ModuleOp"> {
+def ConvertCheckToLoops : Pass<"convert-check-to-loops", "func::FuncOp"> {
   let summary = "Convert check to loops";
   let constructor = "mlir::tpp::createConvertCheckToLoopsPass()";
   let description = [{

--- a/lib/TPP/ConvertCheckToLoops.cpp
+++ b/lib/TPP/ConvertCheckToLoops.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
 using namespace mlir;
 using namespace mlir::check;
 using namespace mlir::cf;
@@ -186,7 +187,7 @@ struct ConvertCheckToLoops
 
 } // namespace
 
-std::unique_ptr<OperationPass<ModuleOp>>
+std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::tpp::createConvertCheckToLoopsPass() {
   return std::make_unique<ConvertCheckToLoops>();
 }


### PR DESCRIPTION
Originally the pass was injecting functions in the module and thus was correctly modeled as ModulePass; it simply replaces the op with other scf/arith ops; therefore, we can make it a function pass. Note that function pass can run in parallel while module pass no.