### PR TITLE
Add pass to fold pack into splat tensor

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -90,6 +90,7 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createGeneralizeTensorPackAndUnPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createRaiseToParallelLoopPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPropagatePackUnPackPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConstantFoldPackPass();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -253,4 +253,12 @@ def PropagatePackUnPack : Pass<"propagate-pack-and-unpack", "func::FuncOp"> {
   let constructor = "mlir::tpp::createPropagatePackUnPackPass()"; 
 }
 
+def ConstantFoldPack : Pass<"constant-fold-pack", "ModuleOp"> {
+  let summary = "Constant fold tensor.pack";
+  let description = [{
+    Reduce pack overhead by folding tensor.pack into constants.
+  }];
+  let constructor = "mlir::tpp::createConstantFoldPackPass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_library(MLIRTPP
     DefaultTppPasses.cpp
     GeneralizeTensorPackAndUnPack.cpp
     RaiseToParallelLoop.cpp
+    ConstantFoldPack.cpp
 
   # Utils
     TransformUtils.cpp

--- a/lib/TPP/ConstantFoldPack.cpp
+++ b/lib/TPP/ConstantFoldPack.cpp
@@ -9,6 +9,7 @@
 #include "TPP/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Transform/IR/TransformUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -21,25 +22,47 @@ using namespace mlir;
 namespace {
 
 struct ConstantFoldPack : public ConstantFoldPackBase<ConstantFoldPack> {
+
+  void foldPackIntoCst(RewriterBase &rewriter, tensor::PackOp packOp) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    Value sourcePack = packOp.getSource();
+    auto cstOp = sourcePack.getDefiningOp<arith::ConstantOp>();
+    if (!cstOp)
+      return;
+    auto cst = cstOp.getValue();
+    if (!cst.isa<DenseElementsAttr>())
+      return;
+    auto oldDense = cast<DenseElementsAttr>(cst);
+    if (!oldDense.isSplat())
+      return;
+    auto newDense = oldDense.reshape(packOp.getDestType());
+
+    rewriter.setInsertionPoint(cstOp);
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(packOp, newDense);
+  }
+
+  void foldPackIntoCstWithFill(RewriterBase &rewriter, tensor::PackOp packOp) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    Value sourcePack = packOp.getSource();
+    auto fillOp = sourcePack.getDefiningOp<linalg::FillOp>();
+    if (!fillOp)
+      return;
+    auto cstOp = fillOp.getInputs()[0].getDefiningOp<arith::ConstantOp>();
+    if (!cstOp)
+      return;
+
+    rewriter.setInsertionPoint(fillOp);
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+        packOp, DenseElementsAttr::get(packOp.getDestType(), cstOp.getValue()));
+  }
+
   void runOnOperation() override {
     auto module = getOperation();
     transform::TrivialPatternRewriter rewriter(&getContext());
+    module->walk(
+        [&](tensor::PackOp packOp) { foldPackIntoCst(rewriter, packOp); });
     module->walk([&](tensor::PackOp packOp) {
-      Value sourcePack = packOp.getSource();
-      auto cstOp = sourcePack.getDefiningOp<arith::ConstantOp>();
-      if (!cstOp)
-        return;
-      auto cst = cstOp.getValue();
-      if (!cst.isa<DenseElementsAttr>())
-        return;
-      auto oldDense = cast<DenseElementsAttr>(cst);
-      if (!oldDense.isSplat())
-        return;
-      auto newDense = oldDense.reshape(packOp.getDestType());
-      rewriter.setInsertionPoint(cstOp);
-      auto newCstOp =
-          rewriter.create<arith::ConstantOp>(cstOp.getLoc(), newDense);
-      rewriter.replaceOp(packOp, newCstOp.getResult());
+      foldPackIntoCstWithFill(rewriter, packOp);
     });
   }
 };

