### PR TITLE
Random fill of inputs in `tpp-run`

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -85,7 +85,7 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createTileConsumerAndFuseProducersPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteConvToMatmulOrBrgemmPass();
-std::unique_ptr<OperationPass<ModuleOp>> createDefaultTppPass();
+std::unique_ptr<OperationPass<ModuleOp>> createDefaultTppPass(bool loops=false);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGeneralizeTensorPackAndUnPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createRaiseToParallelLoopPass();

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -146,6 +146,6 @@ private:
 
 } // namespace
 
-std::unique_ptr<OperationPass<ModuleOp>> mlir::tpp::createDefaultTppPass() {
-  return std::make_unique<DefaultTppPasses>();
+std::unique_ptr<OperationPass<ModuleOp>> mlir::tpp::createDefaultTppPass(bool loops) {
+  return std::make_unique<DefaultTppPasses>(loops);
 }

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -57,14 +58,26 @@ class MLIRBench {
   /// Global variables for all arguments (in order)
   llvm::SmallVector<llvm::StringRef> globals;
 
+  /// Seed for the random tensor filling
+  int seed;
+
+  /// Lower TPP to loops for validation purposes
+  bool tppToLoops;
+
   /// Create a random global based on the memref type
   llvm::StringRef createGlobal(MemRefType);
 
   /// Get a global memref by name
   MemRefType getGlobalType(llvm::StringRef);
 
-  // Create a random constant dense tensor
-  Value createConstTensor(TensorType);
+  // Create a local dense tensor
+  Value createDenseTensor(TensorType);
+
+  // Create a constant dense attribute
+  DenseElementsAttr getDenseAttribute(ShapedType);
+
+  // Return a ConstantOp of a certain type with a certain initializer
+  template <class ValueT> arith::ConstantOp getConstant(Type, ValueT);
 
   /// Gets module's main block
   Block &getModuleBlock();
@@ -74,7 +87,7 @@ class MLIRBench {
 
 public:
   /// Creates context, builder
-  MLIRBench(Operation *op);
+  MLIRBench(Operation *op, int seed, bool tppToLoops);
 
   /// Finds the kernel method, checks correct name and shape
   LogicalResult findKernel(llvm::StringRef);

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -62,7 +62,7 @@ llvm::cl::opt<bool> tppToLoops("tpp-to-loops",
 
 // Random seed, if zero, don't emit randominputs
 llvm::cl::opt<int>
-    seed("seed", llvm::cl::desc("Random seed, defualt 0 (no random)"),
+    seed("seed", llvm::cl::desc("Random seed, default 0 (no random)"),
                   llvm::cl::value_desc("int"), llvm::cl::init(0));
 
 // This function will be called by the pass manager after parsing,


### PR DESCRIPTION
This change allows passing a `-seed` to `tpp-run` command line that will randomly initialize the input tensors to allow for better testing. We're using the `linalg.fill_rng_2d` op with values between 0 and 1 to help with floating point accuracy.

Also changed:
 * Added a new option `-tpp-to-loops` that lowers TPP ops to loops. Used to compare results from the same `-seed` between loops and XSMM.
 * Common up constant and dense generation to simplify generic code.

Works towards #229.

This is just the initial part because:
 * Lowering to loops accumulates in a different order and there are small differences (10^-4) between XSMM and loops, which makes it hard to just verify with CHECKs.
 * We can't select loops or xsmm for individual functions, so to use `check.check_almost_equals` we'd have to run tests with constant seeds and save the expected result as a constant dense of the output shape with a close result.

This change at least helps us run the tool with some random input for manual testing, and later find a better strategy for the testing side.