### PR TITLE
Wrong call to unary_invoke_inline

### DIFF
--- a/lib/TPP/ConvertXsmmToFunc.cpp
+++ b/lib/TPP/ConvertXsmmToFunc.cpp
@@ -205,9 +205,6 @@ struct ConvertUnaryXsmmOp : public OpRewritePattern<UnaryOp> {
     std::string funcName = "xsmm_unary_invoke";
     if (unaryOp.hasScalarInput())
       funcName = "xsmm_unary_scalar_invoke";
-    if (unaryOp.getCallee() == xsmm::UnaryKind::RELU) {
-      funcName = funcName + "_inline";
-    }
     if (succeeded(buildInvokeCall(unaryOp.getLoc(), funcName, unaryOp, useMeta,
                                   rewriter, typeAttr))) {
       rewriter.eraseOp(unaryOp);

--- a/test/Passes/DefaultPipeline/linalg-memref.mlir
+++ b/test/Passes/DefaultPipeline/linalg-memref.mlir
@@ -100,7 +100,7 @@ func.func @relu_3d(%arg3: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: scf.parallel
   // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   call @xsmm_unary_invoke_inline({{.*}}%[[cast]]
+  // CHECK:   call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast]]
   %c0 = arith.constant 0.0 : f32
   linalg.generic {
     indexing_maps = [#map5],
@@ -123,7 +123,7 @@ func.func @relu_3d(%arg3: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
 func.func @relu_mapping_inplace(%arg0: memref<10x10xf32>) {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: %[[cast:.*]] = memref.cast %[[ARG0]]
-  // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast]]
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast]]
   %c0 = arith.constant 0.0 : f32
   linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%arg0: memref<10x10xf32>) {
     ^bb0(%out : f32):
@@ -144,7 +144,7 @@ func.func @relu_mapping_inplace(%arg0: memref<10x10xf32>) {
 func.func @relu_mapping(%arg0: memref<10x10xf32>, %arg1: memref<10x10xf32>) {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: %[[cast:.*]] = memref.cast %[[ARG1]]
-  // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast]]
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast]]
   %c0 = arith.constant 0.0 : f32
   linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1: memref<10x10xf32>) outs(%arg0: memref<10x10xf32>) {
     ^bb0(%in : f32, %out : f32):
@@ -305,7 +305,7 @@ module @predict_function  {
 
     // Relu
     // CHECK: call @xsmm_unary_dispatch
-    // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]], %[[cast0]]
+    // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
     %cst = arith.constant 0.000000e+00 : f32
     linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} outs(%arg3 : memref<128x512xf32>) {
     ^bb0(%out: f32):

--- a/test/Passes/DefaultPipeline/linalg-tensor.mlir
+++ b/test/Passes/DefaultPipeline/linalg-tensor.mlir
@@ -163,7 +163,7 @@ func.func @mlp(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
 
   // Relu
   // CHECK: call @xsmm_unary_dispatch
-  // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]], %[[cast0]]
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
   %c0 = arith.constant 0.0 : f32
   %3 = linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} outs(%2 : tensor<128x512xf32>) {
     ^bb0(%arg9: f32):

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -36,7 +36,7 @@ module @predict_function  {
 
     // Relu
     // CHECK: call @xsmm_unary_dispatch
-    // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]], %[[cast0]]
+    // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
     %2 = xsmm.unary.dispatch relu [128, 512, 512, 512](broadcast none dataType f32)
     xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 

--- a/test/Passes/DefaultPipeline/tpp.mlir
+++ b/test/Passes/DefaultPipeline/tpp.mlir
@@ -103,7 +103,7 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
 func.func @relu(%arg0: memref<3x3xf32>) {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
-  // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]]
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
   tpp.relu ins(%arg0: memref<3x3xf32>) out(%arg0: memref<3x3xf32>)
 
   return
@@ -119,7 +119,7 @@ func.func @relu_3d(%arg0: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: scf.parallel
   // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   call @xsmm_unary_invoke_inline({{.*}}%[[cast]]
+  // CHECK:   call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast]]
   %c0 = arith.constant 0 : index
   %c64 = arith.constant 64 : index
   %c1 = arith.constant 1 : index
@@ -297,7 +297,7 @@ module @predict_function  {
 
     // Relu
     // CHECK: call @xsmm_unary_dispatch
-    // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]], %[[cast0]]
+    // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
     tpp.relu ins(%arg3 : memref<128x512xf32>) out(%arg3 : memref<128x512xf32>)
 
     return

--- a/test/Passes/DefaultPipeline/xsmm.mlir
+++ b/test/Passes/DefaultPipeline/xsmm.mlir
@@ -108,9 +108,9 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
 func.func @relu(%arg0: memref<3x3xf32>) {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
-  // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]]
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
   %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType f32)
-  xsmm.unary relu(dataType f32, %0, %arg0) : (i64, memref<3x3xf32>) -> ()
+  xsmm.unary relu(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }
@@ -125,14 +125,14 @@ func.func @relu_3d(%arg0: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: scf.parallel
   // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   call @xsmm_unary_invoke_inline({{.*}}%[[cast]]
+  // CHECK:   call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast]]
   %c0 = arith.constant 0 : index
   %c64 = arith.constant 64 : index
   %c1 = arith.constant 1 : index
   scf.parallel (%arg1) = (%c0) to (%c64) step (%c1) {
     %subview = memref.subview %arg0[%arg1, 0, 0] [1, 32, 32] [1, 1, 1] : memref<64x32x32xf32> to memref<32x32xf32, #map>
     %0 = xsmm.unary.dispatch relu [32, 32, 32, 32](broadcast none dataType f32)
-    xsmm.unary relu(dataType f32, %0, %subview) : (i64, memref<32x32xf32, #map>) -> ()
+    xsmm.unary relu(dataType f32, %0, %subview, %subview) : (i64, memref<32x32xf32, #map>, memref<32x32xf32, #map>) -> ()
     scf.yield
   }
 
@@ -314,7 +314,7 @@ module @predict_function {
 
     // Relu
     // CHECK: call @xsmm_unary_dispatch
-    // CHECK: call @xsmm_unary_invoke_inline({{.*}}%[[cast0]], %[[cast0]]
+    // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
     %2 = xsmm.unary.dispatch relu [128, 512, 512, 512](broadcast none dataType f32)
     xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 

--- a/tpp-rt/XsmmRunnerUtils.cpp
+++ b/tpp-rt/XsmmRunnerUtils.cpp
@@ -209,13 +209,6 @@ _mlir_ciface_xsmm_unary_invoke(const libxsmm_datatype dType, int64_t addr,
   kernel(&param);
 }
 
-extern "C" void
-_mlir_ciface_xsmm_unary_invoke_inline(const libxsmm_datatype dType,
-                                      int64_t addr,
-                                      UnrankedMemRefType<char> *input) {
-  _mlir_ciface_xsmm_unary_invoke(dType, addr, input, input);
-}
-
 extern "C" void _mlir_ciface_xsmm_binary_invoke(const libxsmm_datatype dType,
                                                 int64_t addr,
                                                 UnrankedMemRefType<char> *lhs,


### PR DESCRIPTION
Code was generating wrong calls to `xsmm_unary_invoke_inline` by passing three arguments to a two argument function. XSMM tests were using a two-argument version when none was ever generated by TPP-to-XSMM pass.

There's no need to have the `_inline` version since neither TPP-to-XSMM not XSMM-to-LLVM lower less arguments for that version.

I thought this could be the source of the ReLU mismatches, but it isn't. Still, good to clean up incorrect function calls and dangling arguments.