### PR TITLE
Relax `SameTypeOperands` constraint for `tpp.add`

### DIFF
--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -36,7 +36,7 @@ def TppVNNIOperand : AnyTypeOf<[TppVNNIMemrefInput, AnyFloat]>;
 
 // Class for tpp binary operations.
 class Tpp_BinaryOp<string mnemonic, list<Trait> traits = []> :
-  Tpp_Op<mnemonic, !listconcat(traits, [SameTypeOperands])> {
+  Tpp_Op<mnemonic, !listconcat(traits, [])> {
 
   let arguments = (ins TppOperand:$lhs, TppOperand:$rhs, TppOperand:$out);
 

--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -14,6 +14,7 @@
 #include <string>
 
 namespace mlir {
+class TypeRange;
 
 namespace linalg {
 class LinalgOp;
@@ -81,6 +82,12 @@ bool isValConstZero(Value val);
 
 // Returns true if the op defining `val` represents a zero filled tensor.
 bool isZeroTensor(Value val);
+
+// Returns true if `types` have the same shape and strides. For example: A:
+// memref<56x32xf32, strided<[32, 1], offset: ?>> B: memref<56x32xf32>
+// allOperandsHaveSameShape(A, B) return true. C: memref<1x32xf32>
+// allOperandsHaveSameShape(A, C) return false.
+bool allOperandsHaveSameShapeAndStrides(TypeRange types);
 
 } // namespace utils
 } // namespace tpp

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -8,6 +8,7 @@
 
 #include "TPP/Dialect/Tpp/TppOps.h"
 #include "TPP/Dialect/Tpp/TppDialect.h"
+#include "TPP/Dialect/Tpp/TppUtils.h"
 #include "mlir/IR/OpImplementation.h"
 
 #define GET_OP_CLASSES
@@ -139,11 +140,10 @@ LogicalResult AddOp::verify() {
   if ((!lhsType.isa<ShapedType>()) || (!rhsType.isa<ShapedType>()) ||
       (!outputType.isa<ShapedType>()))
     return emitOpError("expects all operands to be shaped type");
-  ArrayRef<int64_t> shapeLhs = lhsType.cast<ShapedType>().getShape();
-  ArrayRef<int64_t> shapeRhs = rhsType.cast<ShapedType>().getShape();
-  ArrayRef<int64_t> shapeOut = outputType.cast<ShapedType>().getShape();
-  if ((shapeLhs != shapeRhs) || (shapeRhs != shapeOut))
-    return emitOpError("requires all operands to have the same shape");
+  if (!utils::allOperandsHaveSameShapeAndStrides(
+          {lhsType, rhsType, outputType}))
+    return emitOpError(
+        "requires all operands to have the same shape or strides");
   return success();
 }
 

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -139,6 +139,11 @@ LogicalResult AddOp::verify() {
   if ((!lhsType.isa<ShapedType>()) || (!rhsType.isa<ShapedType>()) ||
       (!outputType.isa<ShapedType>()))
     return emitOpError("expects all operands to be shaped type");
+  ArrayRef<int64_t> shapeLhs = lhsType.cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shapeRhs = rhsType.cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shapeOut = outputType.cast<ShapedType>().getShape();
+  if ((shapeLhs != shapeRhs) || (shapeRhs != shapeOut))
+    return emitOpError("requires all operands to have the same shape");
   return success();
 }
 

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -342,20 +342,13 @@ bool allOperandsHaveSameShapeAndStrides(TypeRange types) {
   return true;
 }
 
-static bool allOperandsHaveSameShapeAndStrides(linalg::GenericOp linalgOp) {
-  SmallVector<Type> types;
-  for (Value operand : linalgOp->getOperands())
-    types.push_back(operand.getType());
-  return allOperandsHaveSameShapeAndStrides(types);
-}
-
 // Return true if the linalg.generic can be mapped to a tpp.add.
 bool isTppAdd(linalg::GenericOp linalgOp) {
   if (!hasMappingToTppConditions(linalgOp))
     return false;
   if (!isBinaryOp(linalgOp))
     return false;
-  if (!allOperandsHaveSameShapeAndStrides(linalgOp))
+  if (!allOperandsHaveSameShapeAndStrides(linalgOp->getOperands().getTypes()))
     return false;
   return allIndexingsAreProjectedPermutation(linalgOp) &&
          hasOnlyOp<arith::AddFOp>(linalgOp.getRegion());

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp.mlir
@@ -128,7 +128,7 @@ func.func @add_mapping(%arg0: memref<1xf32>, %arg1: memref<1xf32>) {
 
 // Scalar operands we don't expect any mapping to tpp.
 #map = affine_map<() -> ()>
-func.func @add_mapping(%arg0: memref<f32>, %arg1: memref<f32>) {
+func.func @add_mapping_scalar(%arg0: memref<f32>, %arg1: memref<f32>) {
   // CHECK-NOT: tpp.add
   linalg.generic {
     indexing_maps = [#map, #map], 
@@ -146,7 +146,7 @@ func.func @add_mapping(%arg0: memref<f32>, %arg1: memref<f32>) {
 // We don't support broadcast for tpp.add. All operands must have the same type.
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (0, d1)>
-func.func @add_mapping(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) {
+func.func @add_mapping_brcst(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) {
   // CHECK-NOT: tpp.add
   linalg.generic {
     indexing_maps = [#map, #map1],

--- a/test/Dialect/Tpp/tpp-invalid.mlir
+++ b/test/Dialect/Tpp/tpp-invalid.mlir
@@ -3,7 +3,7 @@
 func.func @tpp_add_invalid(%arg0: memref<1x2xf32>,
                            %arg1: memref<2x2xf32>) -> memref<2x1xf32> {
 
-  // expected-error @below {{'tpp.add' op requires all operands to have the same type}}
+  // expected-error @below {{'tpp.add' op requires all operands to have the same shape}}
   tpp.add ins(%arg0: memref<1x2xf32>, %arg1: memref<2x2xf32>) out(%arg1: memref<2x2xf32>)
   return %arg1: memref<2x2xf32>
 }

--- a/test/Dialect/Tpp/tpp-invalid.mlir
+++ b/test/Dialect/Tpp/tpp-invalid.mlir
@@ -3,7 +3,7 @@
 func.func @tpp_add_invalid(%arg0: memref<1x2xf32>,
                            %arg1: memref<2x2xf32>) -> memref<2x1xf32> {
 
-  // expected-error @below {{'tpp.add' op requires all operands to have the same shape}}
+  // expected-error @below {{'tpp.add' op requires all operands to have the same shape or strides}}
   tpp.add ins(%arg0: memref<1x2xf32>, %arg1: memref<2x2xf32>) out(%arg1: memref<2x2xf32>)
   return %arg1: memref<2x2xf32>
 }
@@ -112,4 +112,12 @@ func.func @tpp_matmul_invalid(%arg0: memref<3x2xf32>, %arg1: memref<2x3xf32>,
   // expected-error @below {{'tpp.matmul' op requires the same element type for all operands}}
   tpp.matmul ins(%arg0: memref<3x2xf32>, %arg1: memref<2x3xf32>) out(%arg2: memref<3x3xbf16>)
   return %arg2: memref<3x3xbf16>
+}
+
+// -----
+
+func.func @tpp_add_wrong_strides(%arg0: memref<4x4xf32>, %arg1: memref<4x4xf32, strided<[4, 2], offset: ?>>) {
+  // expected-error @below {{'tpp.add' op requires all operands to have the same shape or strides}}
+  tpp.add ins(%arg0: memref<4x4xf32>, %arg0: memref<4x4xf32>) out(%arg1: memref<4x4xf32, strided<[4, 2], offset: ?>>)
+  return
 }

--- a/test/Integration/tpp-add.mlir
+++ b/test/Integration/tpp-add.mlir
@@ -1,0 +1,81 @@
+// RUN: tpp-opt %s -convert-linalg-to-tpp -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
+// RUN: mlir-cpu-runner \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%llvmlibdir/libmlir_runner_utils%shlibext | FileCheck %s -check-prefix=EXE
+//
+
+// RUN: tpp-opt %s -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
+// RUN: mlir-cpu-runner \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%llvmlibdir/libmlir_runner_utils%shlibext | FileCheck %s -check-prefix=EXE
+//
+
+// RUN: tpp-opt %s -convert-linalg-to-loops -convert-tpp-to-loops -convert-tpp-to-xsmm -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
+// RUN: mlir-cpu-runner \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%llvmlibdir/libmlir_runner_utils%shlibext | FileCheck %s -check-prefix=EXE
+//
+
+// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck %s
+
+func.func private @generate_1D_source(%init_source : memref<?xf32>){
+  linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%init_source : memref<?xf32>) {
+    ^bb0(%b0 : f32):
+      %inner = linalg.index 0 : index
+      %inner_val_i32 = arith.index_cast %inner : index to i32
+      %inner_val_f32 = arith.sitofp %inner_val_i32 : i32 to f32
+      linalg.yield %inner_val_f32 :  f32
+  }
+  return
+}
+
+func.func @entry() {
+  %arg0 = memref.alloc() : memref<56x32xf32>
+  %arg1 = memref.alloc() : memref<56x32xf32>
+  %arg2 = memref.alloc() : memref<1x2x56x56x32xf32>
+
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %c56 = arith.constant 56 : index
+  %c1_cst = arith.constant 1.0 : f32
+  %c32 = arith.constant 32 : index
+
+  %seed = memref.alloc(%c32) : memref<?xf32>
+  call @generate_1D_source(%seed) : (memref<?xf32>) -> () 
+  %cast_seed = memref.cast %seed : memref<?xf32> to memref<32xf32>
+  linalg.broadcast ins(%cast_seed : memref<32xf32>)
+                   outs(%arg0 : memref<56x32xf32>)
+                   dimensions = [0]
+  linalg.broadcast ins(%cast_seed : memref<32xf32>)
+                   outs(%arg1 : memref<56x32xf32>)
+                   dimensions = [0]
+  linalg.fill ins(%c1_cst : f32) outs(%arg2 : memref<1x2x56x56x32xf32>)
+  
+  scf.for %arg3 = %c0 to %c2 step %c1 {
+    scf.for %arg4 = %c0 to %c56 step %c1 {
+      %subview = memref.subview %arg2 [0, %arg3, %arg4, 0, 0] [1, 1, 1, 56, 32] [1, 1, 1, 1, 1] 
+        : memref<1x2x56x56x32xf32> to memref<56x32xf32, strided<[32, 1], offset: ?>>
+      // CHECK: tpp.add
+      linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, 
+                       affine_map<(d0, d1) -> (d0, d1)>], 
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0, %arg1 : memref<56x32xf32>, memref<56x32xf32>)
+      outs(%subview : memref<56x32xf32, strided<[32, 1], offset: ?>>) {
+        ^bb0(%in: f32, %in_0: f32, %out: f32):
+          %0 = arith.addf %in, %in_0 : f32
+          linalg.yield %0 : f32
+      }
+    }
+  }
+  %to_print = memref.cast %arg2 : memref<1x2x56x56x32xf32> to memref<*xf32>
+  // EXE-COUNT-6272: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62]
+  call @printMemrefF32(%to_print) : (memref<*xf32>) -> ()
+  return
+}
+
+func.func private @printMemrefF32(%ptr : memref<*xf32>) attributes {llvm.emit_c_interface}

--- a/test/Integration/tpp-add.mlir
+++ b/test/Integration/tpp-add.mlir
@@ -1,14 +1,14 @@
-// RUN: tpp-opt %s -convert-linalg-to-tpp -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
+// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" | \
 // RUN: tpp-run -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE
 
-// RUN: tpp-opt %s -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
+// RUN: tpp-opt %s -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
 // RUN: tpp-run -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE
 
-// RUN: tpp-opt %s -convert-linalg-to-loops -convert-tpp-to-loops -convert-tpp-to-xsmm -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE

--- a/test/Integration/tpp-add.mlir
+++ b/test/Integration/tpp-add.mlir
@@ -1,20 +1,17 @@
 // RUN: tpp-opt %s -convert-linalg-to-tpp -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
-// RUN:  -e entry -entry-point-result=void  \
-// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%llvmlibdir/libmlir_runner_utils%shlibext | FileCheck %s -check-prefix=EXE
-//
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s -check-prefix=EXE
 
 // RUN: tpp-opt %s -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
-// RUN:  -e entry -entry-point-result=void  \
-// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%llvmlibdir/libmlir_runner_utils%shlibext | FileCheck %s -check-prefix=EXE
-//
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s -check-prefix=EXE
 
 // RUN: tpp-opt %s -convert-linalg-to-loops -convert-tpp-to-loops -convert-tpp-to-xsmm -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
-// RUN:  -e entry -entry-point-result=void  \
-// RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%llvmlibdir/libmlir_runner_utils%shlibext | FileCheck %s -check-prefix=EXE
-//
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s -check-prefix=EXE
 
 // RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck %s
 

--- a/test/Integration/tpp-add.mlir
+++ b/test/Integration/tpp-add.mlir
@@ -1,15 +1,13 @@
-// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" | \
+// RUN: tpp-run %s -tpp-to-loops -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s -check-prefix=EXE
+
+// RUN: tpp-opt %s -convert-linalg-to-loops | \
 // RUN: tpp-run -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE
 
-// RUN: tpp-opt %s -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -expand-strided-metadata -lower-affine -convert-arith-to-llvm -convert-vector-to-llvm -finalize-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: tpp-run -print \
-// RUN:  -e entry -entry-point-result=void | \
-// RUN: FileCheck %s -check-prefix=EXE
-
-// RUN: tpp-opt %s -default-tpp-passes | \
-// RUN: tpp-run -print \
+// RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE
 


### PR DESCRIPTION
Requiring all operands to have the same type is too restrictive, and we may lose mapping opportunities. For example, one operand can be a strided memref like `memref<56x32xf32, strided<[32, 1], offset: ?>>` while another, a non-strided one `memref<56x32xf32>`. The types of the memref are different, but we still want to allow both in `tpp.add`. Relax the operand check and now require each operand to have the same *shape* as we do not support broadcast yet.