### PR TITLE
Fix xsmm tests

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -13,9 +13,9 @@ include "XsmmDialect.td"
 include "XsmmAttr.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def XsmmMemRef : AnyTypeOf<[MemRefRankOf<[AnyFloat], [1, 2, 3, 4]>, AnyFloat, I64]>;
-def Xsmm2DMemRef : AnyTypeOf<[MemRefRankOf<[AnyFloat], [2]>]>;
-def Xsmm4DMemRef : AnyTypeOf<[MemRefRankOf<[AnyFloat], [4]>]>;
+def XsmmMemRef : AnyTypeOf<[MemRefRankOf<[F32, BF16], [1, 2, 3, 4]>, F32, BF16, I64]>;
+def Xsmm2DMemRef : AnyTypeOf<[MemRefRankOf<[F32, BF16], [2]>]>;
+def Xsmm4DMemRef : AnyTypeOf<[MemRefRankOf<[F32, BF16], [4]>]>;
 
 //===----------------------------------------------------------------------===//
 // TernaryOp

--- a/test/Integration/relayout-gemm.mlir
+++ b/test/Integration/relayout-gemm.mlir
@@ -5,6 +5,17 @@
 // RUN: FileCheck %s
 //
 
+// Validate default pipeline
+// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" -expand-strided-metadata -lower-affine | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes -expand-strided-metadata -lower-affine | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 #accessesToBlock = [
   affine_map<(n1, c1, n2, c2) -> (n1 * 2 + n2, c1 * 2 + c2)>,
   affine_map<(n1, c1, n2, c2) -> (n1, c1, n2, c2)>

--- a/test/Integration/relayout-more-interesting.mlir
+++ b/test/Integration/relayout-more-interesting.mlir
@@ -5,6 +5,17 @@
 // RUN: FileCheck %s
 //
 
+// Validate default pipeline
+// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" -expand-strided-metadata -lower-affine | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes -expand-strided-metadata -lower-affine | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 #accessesToBlock = [
   affine_map<(n1, c1, n2, c2) -> (n1 * 2 + n2, c1 * 2 + c2)>,
   affine_map<(n1, c1, n2, c2) -> (n1, c1, n2, c2)>

--- a/test/Integration/smoke.mlir
+++ b/test/Integration/smoke.mlir
@@ -11,16 +11,27 @@
 // RUN: FileCheck %s
 //
 
+// Validate default pipeline
+// RUN: tpp-opt %s -linalg-generalize-named-ops -default-tpp-passes="tpp-to-loops" | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// RUN: tpp-opt %s -linalg-generalize-named-ops -default-tpp-passes | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 module {
   //
   // Computes C = A x B with all matrices dense.
   //
-  func.func @matmul1(%A: tensor<4x8xf64>, %B: tensor<8x4xf64>,
-                     %C: tensor<4x4xf64>) -> tensor<4x4xf64> {
+  func.func @matmul1(%A: tensor<4x8xf32>, %B: tensor<8x4xf32>,
+                     %C: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %D = linalg.matmul
-      ins(%A, %B: tensor<4x8xf64>, tensor<8x4xf64>)
-         outs(%C: tensor<4x4xf64>) -> tensor<4x4xf64>
-    return %D: tensor<4x4xf64>
+      ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
+         outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+    return %D: tensor<4x4xf32>
   }
 
   //
@@ -28,7 +39,7 @@ module {
   //
   func.func @entry() {
     %c0 = arith.constant 0 : index
-    %d1 = arith.constant -1.0 : f64
+    %d1 = arith.constant -1.0 : f32
 
     // Initialize various matrices, dense for stress testing,
     // and sparse to verify correct nonzero structure.
@@ -37,7 +48,7 @@ module {
         [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2 ],
         [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3 ],
         [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4 ]
-    ]> : tensor<4x8xf64>
+    ]> : tensor<4x8xf32>
     %db = arith.constant dense<[
         [ 10.1, 11.1, 12.1, 13.1 ],
         [ 10.2, 11.2, 12.2, 13.2 ],
@@ -47,12 +58,12 @@ module {
         [ 10.6, 11.6, 12.6, 13.6 ],
         [ 10.7, 11.7, 12.7, 13.7 ],
         [ 10.8, 11.8, 12.8, 13.8 ]
-    ]> : tensor<8x4xf64>
+    ]> : tensor<8x4xf32>
 
     // Call kernels with dense.
-    %C = arith.constant dense<0.0> : tensor<4x4xf64>
+    %C = arith.constant dense<0.0> : tensor<4x4xf32>
     %0 = call @matmul1(%da, %db, %C)
-       : (tensor<4x8xf64>, tensor<8x4xf64>, tensor<4x4xf64>) -> tensor<4x4xf64>
+       : (tensor<4x8xf32>, tensor<8x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
 
     //
     // CHECK:    ( ( 388.76, 425.56, 462.36, 499.16 ),
@@ -60,8 +71,8 @@ module {
     // CHECK-SAME: ( 405.48, 443.88, 482.28, 520.68 ),
     // CHECK-SAME: ( 413.84, 453.04, 492.24, 531.44 ) )
     //
-    %v0 = vector.transfer_read %0[%c0, %c0], %d1 : tensor<4x4xf64>, vector<4x4xf64>
-    vector.print %v0 : vector<4x4xf64>
+    %v0 = vector.transfer_read %0[%c0, %c0], %d1 : tensor<4x4xf32>, vector<4x4xf32>
+    vector.print %v0 : vector<4x4xf32>
 
     return
   }


### PR DESCRIPTION
Fixes #286 

Fixes:
- converts `smoke.mlir` to `f32` as our runtime doesn't currently handle `f64` dispatch
- restricts XSMM ops from `AnyFloat` to `f32` and `bf16` to avoid future surprises like with the `smoke.mlir` test
  - this should be reverted once we decide to have full LIBXSMM type support
- fixes ldi computation for `tpp.identity` to address `relayout-*.mlir` tests issues