### PR TITLE
Introduce an interchange pass to expose matmul in blocked convolutions

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -90,6 +90,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createGeneralizeTensorPackAndUnPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createRaiseToParallelLoopPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPropagatePackUnPackPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createInterchangeBlockConvToExposeMatmulPass();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -253,4 +253,14 @@ def PropagatePackUnPack : Pass<"propagate-pack-and-unpack", "func::FuncOp"> {
   let constructor = "mlir::tpp::createPropagatePackUnPackPass()"; 
 }
 
+def InterchangeBlockConvToExposeMatmul : 
+  Pass<"interchange-conv-to-expose-matmul", "func::FuncOp"> {
+  let summary = "Interchange a blocked convolution to expose a matmul op.";
+  let constructor = "mlir::tpp::createInterchangeBlockConvToExposeMatmulPass()";
+  let description = [{
+    The interchange exposes as innermost loops a [reduction, parallel, parallel, 
+    reduction] that can map to BRGEMM or Matmul.
+  }];
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_library(MLIRTPP
     DefaultTppPasses.cpp
     GeneralizeTensorPackAndUnPack.cpp
     RaiseToParallelLoop.cpp
+    InterchangeBlockConvToExposeMatmul.cpp
 
   # Utils
     TransformUtils.cpp

--- a/lib/TPP/InterchangeBlockConvToExposeMatmul.cpp
+++ b/lib/TPP/InterchangeBlockConvToExposeMatmul.cpp
@@ -1,0 +1,84 @@
+//===- InterchangeBlockConvToExposeMatmul.cpp --------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+#include "TPP/TransformUtils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+// Interchange a blocked convolutions to expose a linalg.matmul.
+struct InterchangeBlockConvToExposeMatmulImpl
+    : OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
+                                PatternRewriter &rewriter) const override {
+    if (!linalgx::utils::isBlockedConvolution(genericOp))
+      return failure();
+
+    // clang-format off
+    // N                [parallel]
+    //  K               [parallel - blocked]
+    //    P             [parallel]
+    //      Q           [parallel]
+    //        k         [parallel - block of K]
+    //          C       [reduction - blocked]
+    //            R     [reduction]
+    //              S   [reduction]
+    //                c [reduction - block of C]
+
+    // expose matmul by interchange
+
+    // N                [parallel]
+    //  K               [parallel - blocked]
+    //    P             [parallel]
+    //      C           [reduction - blocked]
+    //        R         [reduction]
+    //          S       [reduction]
+    //            Q     [parallel]
+    //              k   [parallel - block of K]
+    //                c [reduction - block of C]
+    //
+    // Matmul: m = %Q, n = %k and k = %c
+    // clang-format on
+
+    SmallVector<unsigned> interchangeVector = {0, 1, 2, 5, 6, 7, 3, 4, 8};
+    FailureOr<linalg::GenericOp> maybeInterchange =
+        interchangeGenericOp(rewriter, genericOp, interchangeVector);
+    if (failed(maybeInterchange))
+      return failure();
+    return success();
+  }
+};
+
+struct InterchangeBlockConvToExposeMatmul
+    : public InterchangeBlockConvToExposeMatmulBase<
+          InterchangeBlockConvToExposeMatmul> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(getOperation().getContext());
+    patterns.add<InterchangeBlockConvToExposeMatmulImpl>(patterns.getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    return;
+  }
+};
+
+} // end namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createInterchangeBlockConvToExposeMatmulPass() {
+  return std::make_unique<InterchangeBlockConvToExposeMatmul>();
+}

