### PR TITLE
Allow test kernels to return results

### DIFF
--- a/test/Benchmarks/matmul_48x64x96.mlir
+++ b/test/Benchmarks/matmul_48x64x96.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/matmul_64x48x96.mlir
+++ b/test/Benchmarks/matmul_64x48x96.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/matmul_64x64x64.mlir
+++ b/test/Benchmarks/matmul_64x64x64.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/mlp.mlir
+++ b/test/Benchmarks/mlp.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/resnet50_bottleneck.mlir
+++ b/test/Benchmarks/resnet50_bottleneck.mlir
@@ -1,6 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN: -buffer-results-to-out-params -buffer-deallocation \
-// RUN: -expand-strided-metadata -lower-affine | \
+// RUN: tpp-opt %s -default-tpp-passes -expand-strided-metadata -lower-affine | \
 // RUN: tpp-run -n 10 -print \
 // RUN: -e resnet50_bottleneck_block -entry-point-result=void | \
 // RUN: FileCheck %s
@@ -225,7 +223,17 @@ func.func @resnet50_bottleneck_block(%input_2d : !first_conv1x1_input_tensor_2d_
 
     // Extract a 2D slice for printing: avoids 2D-memref print limitation
     %3 = tensor.extract_slice %second_conv1x1_output[0, 0, 0, 0][1, 1, 2, 4][1, 1, 1, 1] : !second_conv1x1_output_tensor_t to tensor<2x4xf32>
-    return %3 : tensor<2x4xf32>
+
+    // Copy the result into a separate output buffer
+    %outBuf = bufferization.alloc_tensor() : tensor<2x4xf32>
+    %out = linalg.copy ins(%3 : tensor<2x4xf32>) outs(%outBuf : tensor<2x4xf32>) -> tensor<2x4xf32>
+
+    // Cleanup temporary buffers
+    bufferization.dealloc_tensor %first_conv1x1_output : !first_conv1x1_output_tensor_t
+    bufferization.dealloc_tensor %conv3x3_output : !conv3x3_output_tensor_t
+    bufferization.dealloc_tensor %second_conv1x1_output : !second_conv1x1_output_tensor_t
+
+    return %out : tensor<2x4xf32>
 }
 
 // Output

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes \
-// RUN:  -buffer-results-to-out-params -buffer-deallocation | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -n 10 \
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s

--- a/test/Integration/result-out-arg.mlir
+++ b/test/Integration/result-out-arg.mlir
@@ -1,0 +1,49 @@
+// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-run -print -n 10 \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @matmultpp(%A: memref<2x2xf32>,
+          %B: memref<2x2xf32>, %C: memref<2x2xf32>) attributes {llvm.emit_c_interface} {
+  linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%A, %B: memref<2x2xf32>, memref<2x2xf32>) outs(%C: memref<2x2xf32>) {
+        ^bb0(%a: f32, %b: f32, %c: f32):
+          %0 = arith.mulf %a, %b : f32
+          %1 = arith.addf %c, %0 : f32
+          linalg.yield %1 : f32
+  }
+  return
+}
+
+memref.global "private" constant @__constant_da : memref<2x2xf32> =
+  dense<[
+        [ 1.0, 2.0 ],
+        [ 3.0, 4.0 ]
+  ]>
+
+memref.global "private" constant @__constant_db : memref<2x2xf32> =
+  dense<[
+        [ 2.0, 1.0 ],
+        [ 1.0, 2.0 ]
+  ]>
+
+func.func @entry(%out : memref<2x2xf32>) {
+  %c0 = arith.constant 0.0 : f32
+  linalg.fill ins(%c0 : f32) outs(%out : memref<2x2xf32>)
+
+  %A = memref.get_global @__constant_da : memref<2x2xf32>
+  %B = memref.get_global @__constant_db : memref<2x2xf32>
+
+  // Call kernel.
+  call @matmultpp(%A, %B, %out) : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
+
+  return
+}
+
+// CHECK: ( 4, 5 )
+// CHECK: ( 10, 11 )

--- a/test/Integration/result-out-return.mlir
+++ b/test/Integration/result-out-return.mlir
@@ -1,0 +1,17 @@
+// RUN: tpp-opt %s -default-tpp-passes | \
+// RUN: tpp-run -print -n 10 \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry() -> memref<1x1xf32> {
+  %c1 = arith.constant 1.0 : f32
+  %c0 = arith.constant 0 : index
+
+  %0 = arith.addf %c1, %c1 : f32
+  %out = memref.alloc() : memref<1x1xf32>
+  memref.store %0, %out[%c0, %c0] : memref<1x1xf32>
+
+  return %out : memref<1x1xf32>
+}
+
+// CHECK: ( 2 )

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes -buffer-results-to-out-params -buffer-deallocation  | FileCheck %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck %s
 //
 
 // ----------------------
@@ -77,7 +77,7 @@
 
 //
 // CHECK-LABEL: @mobilenet(
-// CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>, %[[arg:.*]]: memref<1x1001xf32>) {
+// CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1001xf32> {
 //
 func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
   //

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -95,9 +95,12 @@ public:
   /// Create main wrapper function, sets insertion point
   LogicalResult createMainWrapper();
 
-  /// Calls the kernel, returns the result, which is either
+  /// Creates and returns a call to the kernel.
+  Operation *callKernel(llvm::SmallVector<llvm::StringRef> &);
+
+  /// Returns the result of a kernel call, which is either
   /// the return value (if any) or the last argument (outs).
-  Value callKernel(llvm::SmallVector<llvm::StringRef> &);
+  Value getKernelResult(Operation *kernelCall);
 
   /// Create a benchmarking region around the kernel call
   /// Returns the memref containing measured time deltas
@@ -111,6 +114,9 @@ public:
 
   /// Prints the memref as a vector read + print
   LogicalResult printMemRef(Value);
+
+  /// Prints the result of a kernel call
+  LogicalResult printResult(Operation *kernelCall);
 
   /// Terminates the function, issuing a return, lower to LLVM
   LogicalResult finalize();

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -46,8 +46,8 @@ llvm::cl::opt<unsigned>
                   llvm::cl::value_desc("int"), llvm::cl::init(1));
 
 // Print result
-llvm::cl::opt<bool> printResultMemRef("print",
-                                      llvm::cl::desc("Print result memref"),
+llvm::cl::opt<bool> printKernelResult("print",
+                                      llvm::cl::desc("Print kernel result"),
                                       llvm::cl::value_desc("true/false"),
                                       llvm::cl::init(false));
 
@@ -84,12 +84,12 @@ static LogicalResult prepareMLIRKernel(Operation *op,
     return bench.emitError("Cannot create main wrapper");
 
   // Call kernel once, to bootstrap (JIT compile, warm up caches)
-  auto ret = bench.callKernel(globalList);
-  if (!ret)
+  auto call = bench.callKernel(globalList);
+  if (!call)
     return bench.emitError("Cannot generate a call to the kernel");
 
   // Print the result of the warming up, should be the same as any other
-  if (printResultMemRef && failed(bench.printMemRef(ret)))
+  if (printKernelResult && failed(bench.printResult(call)))
     return bench.emitError("Cannot print result memref");
 
   // This is the main loop, if N > 1


### PR DESCRIPTION
Adds automatic memory deallocation to `tpp-run` to allow test kernels to pass test outputs through function return without memory leaks.
This change then allows us to stop using `-buffer-results-to-out-params` for more predictable kernel APIs and removes need for non-default passes. Extra manual memory management is added when needed.

Work towards #234 