### PR TITLE
Align transform ops to underneath method names (NFC)

### DIFF
--- a/include/TPP/Dialect/Transform/LinalgXTransformOps.td
+++ b/include/TPP/Dialect/Transform/LinalgXTransformOps.td
@@ -80,10 +80,10 @@ def CollapseOp : Op<Transform_Dialect, "structured.collapse", [
 }
 
 //===----------------------------------------------------------------------===//
-// MapToBrgemmOp
+// RewriteToBrgemmOp
 //===----------------------------------------------------------------------===//
 
-def MapToBrgemmOp : Op<Transform_Dialect, "structured.map_to_brgemm", [
+def RewriteToBrgemmOp : Op<Transform_Dialect, "structured.rewrite_to_brgemm", [
     FunctionalStyleTransformOpTrait,
     MemoryEffectsOpInterface,
     TransformOpInterface,
@@ -111,10 +111,11 @@ def MapToBrgemmOp : Op<Transform_Dialect, "structured.map_to_brgemm", [
 }
 
 //===----------------------------------------------------------------------===//
-// MapConvToMatmulOp
+// RewriteConvToMatmulOp
 //===----------------------------------------------------------------------===//
 
-def MapConvToMatmulOp : Op<Transform_Dialect, "structured.map_conv_to_matmul", [
+def RewriteConvToMatmulOp : Op<Transform_Dialect, 
+    "structured.rewrite_conv_to_matmul", [
     FunctionalStyleTransformOpTrait,
     MemoryEffectsOpInterface,
     TransformOpInterface,

--- a/lib/TPP/Dialect/Transform/LinalgXTransformOps.cpp
+++ b/lib/TPP/Dialect/Transform/LinalgXTransformOps.cpp
@@ -102,13 +102,13 @@ transform::CollapseOp::getReassociationIndices() {
 }
 
 //===----------------------------------------------------------------------===//
-// MapToBrgemmOp
+// RewriteToBrgemmOp
 //===----------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure
-transform::MapToBrgemmOp::applyToOne(linalg::LinalgOp target,
-                                     ApplyToEachResultList &results,
-                                     transform::TransformState &state) {
+transform::RewriteToBrgemmOp::applyToOne(linalg::LinalgOp target,
+                                         ApplyToEachResultList &results,
+                                         transform::TransformState &state) {
   if (!llvm::isa_and_nonnull<linalg::GenericOp>(target))
     return DiagnosedSilenceableFailure::success();
   TrivialPatternRewriter rewriter(target->getContext());
@@ -119,13 +119,13 @@ transform::MapToBrgemmOp::applyToOne(linalg::LinalgOp target,
 }
 
 //===----------------------------------------------------------------------===//
-// MapConvToMatmulOp
+// RewriteConvToMatmulOp
 //===----------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure
-transform::MapConvToMatmulOp::applyToOne(linalg::LinalgOp target,
-                                         ApplyToEachResultList &results,
-                                         transform::TransformState &state) {
+transform::RewriteConvToMatmulOp::applyToOne(linalg::LinalgOp target,
+                                             ApplyToEachResultList &results,
+                                             transform::TransformState &state) {
   if (!llvm::isa_and_nonnull<linalg::GenericOp>(target))
     return DiagnosedSilenceableFailure::definiteFailure();
   TrivialPatternRewriter rewriter(target->getContext());

--- a/lib/TPP/RewriteToBatchReduceGEMM.cpp
+++ b/lib/TPP/RewriteToBatchReduceGEMM.cpp
@@ -26,7 +26,7 @@ using namespace mlir;
 #define GEN_PASS_CLASSES
 #include "TPP/Passes.h.inc"
 
-#define DEBUG_TYPE "mlir-map-to-brgemm"
+#define DEBUG_TYPE "mlir-rewrite-to-brgemm"
 
 // Look for [p ... p] brgemm [r p p r r]
 static LogicalResult checkVNNIStructure(linalg::LinalgOp linalgOp) {

--- a/test/Dialect/Transform/transform-convolutions.mlir
+++ b/test/Dialect/Transform/transform-convolutions.mlir
@@ -30,7 +30,7 @@ transform.sequence failures(propagate) {
     // You can now see the matmul: image[*][*][W][C] * filter[*][*][C][K]
     //
     %2 = transform.structured.interchange %1 iterator_interchange = [ 0, 1, 4, 5, 2, 3, 6 ] 
-    transform.structured.map_conv_to_matmul %2
+    transform.structured.rewrite_conv_to_matmul %2
 }
 
 func.func @conv1(%arg0: memref<1x4x4x3xf32>, %arg1: memref<1x1x3x8xf32>, %arg2: memref<1x4x4x8xf32>) {
@@ -60,7 +60,7 @@ transform.sequence failures(propagate) {
     %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1 : (!pdl.operation) -> !pdl.operation
     %1 = transform.structured.generalize %0
     %2 = transform.structured.interchange %1 iterator_interchange = [ 0, 1, 4, 5, 2, 3, 6 ] 
-    transform.structured.map_conv_to_matmul %2
+    transform.structured.rewrite_conv_to_matmul %2
 }
 
 func.func @conv2(%arg0: memref<1x4x4x3xf32>, %arg1: memref<2x2x3x8xf32>, %arg2: memref<1x3x3x8xf32>) {
@@ -94,7 +94,7 @@ transform.sequence failures(propagate) {
     %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1 : (!pdl.operation) -> !pdl.operation
     %1 = transform.structured.generalize %0
     %2 = transform.structured.interchange %1 iterator_interchange = [ 0, 1, 4, 5, 2, 3, 6 ] 
-    transform.structured.map_conv_to_matmul %2
+    transform.structured.rewrite_conv_to_matmul %2
 }
 
 func.func @conv3(%arg0: memref<?x?x?x?xf32>, %arg1: memref<1x1x?x?xf32>, %arg2: memref<?x?x?x?xf32>) {
@@ -155,7 +155,7 @@ transform.sequence failures(propagate) {
     //        output[N][K'][P + Q][k] += image[N][C'][H + W][c] * filter[K'][C'][c][k]
     //
     %4 = transform.structured.interchange %3 iterator_interchange = [0, 1, 4, 2, 3, 5] 
-    transform.structured.map_to_brgemm %4
+    transform.structured.rewrite_to_brgemm %4
 }
 
 func.func @conv(%i: tensor<14x512x28x28xf32>, %f: tensor<1024x512x1x1xf32>,
@@ -290,14 +290,14 @@ transform.sequence failures(propagate) {
     // Map the conv to linalg.matmul
     // With R = S = 3 we map to linalg.matmul
     %conv1 = transform.structured.interchange %convs#1 iterator_interchange = [0, 1, 2, 5, 6, 7, 3, 4, 8] 
-    transform.structured.map_conv_to_matmul %conv1
+    transform.structured.rewrite_conv_to_matmul %conv1
 
     // Map the conv to linalg.batch_reduce_matmul
     // With R = S = 1 we map to linalg.batch_reduce_matmul
     %7 = transform.structured.collapse %convs#0 [[0], [1], [2], [3], [4], [5, 6, 7], [8]]
     %8 = transform.structured.collapse %7 [[0], [1], [2, 3], [4], [5], [6]]
     %9 = transform.structured.interchange %8 iterator_interchange = [0, 1, 4, 2, 3, 5] 
-    transform.structured.map_to_brgemm %9
+    transform.structured.rewrite_to_brgemm %9
 }
 
 // -----
@@ -307,7 +307,7 @@ transform.sequence failures(propagate) {
     %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1 : (!pdl.operation) -> !pdl.operation
     %1 = transform.structured.generalize %0
     %2 = transform.structured.interchange %1 iterator_interchange = [0, 1, 4, 5, 2, 3, 6]
-    transform.structured.map_conv_to_matmul %2
+    transform.structured.rewrite_conv_to_matmul %2
 }
 
 func.func @conv2d_stride(%arg0: tensor<1x113x113x64xf32>, %arg1: tensor<3x3x64x256xf32>, %arg2: tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32> {
@@ -344,7 +344,7 @@ transform.sequence failures(propagate) {
     %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1 : (!pdl.operation) -> !pdl.operation
     %1 = transform.structured.pack_ext %0 blocking_factors = [32, 32]
     %2 = transform.structured.interchange %1 iterator_interchange = [0, 1, 2, 5, 6, 7, 3, 4, 8] 
-    transform.structured.map_conv_to_matmul %2
+    transform.structured.rewrite_conv_to_matmul %2
 }
 
 func.func @conv2d_stride(%arg0: tensor<1x113x113x64xf32>, %arg1: tensor<3x3x64x256xf32>, %arg2: tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32> {

--- a/test/Dialect/Transform/transform-matmuls.mlir
+++ b/test/Dialect/Transform/transform-matmuls.mlir
@@ -109,7 +109,7 @@ transform.sequence failures(propagate) {
     // Get the producer for the relu (aka the packed matmul)
     %6 = get_producer_of_operand %5[0] : (!pdl.operation) -> !pdl.operation
     // Map the matmul to brgemm
-    transform.structured.map_to_brgemm %6
+    transform.structured.rewrite_to_brgemm %6
 
     // Clean-up IR after transformations
     transform.structured.canonicalize %arg1 {

--- a/test/Dialect/Transform/transform-mlp.mlir
+++ b/test/Dialect/Transform/transform-mlp.mlir
@@ -78,7 +78,7 @@ transform.sequence failures(propagate) {
     // Fuse matmul + relu and map the matmul to BRGEMM
     %9, %loop1 = transform.structured.fuse %8 { tile_sizes = [1, 0, 0] }
     %10 = get_producer_of_operand %9[0] : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %10
+    transform.structured.rewrite_to_brgemm %10
 }
 
 // We have 4 layers. 1 loop for each layer and 1 outermost loop for all the layers
@@ -115,7 +115,7 @@ transform.sequence failures(propagate) {
 
     // map a packed matmul to a brgemm
     %7 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %7
+    transform.structured.rewrite_to_brgemm %7
 }
 
 func.func @mlp_single_layer_with_fusion(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t, %Bias: !Bias_tensor_t) -> !C_tensor_t {

--- a/test/Dialect/Transform/transform-rewrite-to-brgemm.mlir
+++ b/test/Dialect/Transform/transform-rewrite-to-brgemm.mlir
@@ -7,7 +7,7 @@
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %0
+    transform.structured.rewrite_to_brgemm %0
 }
 
 // CHECK-LABEL: func.func @blocked_matmul(
@@ -49,7 +49,7 @@ func.func @blocked_matmul(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor<8x16x32x3
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %0
+    transform.structured.rewrite_to_brgemm %0
 }
 
 // CHECK-LABEL: func.func @blocked_matmul(
@@ -86,7 +86,7 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %0
+    transform.structured.rewrite_to_brgemm %0
 }
 
 // CHECK-LABEL: func.func @blocked_matmul(
@@ -112,7 +112,7 @@ func.func @blocked_matmul(%arg0: tensor<8x32x32xf32>, %arg1: tensor<8x32x32xf32>
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %0
+    transform.structured.rewrite_to_brgemm %0
 }
 
 // CHECK-LABEL: func.func @blocked_matmul(
@@ -151,7 +151,7 @@ func.func @blocked_matmul(%arg0: tensor<4x8x32x32xf32>, %arg1: tensor<16x8x32x32
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %0
+    transform.structured.rewrite_to_brgemm %0
 }
 
 // CHECK-LABEL: func.func @blocked_matmul(
@@ -193,7 +193,7 @@ func.func @blocked_matmul(%arg0: tensor<4x8x32x32xf32>, %arg1: tensor<16x8x32x32
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %0
+    transform.structured.rewrite_to_brgemm %0
 }
 
 func.func @blocked_matmul(%arg0: tensor<?x32x32xf32>, %arg1: tensor<?x32x32xf32>, %arg2: tensor<32x32xf32>) -> tensor<32x32xf32> {

--- a/test/Dialect/Transform/transform-rewrite-to-gemm.mlir
+++ b/test/Dialect/Transform/transform-rewrite-to-gemm.mlir
@@ -18,5 +18,5 @@ func.func @conv(%arg0: tensor<1x4x4x3xi64>, %arg1: tensor<2x2x3x8xi64>, %arg2: t
 transform.sequence failures(propagate) {
   ^bb0(%arg0: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg0 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_conv_to_matmul %0
+    transform.structured.rewrite_conv_to_matmul %0
 }

--- a/test/Integration/transform/transform-convolution.mlir
+++ b/test/Integration/transform/transform-convolution.mlir
@@ -68,7 +68,7 @@ transform.sequence failures(propagate) {
     %4 = transform.structured.collapse %generic#2 [[0], [1], [2], [3], [4], [5, 6, 7], [8]]
     %5 = transform.structured.collapse %4 [[0], [1], [2, 3], [4], [5], [6]]
     %6 = transform.structured.interchange %5 iterator_interchange = [0, 1, 4, 2, 3, 5] 
-    transform.structured.map_to_brgemm %6
+    transform.structured.rewrite_to_brgemm %6
 }
 
 func.func @entry() {

--- a/test/Integration/transform/transform-convolutions.mlir
+++ b/test/Integration/transform/transform-convolutions.mlir
@@ -99,14 +99,14 @@ transform.sequence failures(propagate) {
     // Map the conv to linalg.matmul
     // With R = S = 3 we map to linalg.matmul
     %conv1 = transform.structured.interchange %convs#1 iterator_interchange = [0, 1, 2, 5, 6, 7, 3, 4, 8] 
-    transform.structured.map_conv_to_matmul %conv1
+    transform.structured.rewrite_conv_to_matmul %conv1
 
     // Map the conv to linalg.batch_reduce_matmul
     // With R = S = 1 we map to linalg.batch_reduce_matmul
     %7 = transform.structured.collapse %convs#0 [[0], [1], [2], [3], [4], [5, 6, 7], [8]]
     %8 = transform.structured.collapse %7 [[0], [1], [2, 3], [4], [5], [6]]
     %9 = transform.structured.interchange %8 iterator_interchange = [0, 1, 4, 2, 3, 5] 
-    transform.structured.map_to_brgemm %9
+    transform.structured.rewrite_to_brgemm %9
 }
 
 func.func @entry() {

--- a/test/Integration/transform/transform-matmul.mlir
+++ b/test/Integration/transform/transform-matmul.mlir
@@ -71,7 +71,7 @@ transform.sequence failures(propagate) {
     transform.structured.packing_propagation %2
 
     %3 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-    transform.structured.map_to_brgemm %3
+    transform.structured.rewrite_to_brgemm %3
 }
 
 func.func @entry() {

--- a/test/Integration/transform/transform-rewrite-conv-to-gemm.mlir
+++ b/test/Integration/transform/transform-rewrite-conv-to-gemm.mlir
@@ -30,7 +30,7 @@ transform.sequence failures(propagate) {
     %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1 : (!pdl.operation) -> !pdl.operation
     %1 = transform.structured.generalize %0
     %2 = transform.structured.interchange %1 iterator_interchange = [ 0, 1, 4, 5, 2, 3, 6 ] 
-    transform.structured.map_conv_to_matmul %2
+    transform.structured.rewrite_conv_to_matmul %2
 }
 
 func.func @conv(%img: tensor<1x4x4x3xf32>, %filt: tensor<2x2x3x8xf32>,


### PR DESCRIPTION
Methods like mapToBrgemm has been renamed to rewriteToBrgemm align the transform ops to the new names.