### PR TITLE
Default pipeline raise-to-parallel-loop pass

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -91,7 +91,7 @@ private:
     // Generalize tensor.pack and tensor.unpack.
     pm.addNestedPass<func::FuncOp>(createGeneralizeTensorPackAndUnPackPass());
 
-    // Preprocess tensors
+    // Preprocess tensors.
     pm.addPass(bufferization::createEmptyTensorEliminationPass());
     pm.addPass(bufferization::createEmptyTensorToAllocTensorPass());
 
@@ -136,6 +136,7 @@ private:
     // This approach assumes that the function calls do not have any side
     // effects and can be safely moved outside of loop body.
     pm.addPass(createLoopInvariantCodeMotionPass());
+    pm.addPass(createRaiseToParallelLoopPass());
     pm.addPass(createParallelLoopFusionPass());
 
     // Lower all XSMM ops.

--- a/test/BF16/matmul-pbf16.mlir
+++ b/test/BF16/matmul-pbf16.mlir
@@ -5,6 +5,11 @@
 // RUN: FileCheck %s
 //
 
+// Validate default pipeline
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 func.func @matmultpp(%A: memref<4x8xbf16>,
           %B: memref<4x4x2xbf16>, %C: memref<4x4xbf16>) attributes {llvm.emit_c_interface} {
   tpp.vnni_matmul ins(%A: memref<4x8xbf16>, %B: memref<4x4x2xbf16>)

--- a/test/BF16/mlp-all.mlir
+++ b/test/BF16/mlp-all.mlir
@@ -9,6 +9,10 @@
 // 2*128x512 (131072) + 2*128x256x512 (33554432) + 2*128x1024 (262144) + 2*128x512x1024 (134217728) + 2*128x2048 (524288) + 2*128x1024x2048 (536870912) + 2*128x1000 (256000) + 2*128x2048x1000 (524288000) = 1230102376
 // BENCH_TOTAL_FLOPS: 1230102376
 
+// Validate default pipeline
+// RUN: tpp-opt %s -pack-matmul="block-factors=32,32,32" -pack-vnni | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void
  
 #map0 = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/BF16/mlp-single-layer-bf16.mlir
+++ b/test/BF16/mlp-single-layer-bf16.mlir
@@ -4,6 +4,10 @@
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext
 //
 
+// Validate default pipeline
+// RUN: tpp-run %s \
+// RUN:  -e entry -entry-point-result=void
+
 func.func @entry(){
   %c0 = arith.constant 1.0:bf16
   %arg0 = memref.alloc():memref<128x256xbf16>

--- a/test/BF16/mlp-single-layer-blocked-bf16.mlir
+++ b/test/BF16/mlp-single-layer-blocked-bf16.mlir
@@ -5,6 +5,11 @@
 // RUN: FileCheck %s
 //
 
+// Validate default pipeline
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 func.func @entry(){
   %f0 = arith.constant 1.0:bf16
   %c4 = arith.constant 4 : index

--- a/test/Dialect/Check/check-ops.mlir
+++ b/test/Dialect/Check/check-ops.mlir
@@ -4,6 +4,10 @@
 // RUN: -shared-libs=%llvmlibdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext
 //
 
+// Validate default pipeline
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void
+
 func.func @entry() {
  %a = arith.constant 1:i1
  check.expect_true(%a):i1

--- a/test/Integration/tpp-identity.mlir
+++ b/test/Integration/tpp-identity.mlir
@@ -8,7 +8,7 @@
 // RUN: tpp-opt %s -canonicalize -empty-tensor-to-alloc-tensor -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
 
 // Validate default pipeline
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s \
 // RUN:  -e entry -entry-point-result=void
 
 #map = affine_map<(d0, d1, d2, d3) -> (d3)>

--- a/test/Integration/tpp-relu-with-subviews.mlir
+++ b/test/Integration/tpp-relu-with-subviews.mlir
@@ -8,7 +8,7 @@
 // RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
 
 // Validate default pipeline
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s \
 // RUN:  -e entry -entry-point-result=void
 
 #map = affine_map<(d0) -> (d0)>

--- a/test/Passes/DefaultPipeline/linalg-memref.mlir
+++ b/test/Passes/DefaultPipeline/linalg-memref.mlir
@@ -13,7 +13,6 @@ func.func @matmul(%A: memref<4x8xf32>,
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   linalg.matmul ins(%A, %B : memref<4x8xf32>, memref<8x4xf32>) outs(%C : memref<4x4xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -33,7 +32,6 @@ func.func @brgemm(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
   linalg.batch_reduce_matmul ins(%arg0, %arg1: memref<3x5x4xf32>, memref<3x4x5xf32>)
                              outs(%arg2: memref<5x5xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -61,7 +59,6 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
       linalg.yield %9 : f32
   }
 
-  // CHECK: return
   return
 }
 
@@ -90,7 +87,6 @@ func.func @blocked_matmul_mapped(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x
     scf.yield
   }
 
-  // CHECK: return
   return
 }
 
@@ -115,7 +111,6 @@ func.func @relu_3d(%arg3: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
         linalg.yield %13 : f32
   }
 
-  // CHECK: return
   return %arg3 : memref<64x32x32xf32>
 }
 
@@ -136,7 +131,6 @@ func.func @relu_mapping_inplace(%arg0: memref<10x10xf32>) {
       linalg.yield %0 : f32
   }
 
-  // CHECK: return
   return
 }
 
@@ -158,7 +152,6 @@ func.func @relu_mapping(%arg0: memref<10x10xf32>, %arg1: memref<10x10xf32>) {
       linalg.yield %0 : f32
   }
 
-  // CHECK: return
   return
 }
 
@@ -176,7 +169,6 @@ func.func @relu_mapping_fail(%arg0: memref<10x10xf32>, %arg1: memref<10x10xf32>)
       linalg.yield %0 : f32
   }
 
-  // CHECK: return
   return
 }
 