--- a/lib/TPP/ConstantFoldPack.cpp
+++ b/lib/TPP/ConstantFoldPack.cpp
@@ -1,0 +1,51 @@
+//===- ConstantFoldPack.cpp --------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Transform/IR/TransformUtils.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+struct ConstantFoldPack : public ConstantFoldPackBase<ConstantFoldPack> {
+  void runOnOperation() override {
+    auto module = getOperation();
+    transform::TrivialPatternRewriter rewriter(&getContext());
+    module->walk([&](tensor::PackOp packOp) {
+      Value sourcePack = packOp.getSource();
+      auto cstOp = sourcePack.getDefiningOp<arith::ConstantOp>();
+      if (!cstOp)
+        return;
+      auto cst = cstOp.getValue();
+      if (!cst.isa<DenseElementsAttr>())
+        return;
+      auto oldDense = cast<DenseElementsAttr>(cst);
+      if (!oldDense.isSplat())
+        return;
+      auto newDense = oldDense.reshape(packOp.getDestType());
+      rewriter.setInsertionPoint(cstOp);
+      auto newCstOp =
+          rewriter.create<arith::ConstantOp>(cstOp.getLoc(), newDense);
+      rewriter.replaceOp(packOp, newCstOp.getResult());
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> mlir::tpp::createConstantFoldPackPass() {
+  return std::make_unique<ConstantFoldPack>();
+}

--- a/test/Passes/fold-pack-and-constant.mlir
+++ b/test/Passes/fold-pack-and-constant.mlir
@@ -1,0 +1,27 @@
+// RUN: tpp-opt %s -constant-fold-pack -canonicalize -cse -split-input-file | FileCheck %s
+
+func.func @main() ->  tensor<8x2x1x1x32x32xi64> {
+  %cst = arith.constant dense<1> : tensor<1x1x64x256xi64>
+  %0 = tensor.empty() : tensor<8x2x1x1x32x32xi64>
+  %pack = tensor.pack %cst outer_dims_perm = [3, 2, 0, 1] inner_dims_pos = [2, 3] inner_tiles = [32, 32] into %0 : tensor<1x1x64x256xi64> -> tensor<8x2x1x1x32x32xi64>
+  return  %pack : tensor<8x2x1x1x32x32xi64>
+}
+
+// CHECK: func.func @main(
+// CHECK: %[[CST:.+]] = arith.constant dense<1> : tensor<8x2x1x1x32x32xi64>
+// CHECK-NEXT: return %[[CST]] : tensor<8x2x1x1x32x32xi64>
+
+// -----
+
+func.func @main() -> tensor<1x8x56x56x32xi64> {
+  %c0_i64 = arith.constant 0 : i64
+  %0 = tensor.empty() : tensor<1x56x56x256xi64>
+  %1 = linalg.fill ins(%c0_i64 : i64) outs(%0 : tensor<1x56x56x256xi64>) -> tensor<1x56x56x256xi64>
+  %2 = tensor.empty() : tensor<1x8x56x56x32xi64>
+  %3 = tensor.pack %1 outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %2 : tensor<1x56x56x256xi64> -> tensor<1x8x56x56x32xi64>
+  return %3 : tensor<1x8x56x56x32xi64>
+}
+
+// CHECK: func.func @main(
+// CHECK: %[[CST:.+]] = arith.constant dense<0> : tensor<1x8x56x56x32xi64>
+// CHECK-NEXT: return %[[CST]] : tensor<1x8x56x56x32xi64>

--- a/test/Passes/fold-pack-into-constant-weight.mlir
+++ b/test/Passes/fold-pack-into-constant-weight.mlir
@@ -1,0 +1,12 @@
+// RUN: tpp-opt %s -constant-fold-pack -canonicalize | FileCheck %s
+
+func.func @main() ->  tensor<8x2x1x1x32x32xi64> {
+  %cst = arith.constant dense<1> : tensor<1x1x64x256xi64>
+  %0 = tensor.empty() : tensor<8x2x1x1x32x32xi64>
+  %pack = tensor.pack %cst outer_dims_perm = [3, 2, 0, 1] inner_dims_pos = [2, 3] inner_tiles = [32, 32] into %0 : tensor<1x1x64x256xi64> -> tensor<8x2x1x1x32x32xi64>
+  return  %pack : tensor<8x2x1x1x32x32xi64>
+}
+
+// CHECK: func.func @main(
+// CHECK: %[[CST:.+]] = arith.constant dense<1> : tensor<8x2x1x1x32x32xi64>
+// CHECK-NEXT: return %[[CST]] : tensor<8x2x1x1x32x32xi64>


### PR DESCRIPTION
Packing a constant-tensor can be avoided by rewriting the constant. Currently support only splat tensor.