### PR TITLE
Move utils in linalgx namespace (NFC)

### DIFF
--- a/include/TPP/TransformUtils.h
+++ b/include/TPP/TransformUtils.h
@@ -22,6 +22,7 @@ namespace linalg {
 class LinalgOp;
 } // namespace linalg
 
+namespace linalgx {
 namespace utils {
 
 // Given an opOperand and a range of ivs return the one used by the operands.
@@ -55,7 +56,7 @@ FailureOr<SmallVector<Range>> getLoopsToMaterialize(RewriterBase &rewriter,
                                                     unsigned upTo);
 
 } // namespace utils
-
+} // namespace linalgx
 } // namespace mlir
 
 #endif

--- a/lib/TPP/MapConvToMatmul.cpp
+++ b/lib/TPP/MapConvToMatmul.cpp
@@ -151,8 +151,9 @@ static FailureOr<Value> getSlicedConvOperandImpl(OpBuilder &builder,
     strides[strides.size() - 2] = builder.getIndexAttr(
         multiplicativeFactor.cast<AffineConstantExpr>().getValue());
   }
-  return utils::getSliceOperand(builder, linalgOp, operandToUse, offsets, sizes,
-                                strides, desiredResultRank);
+  return linalgx::utils::getSliceOperand(builder, linalgOp, operandToUse,
+                                         offsets, sizes, strides,
+                                         desiredResultRank);
 }
 
 // Extract the sliced version of `operand` such that we can use it in a
@@ -164,7 +165,7 @@ static FailureOr<Value> getSlicedConvOperand(OpBuilder &builder,
                                              ValueRange valuesToUse) {
   Location loc = linalgOp.getLoc();
   FailureOr<SmallVector<Value>> involvedDimForOperand =
-      utils::getInvolvedLocalDimsForOperand(
+      linalgx::utils::getInvolvedLocalDimsForOperand(
           builder, loc, operand, linalgOp.getMatchingIndexingMap(operand), ivs);
   if (failed(involvedDimForOperand))
     return failure();
@@ -239,7 +240,7 @@ mlir::linalgx::mapConvToMatmul(RewriterBase &rewriter,
   // peel-out all loops but the three innermost.
   unsigned upTo = linalgOp.getNumLoops() - /*GEMM loops=*/3;
   FailureOr<SmallVector<Range>> maybeLoopRanges =
-      mlir::utils::getLoopsToMaterialize(rewriter, linalgOp, upTo);
+      linalgx::utils::getLoopsToMaterialize(rewriter, linalgOp, upTo);
   if (failed(maybeLoopRanges))
     return failure();
   SmallVector<Range> loopRanges = *maybeLoopRanges;

--- a/lib/TPP/MapToBatchReduceGEMM.cpp
+++ b/lib/TPP/MapToBatchReduceGEMM.cpp
@@ -110,14 +110,14 @@ getSlicedOperands(OpBuilder &builder, Location loc, ValueRange localIvs,
 
   SmallVector<Value> slicedOperands;
   for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
-    FailureOr<Value> slicedOperand = utils::getSliceOperand(
+    FailureOr<Value> slicedOperand = linalgx::utils::getSliceOperand(
         builder, operand, linalgOp, localIvs, valuesToUse, 3);
     if (failed(slicedOperand))
       return failure();
     slicedOperands.push_back(*slicedOperand);
   }
   for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
-    FailureOr<Value> slicedOperand = utils::getSliceOperand(
+    FailureOr<Value> slicedOperand = linalgx::utils::getSliceOperand(
         builder, operand, linalgOp, localIvs, valuesToUse, 2);
     if (failed(slicedOperand))
       return failure();
@@ -150,15 +150,15 @@ mlir::linalgx::mapToBRGEMMOp(RewriterBase &rewriter,
   if (failed(checkBody(linalgOp)))
     return rewriter.notifyMatchFailure(linalgOp, "expects a GEMM-like body");
 
-  // materialize outer loops
+  // Materialize outer loops.
   unsigned upTo = linalgOp.getNumLoops() - /*BRGEMM loops=*/4;
   FailureOr<SmallVector<Range>> maybeLoopRanges =
-      mlir::utils::getLoopsToMaterialize(rewriter, linalgOp, upTo);
+      linalgx::utils::getLoopsToMaterialize(rewriter, linalgOp, upTo);
   if (failed(maybeLoopRanges))
     return failure();
   SmallVector<Range> loopRanges = *maybeLoopRanges;
 
-  // replace linalgOp with BRGEMM.
+  // Replace linalgOp with BRGEMM.
   SmallVector<Value> ivs, tensorResults;
   auto brgemmBuilder = [&](OpBuilder &builder, Location loc,
                            ValueRange localIvs,

--- a/lib/TPP/TransformUtils.cpp
+++ b/lib/TPP/TransformUtils.cpp
@@ -14,9 +14,9 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
-using namespace mlir;
-
 namespace mlir {
+
+namespace linalgx {
 
 namespace utils {
 
@@ -185,5 +185,7 @@ FailureOr<SmallVector<Range>> getLoopsToMaterialize(RewriterBase &rewriter,
 }
 
 } // namespace utils
+
+} // namespace linalgx
 
 } // namespace mlir


### PR DESCRIPTION
All the methods in TransformUtils are used on linalg operations, thus it is better to move the utils in a linalgx namespace instead of mlir::utils.