@@ -198,7 +190,6 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
       linalg.yield %in : f32
   }
 
-  // CHECK: return
   return %alloc : memref<12x56x56x64xf32>
 }
 
@@ -218,7 +209,6 @@ func.func @add_mapping(%arg0: memref<1x10x10xf32>, %arg1: memref<1x10x10xf32>) {
       linalg.yield %0 : f32
   }
 
-  // CHECK: return
   return
 }
 
@@ -239,7 +229,6 @@ func.func @add_mapping_parallel(%arg0: memref<10x10x10xf32>, %arg1: memref<10x10
       linalg.yield %0 : f32
   }
 
-  // CHECK: return
   return
 }
 
@@ -324,7 +313,6 @@ module @predict_function  {
       linalg.yield %0 : f32
     }
 
-    // CHECK: return
     return
   }
 }

--- a/test/Passes/DefaultPipeline/linalg-tensor.mlir
+++ b/test/Passes/DefaultPipeline/linalg-tensor.mlir
@@ -13,7 +13,6 @@ func.func @matmul(%A: tensor<4x8xf32>,
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
 
-  // CHECK: return
   return %D : tensor<4x4xf32>
 }
 
@@ -41,7 +40,6 @@ func.func @blocked_matmul(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor<8x16x32x3
       linalg.yield %9 : f32
     } -> tensor<4x8x32x32xf32>
 
-  // CHECK: return
   return %1 :  tensor<4x8x32x32xf32>
 }
 
@@ -173,6 +171,5 @@ func.func @mlp(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
       linalg.yield %16 : f32
   } -> tensor<128x512xf32>
 
-  // CHECK: return
   return %3 : tensor<128x512xf32>
 }

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -40,7 +40,6 @@ module @predict_function  {
     %2 = xsmm.unary.dispatch relu [128, 512, 512, 512](broadcast none dataType f32)
     xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 
-    // CHECK: return
     return
   }
 }