--- a/test/Passes/pass-interchange-blck-conv.mlir
+++ b/test/Passes/pass-interchange-blck-conv.mlir
@@ -1,0 +1,105 @@
+// RUN: tpp-opt %s -interchange-conv-to-expose-matmul -split-input-file | FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d5, d2 + d6, d3 + d7, d8)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d8, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
+
+func.func @blck_conv(%arg0: tensor<1x2x56x56x32xi64>, %arg1: tensor<2x2x1x1x32x32xi64>, 
+                     %arg2: tensor<1x2x56x56x32xi64>) -> tensor<1x2x56x56x32xi64> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction", "reduction"]} 
+    ins(%arg0, %arg1 : tensor<1x2x56x56x32xi64>, tensor<2x2x1x1x32x32xi64>) outs(%arg2 : tensor<1x2x56x56x32xi64>) {
+    ^bb0(%in: i64, %in_51: i64, %out: i64):
+      %151 = arith.muli %in, %in_51 : i64
+      %152 = arith.addi %out, %151 : i64
+      linalg.yield %152 : i64
+  } -> tensor<1x2x56x56x32xi64>
+  return %0 : tensor<1x2x56x56x32xi64>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d3, d2 + d4, d6 + d5, d8)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d3, d4, d5, d8, d7)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d6, d7)>
+// CHECK: func.func @blck_conv(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<1x2x56x56x32xi64>, %[[ARG1:.+]]: tensor<2x2x1x1x32x32xi64>,
+// CHECK-SAME:  %[[ARG2:.+]]: tensor<1x2x56x56x32xi64>)
+// CHECK: %{{.+}} = linalg.generic
+// CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "reduction", 
+// CHECK-SAME:                    "reduction", "reduction", "parallel", "parallel", "reduction"]
+// CHECK-SAME:  ins(%[[ARG0]], %[[ARG1]]
+// CHECK-SAME:  outs(%[[ARG2]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d5, d2 + d6, d3 + d7, d8)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d8, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
+
+func.func @blck_conv(%arg0: tensor<1x2x56x56x32xi64>, %arg1: tensor<2x2x1x1x32x32xi64>,
+                     %arg2: tensor<1x2x56x56x32xi64>) -> tensor<1x2x56x56x32xi64> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction", "reduction"]} 
+    ins(%arg0, %arg1 : tensor<1x2x56x56x32xi64>, tensor<2x2x1x1x32x32xi64>) outs(%arg2 : tensor<1x2x56x56x32xi64>) {
+    ^bb0(%in: i64, %in_51: i64, %out: i64):
+      %151 = arith.muli %in, %in_51 : i64
+      %152 = arith.subi %out, %151 : i64
+      linalg.yield %152 : i64
+  } -> tensor<1x2x56x56x32xi64>
+  return %0 : tensor<1x2x56x56x32xi64>
+}
+
+// Not a conv.
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d5, d2 + d6, d3 + d7, d8)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d8, d4)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
+// CHECK: func.func @blck_conv(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<1x2x56x56x32xi64>, %[[ARG1:.+]]: tensor<2x2x1x1x32x32xi64>,
+// CHECK-SAME:  %[[ARG2:.+]]: tensor<1x2x56x56x32xi64>)
+// CHECK: %{{.+}} = linalg.generic
+// CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel", 
+// CHECK-SAME:                    "parallel", "reduction", "reduction", "reduction", "reduction"]
+// CHECK-SAME:  ins(%[[ARG0]], %[[ARG1]]
+// CHECK-SAME:  outs(%[[ARG2]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d1, d2, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+
+func.func @blck_conv(%arg0: tensor<1x2x56x56x32xi64>, %arg1: tensor<2x2x1x1x32x32xi64>, %arg2: tensor<1x2x56x56x32xi64>) -> tensor<1x2x56x56x32xi64> {
+  %collapsed = tensor.collapse_shape %arg0 [[0, 1], [2], [3], [4]] : tensor<1x2x56x56x32xi64> into tensor<2x56x56x32xi64>
+  %collapsed_0 = tensor.collapse_shape %arg1 [[0], [1, 2, 3], [4], [5]] : tensor<2x2x1x1x32x32xi64> into tensor<2x2x32x32xi64>
+  %collapsed_1 = tensor.collapse_shape %arg2 [[0, 1], [2], [3], [4]] : tensor<1x2x56x56x32xi64> into tensor<2x56x56x32xi64>
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%collapsed, %collapsed_0 : tensor<2x56x56x32xi64>, tensor<2x2x32x32xi64>) outs(%collapsed_1 : tensor<2x56x56x32xi64>) {
+    ^bb0(%in: i64, %in_2: i64, %out: i64):
+      %1 = arith.muli %in, %in_2 : i64
+      %2 = arith.subi %out, %1 : i64
+      linalg.yield %2 : i64
+  } -> tensor<2x56x56x32xi64>
+  %expanded = tensor.expand_shape %0 [[0, 1], [2], [3], [4]] : tensor<2x56x56x32xi64> into tensor<1x2x56x56x32xi64>
+  return %expanded : tensor<1x2x56x56x32xi64>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d1, d2, d5)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5, d3)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+// CHECK: func.func @blck_conv(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<1x2x56x56x32xi64>,
+// CHECK-SAME:  %[[ARG1:.+]]: tensor<2x2x1x1x32x32xi64>,
+// CHECK-SAME:  %[[ARG2:.+]]: tensor<1x2x56x56x32xi64>)
+// CHECK: %[[CLPS:.+]] = tensor.collapse_shape %[[ARG0]] {{\[}}[0, 1], [2], [3], [4]] 
+// CHECK-SAME:  : tensor<1x2x56x56x32xi64> into tensor<2x56x56x32xi64>
+// CHECK: %[[CLPS0:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2, 3], [4], [5]] 
+// CHECK-SAME:  : tensor<2x2x1x1x32x32xi64> into tensor<2x2x32x32xi64>
+// CHECK: %[[CLPS1:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0, 1], [2], [3], [4]] 
+// CHECK-SAME:  : tensor<1x2x56x56x32xi64> into tensor<2x56x56x32xi64>
+// CHECK: %{{.+}} = linalg.generic
+// CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK-SAME:  ins(%[[CLPS]], %[[CLPS0]]
+// CHECK-SAME:  outs(%[[CLPS1]]


### PR DESCRIPTION
Introduce a specific pass to interchange loops to expose a matmul as the innermost operation. Introducing this pass is *ugly* as we cannot have such a specific pass in our pipeline. We should reevaluate the transform dialect.