### PR TITLE
Introduce a pass to rewrite scf.for to scf.parallel

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -88,6 +88,7 @@ createDecomposeConvToMatmulOrBrgemmPass();
 std::unique_ptr<OperationPass<ModuleOp>> createDefaultTppPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGeneralizeTensorPackAndUnPackPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createRaiseToParallelLoopPass();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -246,4 +246,13 @@ def GeneralizeTensorPackAndUnPack : Pass<"generalize-tensor-pack-unpack",
   let constructor = "mlir::tpp::createGeneralizeTensorPackAndUnPackPass()";
 }
 
+def RaiseToParallelLoop : Pass<"raise-to-parallel-loop",
+                               "func::FuncOp"> {
+  let summary = "Rewrite scf.for to scf.parallel.";
+  let description = [{
+
+  }]; 
+  let constructor = "mlir::tpp::createRaiseToParallelLoopPass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_library(MLIRTPP
     DecomposeConvsToMatmulOrBrgemm.cpp
     DefaultTppPasses.cpp
     GeneralizeTensorPackAndUnPack.cpp
+    RaiseToParallelLoop.cpp
 
   # Utils
     TransformUtils.cpp

--- a/lib/TPP/RaiseToParallelLoop.cpp
+++ b/lib/TPP/RaiseToParallelLoop.cpp
@@ -1,0 +1,62 @@
+//===- RaiseToParallelLoop.cpp -----------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+struct RaiseToParallelLoopWithAttribute : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    if (forOp.hasIterOperands() || !forOp->hasAttr("parallel"))
+      return failure();
+
+    auto bodyBuilder = [&](OpBuilder &builder, Location loc,
+                           ValueRange iterVals, ValueRange) {
+      Block &innerBody = forOp.getLoopBody().front();
+      IRMapping mapping;
+      mapping.map(innerBody.getArguments(),
+                  iterVals.take_back(innerBody.getNumArguments()));
+      for (Operation &op : innerBody.without_terminator())
+        builder.clone(op, mapping);
+    };
+
+    rewriter.replaceOpWithNewOp<scf::ParallelOp>(
+        forOp, forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
+        std::nullopt, bodyBuilder);
+    return success();
+  }
+};
+
+struct RaiseToParallelLoop
+    : public RaiseToParallelLoopBase<RaiseToParallelLoop> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(getOperation().getContext());
+    patterns.add<RaiseToParallelLoopWithAttribute>(patterns.getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    return;
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createRaiseToParallelLoopPass() {
+  return std::make_unique<RaiseToParallelLoop>();
+}

--- a/test/Passes/raise-to-parallel-loops.mlir
+++ b/test/Passes/raise-to-parallel-loops.mlir
@@ -1,0 +1,20 @@
+//RUN: tpp-opt %s -raise-to-parallel-loop | FileCheck %s
+
+func.func @main(%lb: index, %ub: index, %step: index, %src: memref<32xf32>) {
+  scf.for %i = %lb to %ub step %step {
+    %load = memref.load %src[%i] : memref<32xf32>
+    %add = arith.addf %load, %load : f32
+    memref.store %add, %src[%i] : memref<32xf32>
+  } {parallel}
+  return
+}
+
+// CHECK: func.func @main(
+// CHECK-SAME:  %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index,
+// CHECK-SAME:  %[[SRC:.+]]: memref<32xf32>)
+// CHECK: scf.parallel (%[[I:.+]]) = (%[[LB]]) to (%[[UB]]) step (%[[STEP]]) {
+// CHECK: %[[LOAD:.+]] = memref.load %[[SRC]][%[[I]]] : memref<32xf32>
+// CHECK: %[[ADD:.+]] = arith.addf %[[LOAD]], %[[LOAD]] : f32
+// CHECK: memref.store %[[ADD]], %[[SRC]][%[[I]]] : memref<32xf32>
+// CHECK: scf.yield
+// CHECK: }


### PR DESCRIPTION
`scf.parallel` does not work at the tensor level. To maintain parallelism at the tensor level, we have the following choices: `scf.foreach_theread` or looking at gml dialect in mlir-hlo. Preliminary discussion seems that we don't like either option: `scf.foreach_theread` does not have a lowering, and it is too 'thread' like, and it is unclear how to lower it to OMP, while gml requires adding mlir-hlo as a submodule. If we exclude these two options, we should either extend upstream `scf.parallel` on tensor or raise back and `scf.for` to `scf.parallel` after bufferization. This PR implements the latter option, which is wrong, but it is the path with less friction.

We only raise loop marked as 'parallel'; other passes like tile-consumer-and-fuse-producers are responsible for injecting the attribute when a loop with parallel semantics is materialized.