@@ -67,7 +66,6 @@ func.func @buffer_dealloc(%A: memref<4x8xf32>,
   memref.copy %0, %C : memref<4x4xf32> to memref<4x4xf32>
 
   // CHECK: memref.dealloc %[[alloc]]
-  // CHECK: return
   return
 }
 
@@ -93,7 +91,6 @@ func.func @buffer_no_dealloc(%A: memref<4x8xf32>,
   memref.copy %0, %C : memref<4x4xf32> to memref<4x4xf32>
 
   // CHECK-NOT: memref.dealloc %[[alloc]]
-  // CHECK: return
   return %0 : memref<4x4xf32>
 }
 
@@ -112,6 +109,5 @@ func.func @raise_to_parallel(%lb: index, %ub: index, %step: index,
     memref.store %add, %src[%i] : memref<32xf32>
   } {parallel}
 
-  // CHECK: return
   return
 }

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -96,3 +96,22 @@ func.func @buffer_no_dealloc(%A: memref<4x8xf32>,
   // CHECK: return
   return %0 : memref<4x4xf32>
 }
+
+// -----
+
+// CHECK: func.func @raise_to_parallel(
+// CHECK-SAME:  %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index,
+// CHECK-SAME:  %[[SRC:.+]]: memref<32xf32>)
+func.func @raise_to_parallel(%lb: index, %ub: index, %step: index,
+          %src: memref<32xf32>) {
+  // CHECK-NOT: scf.for
+  // CHECK: scf.parallel
+  scf.for %i = %lb to %ub step %step {
+    %load = memref.load %src[%i] : memref<32xf32>
+    %add = arith.addf %load, %load : f32
+    memref.store %add, %src[%i] : memref<32xf32>
+  } {parallel}
+
+  // CHECK: return
+  return
+}

