### PR TITLE
Remove linalgx.pack from tpp bf16 tests

### DIFF
--- a/test/BF16/matmul-pbf16.mlir
+++ b/test/BF16/matmul-pbf16.mlir
@@ -17,11 +17,9 @@ func.func @entry() {
   %f0 = arith.constant 1.0 : bf16
   %da = memref.alloc() :memref<4x8xbf16>
   linalg.fill ins(%f0 : bf16) outs(%da : memref<4x8xbf16>)
-  %db = memref.alloc() :memref<8x4xbf16>
-  linalg.fill ins(%f0:bf16) outs (%db:memref<8x4xbf16>)
   // Call kernel.
   %0 = memref.alloc() : memref<4x4x2xbf16>
-  linalgx.pack %db inner_dims_pos = [0] inner_tiles = [2] into %0 : (memref<8x4xbf16> memref<4x4x2xbf16>)
+  linalg.fill ins(%f0:bf16) outs (%0: memref<4x4x2xbf16>)
   %D = memref.alloc() : memref<4x4xbf16>
   %zero = arith.constant 0.0 : bf16
   linalg.fill ins(%zero : bf16) outs(%D:memref<4x4xbf16>)

--- a/test/BF16/mlp-all-bf16-tpprun.mlir
+++ b/test/BF16/mlp-all-bf16-tpprun.mlir
@@ -2,44 +2,32 @@
 // RUN:  -e entry -entry-point-result=void
 //
 
-  memref.global "private" constant @arg1 : memref<256x512xbf16> = dense<1.00e+00> 
-  memref.global "private" constant @arg3 : memref<512x1024xbf16> = dense<1.00e+00>
-  memref.global "private" constant @arg5 : memref<1024x2048xbf16> = dense<1.00e+00>
-  memref.global "private" constant @arg7 : memref<2048x1000xbf16> = dense<1.00e+00>
+  memref.global "private" constant @arg1 : memref<128x512x2xbf16> = dense<1.00e+00> 
+  memref.global "private" constant @arg3 : memref<256x1024x2xbf16> = dense<1.00e+00>
+  memref.global "private" constant @arg5 : memref<512x2048x2xbf16> = dense<1.00e+00>
+  memref.global "private" constant @arg7 : memref<1024x1000x2xbf16> = dense<1.00e+00>
 
   func.func @entry(%arg0:memref<128x256xbf16>, %arg2:memref<512xbf16>, %arg4:memref<1024xbf16>, %arg6:memref<2048xbf16>, %arg8:memref<1000xbf16>, %arg9:memref<128x512xbf16>,  %arg10:memref<128x1024xbf16>, %arg11:memref<128x2048xbf16>, %arg12:memref<128x1000xbf16>) {
     tpp.identity ins(%arg2 : memref<512xbf16>) out(%arg9 : memref<128x512xbf16>)
-    %relayout_arg0 = memref.alloc():memref<128x512x2xbf16>
-    %0 = memref.get_global @arg1:memref<256x512xbf16>
-    linalgx.pack %0 inner_dims_pos = [0] inner_tiles = [2] into %relayout_arg0:(memref<256x512xbf16> memref<128x512x2xbf16>)
+    %relayout_arg0 = memref.get_global @arg1:memref<128x512x2xbf16>
     tpp.vnni_matmul ins(%arg0 : memref<128x256xbf16>, %relayout_arg0 : memref<128x512x2xbf16>) out(%arg9 : memref<128x512xbf16>)
     tpp.relu ins(%arg9 : memref<128x512xbf16>) out(%arg9 : memref<128x512xbf16>)
-    memref.dealloc %relayout_arg0:memref<128x512x2xbf16>
  
     tpp.identity ins(%arg4 : memref<1024xbf16>) out(%arg10 : memref<128x1024xbf16>)
-    %relayout_arg12 = memref.alloc():memref<256x1024x2xbf16>
-    %1 = memref.get_global @arg3:memref<512x1024xbf16>
-    linalgx.pack %1 inner_dims_pos = [0] inner_tiles = [2] into %relayout_arg12:(memref<512x1024xbf16> memref<256x1024x2xbf16>)
+    %relayout_arg12 = memref.get_global @arg3:memref<256x1024x2xbf16>
     tpp.vnni_matmul ins(%arg9 : memref<128x512xbf16>, %relayout_arg12 : memref<256x1024x2xbf16>) out(%arg10 : memref<128x1024xbf16>)
     tpp.relu ins(%arg10 : memref<128x1024xbf16>) out(%arg10 : memref<128x1024xbf16>)
-    memref.dealloc %relayout_arg12:memref<256x1024x2xbf16>
 
 
     tpp.identity ins(%arg6 : memref<2048xbf16>) out(%arg11 : memref<128x2048xbf16>)
-    %relayout_arg11 = memref.alloc():memref<512x2048x2xbf16>
-    %2 = memref.get_global @arg5:memref<1024x2048xbf16>
-    linalgx.pack %2 inner_dims_pos = [0] inner_tiles = [2] into %relayout_arg11:(memref<1024x2048xbf16> memref<512x2048x2xbf16>)
+    %relayout_arg11 = memref.get_global @arg5:memref<512x2048x2xbf16>
     tpp.vnni_matmul ins(%arg10 : memref<128x1024xbf16>, %relayout_arg11 : memref<512x2048x2xbf16>) out(%arg11 : memref<128x2048xbf16>)
     tpp.relu ins(%arg11 : memref<128x2048xbf16>) out(%arg11 : memref<128x2048xbf16>)
-    memref.dealloc %relayout_arg11:memref<512x2048x2xbf16>
 
     tpp.identity ins(%arg8 : memref<1000xbf16>) out(%arg12 : memref<128x1000xbf16>)
-    %relayout_arg10 = memref.alloc():memref<1024x1000x2xbf16>
-    %3 = memref.get_global @arg7:memref<2048x1000xbf16>
-    linalgx.pack %3 inner_dims_pos = [0] inner_tiles = [2] into %relayout_arg10:(memref<2048x1000xbf16> memref<1024x1000x2xbf16>)
+    %relayout_arg10 = memref.get_global @arg7:memref<1024x1000x2xbf16>
     tpp.vnni_matmul ins(%arg11 : memref<128x2048xbf16>, %relayout_arg10 : memref<1024x1000x2xbf16>) out(%arg12 : memref<128x1000xbf16>)
     tpp.relu ins(%arg12 : memref<128x1000xbf16>) out(%arg12 : memref<128x1000xbf16>)
-    memref.dealloc %relayout_arg10:memref<1024x1000x2xbf16>
 
     %threshold = arith.constant 1.0 : bf16
     %c4 = arith.constant 2.74878e+11: bf16

--- a/test/BF16/mlp-single-layer-bf16.mlir
+++ b/test/BF16/mlp-single-layer-bf16.mlir
@@ -8,15 +8,13 @@ func.func @entry(){
   %c0 = arith.constant 1.0:bf16
   %arg0 = memref.alloc():memref<128x256xbf16>
   linalg.fill ins(%c0:bf16) outs(%arg0:memref<128x256xbf16>)
-  %arg1 = memref.alloc():memref<256x512xbf16>
-  linalg.fill ins(%c0:bf16) outs(%arg1:memref<256x512xbf16>)
   %arg2 = memref.alloc():memref<512xbf16>
   linalg.fill ins(%c0:bf16) outs(%arg2:memref<512xbf16>)
   %arg3 = memref.alloc():memref<128x512xbf16>
   linalg.fill ins(%c0:bf16) outs(%arg3:memref<128x512xbf16>)
   tpp.identity ins(%arg2 : memref<512xbf16>) out(%arg3 : memref<128x512xbf16>)
   %wt = memref.alloc():memref<128x512x2xbf16>
-  linalgx.pack %arg1 inner_dims_pos=[0] inner_tiles=[2] into %wt: (memref<256x512xbf16> memref<128x512x2xbf16>)
+  linalg.fill ins(%c0:bf16) outs(%wt:memref<128x512x2xbf16>)
   tpp.vnni_matmul ins(%arg0 : memref<128x256xbf16>, %wt : memref<128x512x2xbf16>) out(%arg3 : memref<128x512xbf16>)
   tpp.relu ins(%arg3 : memref<128x512xbf16>) out(%arg3 : memref<128x512xbf16>)
   %result = memref.alloc():memref<128x512xbf16>

--- a/test/BF16/mlp-single-layer-blocked-bf16.mlir
+++ b/test/BF16/mlp-single-layer-blocked-bf16.mlir
@@ -6,28 +6,17 @@
 //
 
 func.func @entry(){
-  %arg0 = memref.alloc(): memref<128x256xbf16>
-  %arg1 = memref.alloc(): memref<256x512xbf16>
-  %arg2 = memref.alloc(): memref<512xbf16>
-  %arg3 = memref.alloc(): memref<128x512xbf16>
   %f0 = arith.constant 1.0:bf16
-  linalg.fill ins(%f0:bf16) outs(%arg0:memref<128x256xbf16>)
-  linalg.fill ins(%f0:bf16) outs(%arg1:memref<256x512xbf16>)
-  linalg.fill ins(%f0:bf16) outs(%arg2:memref<512xbf16>)
-  linalg.fill ins(%f0:bf16) outs(%arg3:memref<128x512xbf16>)
   %c4 = arith.constant 4 : index
   %c0 = arith.constant 0 : index
   %c16 = arith.constant 16 : index
   %c1 = arith.constant 1 : index
-  tpp.identity ins(%arg2 : memref<512xbf16>) out(%arg3 : memref<128x512xbf16>)
   %alloc = memref.alloc() {alignment = 128 : i64} : memref<32x64x4x4xbf16>
-  linalgx.pack %arg0 inner_dims_pos = [0, 1] inner_tiles = [4, 4] into %alloc : (memref<128x256xbf16> memref<32x64x4x4xbf16>)
-  %alloc_0 = memref.alloc() {alignment = 128 : i64} : memref<128x64x4x4xbf16>
-  linalgx.pack %arg1 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [4, 4] into %alloc_0 : (memref<256x512xbf16> memref<128x64x4x4xbf16>)
+  linalg.fill ins(%f0:bf16) outs(%alloc:memref<32x64x4x4xbf16>)
   %wt_alloc = memref.alloc() {alignment = 128 : i64} : memref<128x64x2x4x2xbf16>
-  linalgx.pack %alloc_0 inner_dims_pos = [2] inner_tiles = [2] into %wt_alloc : (memref<128x64x4x4xbf16> memref<128x64x2x4x2xbf16>)
+  linalg.fill ins(%f0:bf16) outs(%wt_alloc:memref<128x64x2x4x2xbf16>)
   %alloc_1 = memref.alloc() {alignment = 128 : i64} : memref<32x128x4x4xbf16>
-  linalgx.pack %arg3 inner_dims_pos = [0, 1] inner_tiles = [4, 4] into %alloc_1 : (memref<128x512xbf16> memref<32x128x4x4xbf16>)
+  linalg.fill ins(%f0:bf16) outs(%alloc_1:memref<32x128x4x4xbf16>)
   scf.for %arg4 = %c0 to %c4 step %c1 {
     %subview = memref.subview %alloc[%arg4, 0, 0, 0] [1, 64, 4, 4] [1, 1, 1, 1] : memref<32x64x4x4xbf16> to memref<64x4x4xbf16, strided<[16, 4, 1], offset: ?>>
     %subview_2 = memref.subview %alloc_1[%arg4, 0, 0, 0] [1, 128, 4, 4] [1, 1, 1, 1] : memref<32x128x4x4xbf16> to memref<128x4x4xbf16, strided<[16, 4, 1], offset: ?>>
@@ -46,14 +35,8 @@ func.func @entry(){
       vector.print %f1 : vector<4x4xf32>
     }
   }
-  linalgx.unpack %alloc_1 inner_dims_pos = [0, 1] inner_tiles = [4, 4] into %arg3 : (memref<32x128x4x4xbf16> memref<128x512xbf16>)
   memref.dealloc %alloc : memref<32x64x4x4xbf16>
   memref.dealloc %wt_alloc : memref<128x64x2x4x2xbf16>
-  memref.dealloc %alloc_0 : memref<128x64x4x4xbf16>
   memref.dealloc %alloc_1 : memref<32x128x4x4xbf16>
-  memref.dealloc %arg0 : memref<128x256xbf16>
-  memref.dealloc %arg1 : memref<256x512xbf16>
-  memref.dealloc %arg2 : memref<512xbf16>
-  memref.dealloc %arg3 : memref<128x512xbf16>
   return
 }

--- a/test/BF16/vnni-to-tpp-fail.mlir
+++ b/test/BF16/vnni-to-tpp-fail.mlir
@@ -1,22 +1,18 @@
 // RUN: tpp-opt --convert-vnni-to-tpp  %s | FileCheck %s
 
 //Unbufferized input that can't lower to tpp
-func.func @matmul_static(%arg0: tensor<256x512xbf16>, %arg1: tensor<512x1024xbf16>, %arg2: tensor<256x1024xbf16>) -> tensor<256x1024xbf16> {
-  %0 = tensor.empty() : tensor<256x1024x2xbf16>
-  %1 = tensor.pack %arg1 inner_dims_pos = [0] inner_tiles = [2] into %0 : tensor<512x1024xbf16> -> tensor<256x1024x2xbf16>
+func.func @matmul_static(%arg0: tensor<256x512xbf16>, %arg1: tensor<256x1024x2xbf16>, %arg2: tensor<256x1024xbf16>) -> tensor<256x1024xbf16> {
   // CHECK-NOT: tpp.vnni_matmul 
-  %2 = vnni.matmul ins(%arg0 : tensor<256x512xbf16>, %1 : tensor<256x1024x2xbf16>) out(%arg2 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+  %2 = vnni.matmul ins(%arg0 : tensor<256x512xbf16>, %arg1 : tensor<256x1024x2xbf16>) out(%arg2 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
   return %2 : tensor<256x1024xbf16>
 }
 
 // -----
 
 //Dynamic shapes that can't lower to tpp
-func.func @matmul_dynamic(%arg0: memref<?xbf16>, %arg1: memref<512x1024xbf16>, %arg2: memref<?xbf16>) -> memref<?xbf16> {
-  %0 = memref.alloc() : memref<256x1024x2xbf16>
-  linalgx.pack %arg1 inner_dims_pos = [0] inner_tiles = [2] into %0 : (memref<512x1024xbf16> memref<256x1024x2xbf16>) -> memref<256x1024x2xbf16>
+func.func @matmul_dynamic(%arg0: memref<?xbf16>, %arg1: memref<256x1024x2xbf16>, %arg2: memref<?xbf16>) -> memref<?xbf16> {
   // CHECK-NOT: tpp.vnni_matmul
-  vnni.matmul ins(%arg0 : memref<?xbf16>, %0 : memref<256x1024x2xbf16>) out(%arg2 : memref<?xbf16>)
+  vnni.matmul ins(%arg0 : memref<?xbf16>, %arg1 : memref<256x1024x2xbf16>) out(%arg2 : memref<?xbf16>)
   return %arg2 : memref<?xbf16>
 }
 
@@ -34,10 +30,8 @@ func.func @brgemm_static(%arg0: tensor<4x256x512xbf16>, %arg1: tensor<4x512x1024
 // -----
 
 //Dynamic shapes that can't lower to tpp
-func.func @brgemm_dynamic(%arg0: memref<?xbf16>, %arg1: memref<4x512x1024xbf16>, %arg2: memref<?xbf16>) -> memref<?xbf16> {
-  %0 = memref.alloc() : memref<4x256x1024x2xbf16>
-  linalgx.pack %arg1 inner_dims_pos = [1] inner_tiles = [2] into %0 : (memref<4x512x1024xbf16> memref<4x256x1024x2xbf16>) -> memref<4x256x1024x2xbf16>
+func.func @brgemm_dynamic(%arg0: memref<?xbf16>, %arg1: memref<4x256x1024x2xbf16>, %arg2: memref<?xbf16>) -> memref<?xbf16> {
   // CHECK-NOT: tpp.vnni_brgemm
-  vnni.brgemm ins(%arg0 : memref<?xbf16>, %0 : memref<4x256x1024x2xbf16>) out(%arg2 : memref<?xbf16>)
+  vnni.brgemm ins(%arg0 : memref<?xbf16>, %arg1 : memref<4x256x1024x2xbf16>) out(%arg2 : memref<?xbf16>)
   return %arg2 : memref<?xbf16>
 }


### PR DESCRIPTION
I am removing linalgx.pack from BF16 tests by changing the layout of buffers to packed layouts directly as tpp operates at memref level whereas tensor.pack is at tensor level.  I will introduce new tests to cover packing with vnni operations.