### PR TITLE
Forward output of `linalg.fill` to `tensor.unpack`

### DIFF
--- a/test/Passes/pack-unpack-propagation.mlir
+++ b/test/Passes/pack-unpack-propagation.mlir
@@ -381,7 +381,7 @@ func.func @fill(%arg0: f32, %arg1: tensor<1x56x56x64xf32>, %arg2: tensor<1x1x64x
       %7 = arith.addf %out, %6 : f32
       linalg.yield %7 : f32
   } -> tensor<1x2x56x56x32xf32>
-  %unpack = tensor.unpack %5 outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %1 : tensor<1x2x56x56x32xf32> -> tensor<1x56x56x64xf32>
+  %unpack = tensor.unpack %5 outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %0 : tensor<1x2x56x56x32xf32> -> tensor<1x56x56x64xf32>
   return %unpack : tensor<1x56x56x64xf32>
 }
 


### PR DESCRIPTION
Let's consider the following IR:

```
%e = tensor.empty() : tensor<2x2xf32>
%0 = linalg.fill ins(%cst : f32) outs(%e : tensor<2x2xf32>)
%1 = linalg.matmul ins( ... ) outs(%0 : tensor<2x2xf32>)
```

When blocking the matmul a `tensor.unpack` is inserted right after the blocked matmul. The `tensor.unpack` will unpack the output of the matmul to the orginal un-blocked output (%0) in this case. This is fine becuase %0 will alias %e after bufferization but the IR looks better and some canonicalization patterns are simplified if we unpack directly in %e.