--- a/test/Passes/DefaultPipeline/tpp.mlir
+++ b/test/Passes/DefaultPipeline/tpp.mlir
@@ -10,7 +10,6 @@ func.func @add(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // CHECK: call @xsmm_binary_invoke({{.*}}%[[cast0]], %[[cast1]]
   tpp.add ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) out(%arg1: memref<3x3xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -30,7 +29,6 @@ func.func @add_mapping(%arg0: memref<1x10x10xf32>, %arg1: memref<1x10x10xf32>) {
   %subview_0 = memref.subview %arg1[0, 0, 0] [1, 10, 10] [1, 1, 1] : memref<1x10x10xf32> to memref<10x10xf32>
   tpp.add ins(%subview : memref<10x10xf32>, %subview_0 : memref<10x10xf32>) out(%subview_0 : memref<10x10xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -55,7 +53,6 @@ func.func @add_mapping_parallel(%arg0: memref<10x10x10xf32>, %arg1: memref<10x10
     scf.yield
   }
 
-  // CHECK: return
   return
 }
 
@@ -71,7 +68,6 @@ func.func @identity(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
   // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast1]]
   tpp.identity ins(%arg1: memref<1x1xf32>) out(%arg0: memref<3x3xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -97,7 +93,6 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
     scf.yield
   }
 
-  // CHECK: return
   return %alloc : memref<12x56x56x64xf32>
 }
 
@@ -111,7 +106,6 @@ func.func @relu(%arg0: memref<3x3xf32>) {
   // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]]
   tpp.relu ins(%arg0: memref<3x3xf32>) out(%arg0: memref<3x3xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -135,7 +129,6 @@ func.func @relu_3d(%arg0: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
     scf.yield
   }
 
-  // CHECK: return
   return %arg0 : memref<64x32x32xf32>
 }
 
@@ -153,7 +146,6 @@ func.func @brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: mem
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   tpp.brgemm ins(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>) out(%arg2: memref<3x3xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -172,7 +164,6 @@ func.func @brgemm_bf16(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   tpp.vnni_brgemm ins(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>) out(%arg2: memref<4x4xbf16>)
 
-  // CHECK: return
   return
 }
 
@@ -191,7 +182,6 @@ func.func @matmul(%A: memref<4x8xf32>,
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   tpp.matmul ins(%A : memref<4x8xf32>, %B : memref<8x4xf32>) out(%C : memref<4x4xf32>)
 
-  // CHECK: return
   return
 }
 
@@ -210,7 +200,6 @@ func.func @matmul_bf16(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>,
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   tpp.vnni_matmul ins(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>) out(%arg2: memref<6x6xbf16>)
 
-  // CHECK: return
   return
 }
 
@@ -239,7 +228,6 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
     scf.yield
   }
 
-  // CHECK: return
   return
 }
 
@@ -312,7 +300,6 @@ module @predict_function  {
     // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]], %[[cast0]]
     tpp.relu ins(%arg3 : memref<128x512xf32>) out(%arg3 : memref<128x512xf32>)
 
-    // CHECK: return
     return
   }
 }

--- a/test/Passes/DefaultPipeline/vnni.mlir
+++ b/test/Passes/DefaultPipeline/vnni.mlir
@@ -14,7 +14,6 @@ func.func @matmul_tensor(%arg0: tensor<128x1024xbf16>,
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   %vnni_result = vnni.matmul ins(%arg0: tensor<128x1024xbf16>, %arg1: tensor<512x2048x2xbf16>) out(%arg2: tensor<128x2048xbf16>) -> tensor<128x2048xbf16>
 
-  // CHECK: return
   return %vnni_result : tensor<128x2048xbf16>
 }
 
@@ -34,7 +33,6 @@ func.func @matmul_memref(%arg0: memref<128x1024xbf16>,
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   vnni.matmul ins(%arg0: memref<128x1024xbf16>, %arg1: memref<512x2048x2xbf16>) out(%arg2: memref<128x2048xbf16>)
 
-  // CHECK: return
   return %arg2 : memref<128x2048xbf16>
 }
 
@@ -57,7 +55,6 @@ func.func @matmul_memref_result(%arg0: memref<128x1024xbf16>,
   // CHECK: vnni.matmul
   %vnni_result = vnni.matmul ins(%arg0: memref<128x1024xbf16>, %arg1: memref<512x2048x2xbf16>) out(%arg2: memref<128x2048xbf16>) -> memref<128x2048xbf16>
 
-  // CHECK: return
   return %vnni_result : memref<128x2048xbf16>
 }
 
@@ -79,7 +76,6 @@ func.func @brgemm_static_tensor(%arg0: tensor<4x256x512xbf16>, %arg1: tensor<4x5
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   %2 = vnni.brgemm ins(%arg0 : tensor<4x256x512xbf16>, %1 : tensor<4x256x1024x2xbf16>) out(%arg2 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
 
-  // CHECK: return
   return %2 : tensor<256x1024xbf16>
 }
 
@@ -102,7 +98,6 @@ func.func @brgemm_static_memref(%arg0: memref<4x256x512xbf16>, %arg1: memref<4x5
   vnni.brgemm ins(%arg0 : memref<4x256x512xbf16>, %1 : memref<4x256x1024x2xbf16>) out(%arg2 : memref<256x1024xbf16>)
   memref.dealloc %1 : memref<4x256x1024x2xbf16>
 
-  // CHECK: return
   return %arg2 : memref<256x1024xbf16>
 }
 
@@ -127,6 +122,5 @@ func.func @brgemm_static_memref_result(%arg0: memref<4x256x512xbf16>, %arg1: mem
   // CHECK: vnni.brgemm
   %2 = vnni.brgemm ins(%arg0 : memref<4x256x512xbf16>, %1 : memref<4x256x1024x2xbf16>) out(%arg2 : memref<256x1024xbf16>) -> memref<256x1024xbf16>
 
-  // CHECK: return
   return %2 : memref<256x1024xbf16>
 }

--- a/test/Passes/DefaultPipeline/xsmm.mlir
+++ b/test/Passes/DefaultPipeline/xsmm.mlir
@@ -11,7 +11,6 @@ func.func @add(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   %0 = xsmm.binary.dispatch add [3, 3, 3, 3, 3](broadcast none dataType f32)
   xsmm.binary add(dataType f32, %0, %arg0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -32,7 +31,6 @@ func.func @add_mapping(%arg0: memref<1x10x10xf32>, %arg1: memref<1x10x10xf32>) {
     %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10](broadcast none dataType f32)
     xsmm.binary add(dataType f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32>, memref<10x10xf32>) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -58,7 +56,6 @@ func.func @add_mapping_parallel(%arg0: memref<10x10x10xf32>, %arg1: memref<10x10
     scf.yield
   }
 
-  // CHECK: return
   return
 }
 
@@ -75,7 +72,6 @@ func.func @identity(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
   %0 = xsmm.unary.dispatch identity [3, 3, 1, 3](broadcast scalar dataType f32)
   xsmm.unary identity(dataType f32, %0, %arg1, %arg0) : (i64, memref<1x1xf32>, memref<3x3xf32>) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -102,7 +98,6 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
     scf.yield
   }
 
-  // CHECK: return
   return %alloc : memref<12x56x56x64xf32>
 }
 
@@ -117,7 +112,6 @@ func.func @relu(%arg0: memref<3x3xf32>) {
   %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType f32)
   xsmm.unary relu(dataType f32, %0, %arg0) : (i64, memref<3x3xf32>) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -142,7 +136,6 @@ func.func @relu_3d(%arg0: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
     scf.yield
   }
 
-  // CHECK: return
   return %arg0 : memref<64x32x32xf32>
 }
 
@@ -162,7 +155,6 @@ func.func @brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: mem
   %0 = xsmm.ternary.dispatch brgemm [3, 3, 4, 4, 3, 3](dataType f32)
   xsmm.ternary brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -183,7 +175,6 @@ func.func @brgemm_bf16(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
   %0 = xsmm.ternary.dispatch brgemm [4, 4, 4, 4, 4, 4](dataType bf16)
   xsmm.ternary brgemm(dataType bf16, %0, %arg0, %arg1, %arg2, %c64_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -203,7 +194,6 @@ func.func @matmul(%A: memref<4x8xf32>,
   %0 = xsmm.ternary.dispatch matmul [4, 4, 8, 8, 4, 4](dataType f32)
   xsmm.ternary matmul(dataType f32, %0, %A, %B, %C) : (i64, memref<4x8xf32>, memref<8x4xf32>, memref<4x4xf32>) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -223,7 +213,6 @@ func.func @matmul_bf16(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>,
   %0 = xsmm.ternary.dispatch matmul [6, 6, 10, 10, 6, 6](dataType bf16)
   xsmm.ternary matmul(dataType bf16, %0, %arg0, %arg1, %arg2) : (i64, memref<6x10xbf16>, memref<5x6x2xbf16>, memref<6x6xbf16>) -> ()
 
-  // CHECK: return
   return
 }
 
@@ -254,7 +243,6 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
     scf.yield
   }
 
-  // CHECK: return
   return
 }
 
@@ -330,7 +318,6 @@ module @predict_function {
     %2 = xsmm.unary.dispatch relu [128, 512, 512, 512](broadcast none dataType f32)
     xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 
-    // CHECK: return
     return
   }
 }


### PR DESCRIPTION
Adds `raise-to-parallel-loop` to the default pipeline and a corresponding pass test.
Additionally, adds default pipeline test cases using `tpp-run` to more tests that already use `mlir-cpu-runner`.