### PR TITLE
Default pipeline eliminate-empty-tensors pass

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -91,7 +91,8 @@ private:
     // Generalize tensor.pack and tensor.unpack.
     pm.addNestedPass<func::FuncOp>(createGeneralizeTensorPackAndUnPackPass());
 
-    // Materialize empty tensors
+    // Preprocess tensors
+    pm.addPass(bufferization::createEmptyTensorEliminationPass());
     pm.addPass(bufferization::createEmptyTensorToAllocTensorPass());
 
     // Run bufferization as the rest of the passes prefer working on memref.

--- a/lib/TPP/Dialect/VNNI/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/VNNI/BufferizableOpInterfaceImpl.cpp
@@ -33,11 +33,6 @@ struct MatmulLayoutInterface
     return opOperand.getOperandNumber() == 2;
   }
 
-  bool mustBufferizeInPlace(Operation *op, OpOperand &opOperand,
-                            const AnalysisState &state) const {
-    return true;
-  }
-
   SmallVector<OpResult> getAliasingOpResult(Operation *op, OpOperand &opOperand,
                                             const AnalysisState &state) const {
     if (opOperand.getOperandNumber() < 2)
@@ -90,11 +85,6 @@ struct BRGemmLayoutInterface
   bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
                                const AnalysisState &state) const {
     return opOperand.getOperandNumber() == 2;
-  }
-
-  bool mustBufferizeInPlace(Operation *op, OpOperand &opOperand,
-                            const AnalysisState &state) const {
-    return true;
   }
 
   SmallVector<OpResult> getAliasingOpResult(Operation *op, OpOperand &opOperand,


### PR DESCRIPTION
Adds `eliminate-empty-tensors` to the default pipeline.
Additionally, VNNI in-place bufferization requirement is relaxed as it crashes `eliminate-empty-tensors` but out-of-place bufferization should not affect correctness of VNNI ops.