### PR TITLE
Custom linalg decomposition

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -15,6 +15,8 @@
 
 namespace mlir {
 class TypeRange;
+class Operation;
+class Value;
 
 namespace linalg {
 class LinalgOp;
@@ -29,6 +31,10 @@ namespace utils {
 // dimensions.
 bool hasStaticShape(linalg::LinalgOp linalgOp);
 
+// Returns true if the linalg operation indexing maps are projected permutation
+// maps.
+bool allIndexingsAreProjectedPermutation(linalg::GenericOp genericOp);
+
 // Returns true if the linalg operation has been marked by the tpp detection
 // pass and the operation can be mapped to a tpp operation.
 bool hasTppMark(linalg::LinalgOp linalgOp);
@@ -36,11 +42,33 @@ bool hasTppMark(linalg::LinalgOp linalgOp);
 // Returns true if the linalg operation is marked with 'target'.
 bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target);
 
+// Returns true if the linalg operation matches general tpp mapping
+// prerequisites.
+bool hasMappingToTppConditions(linalg::GenericOp linalgOp);
+
 // Returns true if the linalg operation has a Matmul region.
 bool hasMatmulBody(linalg::LinalgOp linalgOp);
 
 // Returns true if the linalg operation has copy semantics.
 bool hasCopySemantics(linalg::LinalgOp linalgOp);
+
+// Returns true if the op is a maxf(x, 0) operation.
+bool isMaxfZeroOp(Operation *op);
+
+// Returns true if linalg generic region contains a maxf(x, 0) operation.
+bool hasMaxfZeroOp(linalg::LinalgOp linalgOp);
+
+// Returns the number of value users.
+int getNumUsers(Value val);
+
+// Returns true if the value has exactly one user.
+bool hasOneUser(Value val);
+
+// Returns true if the value has no users.
+bool hasZeroUser(Value val);
+
+// Returns true if the value has no more than the specified number of users.
+bool hasMaxNumUsers(Value val, int numUsers);
 
 // Returns true if the linalg operation can convert to a tpp.matmul.
 bool isTppMatmul(linalg::LinalgOp linalgOp);

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -95,8 +95,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createConstantFoldPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createElementWiseFusionPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvInitSimplifyPass();
 std::unique_ptr<OperationPass<ModuleOp>> createBufferizePass();
-std::unique_ptr<OperationPass<ModuleOp>> createDecomposeLinalgPass();
-std::unique_ptr<OperationPass<ModuleOp>> createDecomposeDefaultPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeLinalgPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeDefaultPass();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -85,7 +85,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createTileConsumerAndFuseProducersPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteConvToMatmulOrBrgemmPass();
-std::unique_ptr<OperationPass<ModuleOp>> createDefaultTppPass(bool loops=false);
+std::unique_ptr<OperationPass<ModuleOp>>
+createDefaultTppPass(bool loops = false);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGeneralizeTensorPackAndUnPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createRaiseToParallelLoopPass();
@@ -94,6 +95,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createConstantFoldPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createElementWiseFusionPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvInitSimplifyPass();
 std::unique_ptr<OperationPass<ModuleOp>> createBufferizePass();
+std::unique_ptr<OperationPass<ModuleOp>> createDecomposeLinalgPass();
+std::unique_ptr<OperationPass<ModuleOp>> createDecomposeDefaultPass();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -290,4 +290,23 @@ def Bufferize : Pass<"bufferize", "ModuleOp"> {
   let constructor = "mlir::tpp::createBufferizePass()";
 }
 
+def DecomposeLinalgPass : Pass<"decompose-linalg", "ModuleOp"> {
+  let summary = "Custom linalg decomposition pattern";
+  let description = [{
+    Decompose a GenericOp into multiple ops.
+    Supports memrefs and output buffer reuse.
+    Fixes output buffer propagation when used as input.
+    Limited only to static shaped inputs and all inputs having the same shape.
+  }];
+  let constructor = "mlir::tpp::createDecomposeLinalgPass()";
+}
+
+def DecomposeDefaultPass : Pass<"decompose-default", "ModuleOp"> {
+  let summary = "Default linalg decomposition pattern";
+  let description = [{
+    Invoke upstream linalg decomposition pattern.
+  }];
+  let constructor = "mlir::tpp::createDecomposeDefaultPass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -290,7 +290,7 @@ def Bufferize : Pass<"bufferize", "ModuleOp"> {
   let constructor = "mlir::tpp::createBufferizePass()";
 }
 
-def DecomposeLinalgPass : Pass<"decompose-linalg", "ModuleOp"> {
+def DecomposeLinalgPass : Pass<"decompose-linalg", "func::FuncOp"> {
   let summary = "Custom linalg decomposition pattern";
   let description = [{
     Decompose a GenericOp into multiple ops.
@@ -301,7 +301,7 @@ def DecomposeLinalgPass : Pass<"decompose-linalg", "ModuleOp"> {
   let constructor = "mlir::tpp::createDecomposeLinalgPass()";
 }
 
-def DecomposeDefaultPass : Pass<"decompose-default", "ModuleOp"> {
+def DecomposeDefaultPass : Pass<"decompose-default", "func::FuncOp"> {
   let summary = "Default linalg decomposition pattern";
   let description = [{
     Invoke upstream linalg decomposition pattern.

--- a/include/TPP/Transforms.h
+++ b/include/TPP/Transforms.h
@@ -73,6 +73,8 @@ FailureOr<linalg::GenericOp>
 collapseIterators(RewriterBase &rewriter, linalg::GenericOp genericOp,
                   ArrayRef<SmallVector<int64_t, 2>> reassociation);
 
+void populateDecomposeLinalgOpsPattern(RewritePatternSet &patterns,
+                                       bool removeDeadArgsAndResults = true);
 } // namespace linalgx
 
 namespace tpp {

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -17,6 +17,7 @@ add_mlir_library(MLIRTPP
     RaiseToParallelLoop.cpp
     ConstantFoldPack.cpp
     ConvInitSimplify.cpp
+    DecomposeLinalgOps.cpp
 
   # Utils
     TensorInit.cpp

--- a/lib/TPP/DecomposeLinalgOps.cpp
+++ b/lib/TPP/DecomposeLinalgOps.cpp
@@ -202,14 +202,14 @@ DecomposeLinalgOp::createPeeledGenericOp(linalg::GenericOp genericOp,
                             .getShape();
 
     // Reuse the original output buffer in the following cases:
-    // 1) reuse the operand matching the original yield
-    // 2) reuse the same output buffer if:
-    //     - there is at least the same number of output buffers as the scalar
-    //       operation results
-    //     - the output buffer has the same shape as the current intermediate
-    //       result
-    //     - the output buffer has no consumers other than the current peeled
-    //       operation
+    // 1) Reuse the operand matching the original yield.
+    // 2) Reuse the same output buffer if:
+    //      - There is at least the same number of output buffers as the scalar
+    //        operation results.
+    //      - The output buffer has the same shape as the current intermediate
+    //        result.
+    //      - The output buffer has no consumers other than the current peeled
+    //        operation.
     if (resultNumber ||
         ((origRegionOuts.size() >= numScalarOpResults) &&
          llvm::equal(peeledOutSizes, origOutSizes) &&

--- a/lib/TPP/DecomposeLinalgOps.cpp
+++ b/lib/TPP/DecomposeLinalgOps.cpp
@@ -1,0 +1,649 @@
+//===- DecomposeLinalgOps.cpp - Pattern to break up Linalg ops ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Tpp/TppUtils.h"
+#include "TPP/Passes.h"
+#include "TPP/Transforms.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::linalg;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+/// Pattern to decompose a GenericOp that has more than two statements
+/// into one GenericOp with the first statement (i.e. peeled operation), and
+/// a second GenericOp with the remaining statements (i.e. residual operations).
+
+/// - The result of the first GenericOp has the same shape as the iteration
+///   space of the GenericOp. The body of the op yields as many values as the
+///   original op plus all the results of the peeled operation.
+/// - The second GenericOp has as many operands as the original operation plus
+/// all the results of the first Generic Op. It has the same number of yields as
+/// the original op.
+/// - If the result of the peeled operation was yielded by the original
+///   GenericOp the uses of the corresponding results will be replaced with the
+///   result of the first GenericOp created.
+///
+///  Example
+///
+/// ```mlir
+///  %result:2 = linalg.generic ... ins(%arg0, %arg1, %arg2 : ...)
+///      outs(%init0, %init1 : ...) {
+///    ^bb0(%b0: ... , %b1: ... , %b2: ... , %b3: ..., %b4: ...):
+///      %0 = <s0> %b0, %b1 : ...
+///      %1 = <s1> %0, %b2 : ...
+///      linalg.yield %0, %1 : ...
+///  } -> (..., ...)
+///  return %result#0, %result#1
+/// ```
+///
+/// gets split into
+///
+/// ```mlir
+/// %init = tensor.empty ...
+/// %op0:3 = linalg.generic ... ins(%arg0, %arg1, %arg2 : ...)
+///      outs(%init0, %init1, %init : ...)
+///    ^bb0(%b0: ... , %b1: ... , %b2: ... , %b3: ..., %b4: ..., %b5: ...):
+///      %0 = <s0> %b0, %b1 : ...
+///      linalg.yield %0, %..., %0 : ...
+///  } -> (..., ..., ...)
+/// %op1:2 = linalg.generic ... ins(%arg0, %arg1, %arg2, %op0#2 : ...)
+///      outs(%init0, %init1 : ...) {
+///    ^bb0(%b0: ... , %b1: ... , %b2: ... , %b3: ..., %b4: ..., %b5: ...):
+///      %1 = <s1> %b3, %b2 : ...
+///      linalg.yield %..., %1 : ...
+///  } -> (..., ...)
+///  return %op0#0, %op1#1
+/// ```
+///
+/// After canonicalization this is expected to be
+///
+/// ```mlir
+/// %init = tensor.empty ...
+/// %op0 = linalg.generic ... ins(%arg0, %arg1, : ...)
+///      outs(%init : ...)
+///    ^bb0(%b0: ... , %b1: ... , %b2: ...):
+///      %0 = <s0> %b0, %b1 : ...
+///      linalg.yield %0 : ...
+///  } -> ...
+/// %op1 = linalg.generic ... ins(%arg2, %op0#2 : ...)
+///      outs(%init1 : ...) {
+///    ^bb0(%b0: ... , %b1: ... , %b2: ...):
+///      %1 = <s1> %b1, %b0 : ...
+///      linalg.yield %..., %1 : ...
+///  } -> ...
+///  return %op0, %op1
+/// ```
+struct DecomposeLinalgOp : public OpRewritePattern<GenericOp> {
+  using OpRewritePattern<GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(GenericOp genericOp,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  /// Helper method to create a generic op for the peeled scalar operation. The
+  /// created op has an empty region.
+  GenericOp createPeeledGenericOp(GenericOp genericOp,
+                                  PatternRewriter &rewriter) const;
+
+  /// Helper method to create a generic op for the residual scalar operation.
+  /// The created op has the same region as the original op.
+  GenericOp createResidualGenericOp(GenericOp genericOp,
+                                    GenericOp peeledGenericOp,
+                                    PatternRewriter &rewriter) const;
+};
+
+// Expose the decomposition pattern as a pass.
+struct DecomposeLinalgPass
+    : public DecomposeLinalgPassBase<DecomposeLinalgPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    linalgx::populateDecomposeLinalgOpsPattern(patterns, true);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    return;
+  }
+};
+
+// Expose the upstream decomposition pattern as a pass.
+struct DecomposeDefaultPass
+    : public DecomposeDefaultPassBase<DecomposeDefaultPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    linalg::populateDecomposeLinalgOpsPattern(patterns, true);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    return;
+  }
+};
+} // namespace
+
+/// Helper method to compute the range of a generic op.
+static SmallVector<OpFoldResult> getGenericOpLoopRange(OpBuilder &b,
+                                                       GenericOp op) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(op);
+  Location loc = op.getLoc();
+  auto allShapesSizes =
+      cast<LinalgOp>(op.getOperation()).createFlatListOfOperandDims(b, loc);
+  AffineMap map = op.getShapesToLoopsMap();
+  IRRewriter rewriter(b);
+  return makeComposedFoldedMultiResultAffineApply(rewriter, loc, map,
+                                                  allShapesSizes);
+}
+
+/// Helper method to permute the list of `values` based on the `map`.
+static SmallVector<OpFoldResult> permuteValues(ArrayRef<OpFoldResult> values,
+                                               AffineMap map) {
+  assert(map.isPermutation());
+  SmallVector<OpFoldResult> permutedValues(values.size());
+  for (const auto &position :
+       llvm::enumerate(llvm::map_range(map.getResults(), [](AffineExpr expr) {
+         return expr.cast<AffineDimExpr>().getPosition();
+       })))
+    permutedValues[position.value()] = values[position.index()];
+  return permutedValues;
+}
+
+/// Get zero value for an element type.
+static Value getZero(OpBuilder &b, Location loc, Type elementType) {
+  assert(elementType.isIntOrIndexOrFloat() &&
+         "expected scalar type while computing zero value");
+  if (elementType.isa<IntegerType>())
+    return b.create<arith::ConstantIntOp>(loc, 0, elementType);
+  if (elementType.isIndex())
+    return b.create<arith::ConstantIndexOp>(loc, 0);
+  // Assume float.
+  auto floatType = elementType.cast<FloatType>();
+  return b.create<arith::ConstantFloatOp>(
+      loc, APFloat::getZero(floatType.getFloatSemantics()), floatType);
+}
+
+bool canReuseOutput(GenericOp genericOp, Value genericOpOutput,
+                    Operation *bodyOp, Value bodyOpResult) {
+  assert(bodyOp->getParentOp() == genericOp.getOperation() &&
+         "expected body op to belong to the generic");
+  int numUses = 0;
+  for (auto operand : bodyOp->getOperands()) {
+    // llvm::dbgs() << "operand: " << operand << "\n";
+    // llvm::dbgs() << "outOperand: " << genericOpOutput << "\n";
+    if (operand == genericOpOutput)
+      ++numUses;
+  }
+  if (numUses != (tpp::utils::getNumUsers(genericOpOutput)))
+    return false;
+
+  auto numOpResultUsers = tpp::utils::getNumUsers(bodyOpResult);
+  if (numOpResultUsers > 1) {
+    return false;
+  }
+
+  if (numOpResultUsers == 1) {
+    Operation *nextBodyOp = nullptr;
+    auto *body = genericOp.getBody();
+    for (auto op = body->begin(); op != std::prev(body->end()); ++op) {
+      if (&(*op) == bodyOp) {
+        nextBodyOp = &(*std::next(op));
+        break;
+      }
+    }
+
+    if (!nextBodyOp || (*bodyOpResult.getUsers().begin() != nextBodyOp))
+      return false;
+  }
+
+  return true;
+}
+
+GenericOp
+DecomposeLinalgOp::createPeeledGenericOp(GenericOp genericOp,
+                                         PatternRewriter &rewriter) const {
+  Block *body = genericOp.getBody();
+  Operation *peeledScalarOperation = &(*body->begin());
+  SmallVector<AffineMap> peeledGenericOpIndexingMaps =
+      genericOp.getIndexingMapsArray();
+
+  SmallVector<Value> insOperands = genericOp.getInputs();
+  SmallVector<Value> origOuts = genericOp.getOutputs();
+  insOperands.append(origOuts);
+  for (OpOperand *outOperand : genericOp.getDpsInitOperands())
+    peeledGenericOpIndexingMaps.push_back(
+        genericOp.getMatchingIndexingMap(outOperand));
+
+  /// Compute the loop ranges for operation. This is the shape of the result of
+  /// the generic op for the peeled operation.
+  Location loc = genericOp.getLoc();
+  SmallVector<OpFoldResult> domain = getGenericOpLoopRange(rewriter, genericOp);
+  SmallVector<Value> newInitValues;
+  SmallVector<Type> newResultTypes;
+
+  auto origRegionOuts = genericOp.getRegionOutputArgs();
+  auto numScalarOpResults = peeledScalarOperation->getResults().size();
+
+  int numOutUsers = 0;
+  if (origRegionOuts.size() == numScalarOpResults) {
+    for (auto &outArg : origRegionOuts) {
+      if (!tpp::utils::hasZeroUser(outArg))
+        ++numOutUsers;
+    }
+  }
+
+  // Add as many new results as the number of results of the peeled scalar op.
+  for (auto scalarOpResult :
+       llvm::enumerate(peeledScalarOperation->getResults())) {
+    // If the result is yielded by the original op, use the operand, indexing
+    // map and result type that correspond to the yielded value.
+    // llvm::dbgs() << "scalarOpResult: " << scalarOpResult << "\n";
+    std::optional<unsigned> resultNumber;
+    for (auto *user : scalarOpResult.value().getUsers()) {
+      // llvm::dbgs() << "user: " << *user << "\n";
+      if (auto yieldOp = dyn_cast<YieldOp>(user)) {
+        // Find the first use of the `scalarOpResult` in the yield op.
+        for (OpOperand &yieldOperand : yieldOp->getOpOperands()) {
+          if (yieldOperand.get() == scalarOpResult.value()) {
+            resultNumber = yieldOperand.getOperandNumber();
+            break;
+          }
+        }
+        assert(resultNumber && "unable to find use of a value in its user");
+        break;
+      }
+    }
+
+    if (resultNumber ||
+        ((origRegionOuts.size() >= numScalarOpResults) &&
+         canReuseOutput(genericOp,
+                        genericOp.getRegionOutputArgs()[scalarOpResult.index()],
+                        peeledScalarOperation, scalarOpResult.value()))) {
+      // llvm::dbgs() << "resultNumber: " << *resultNumber << "\n";
+      resultNumber = resultNumber ? *resultNumber : scalarOpResult.index();
+      newInitValues.push_back(
+          genericOp.getDpsInitOperand(*resultNumber)->get());
+      OpResult result = genericOp.getResult(*resultNumber).cast<OpResult>();
+      newResultTypes.push_back(result.getType());
+      // peeledGenericOpIndexingMaps.push_back(
+      //     genericOp.getIndexingMapMatchingResult(result));
+      continue;
+    }
+
+    // Fall back path, use an `init_tensor` and identity indexing map.
+    // AffineMap indexingMap = rewriter.getMultiDimIdentityMap(domain.size());
+    auto elementType = scalarOpResult.value().getType();
+    Value emptyBuf;
+    if (genericOp.hasTensorSemantics()) {
+      emptyBuf = rewriter.create<tensor::EmptyOp>(loc, domain, elementType);
+    } else {
+      SmallVector<int64_t> sizes;
+      for (auto shapeSize : domain) {
+        sizes.push_back(*getConstantIntValue(shapeSize));
+      }
+
+      auto allocationType = MemRefType::get(sizes, elementType);
+      emptyBuf = rewriter.create<memref::AllocOp>(loc, allocationType);
+
+      // Release the temporary buffer after the last split generic op
+      {
+        OpBuilder::InsertionGuard g(rewriter);
+        rewriter.setInsertionPointAfter(genericOp.getOperation());
+        rewriter.create<memref::DeallocOp>(loc, emptyBuf);
+      }
+    }
+    // auto fillOp = rewriter.create<linalg::FillOp>(
+    //     loc, getZero(rewriter, loc, elementType), emptyBuf);
+
+    // // In case of tensors, pass the initialized tensor as the new generic op
+    // // output
+    // if (genericOp.hasTensorSemantics())
+    //   emptyBuf = fillOp.result();
+
+    newInitValues.push_back(emptyBuf);
+    newResultTypes.push_back(emptyBuf.getType());
+    // peeledGenericOpIndexingMaps.push_back(indexingMap);
+  }
+
+  /// Create the peeled generic op with an empty body.
+  SmallVector<Value> outsOperands;
+  outsOperands.append(newInitValues.begin(), newInitValues.end());
+
+  SmallVector<Type>
+      resultTypes; //= llvm::to_vector(genericOp.getResultTypes());
+  if (genericOp.hasTensorSemantics()) {
+    resultTypes.append(newResultTypes.begin(), newResultTypes.end());
+  }
+  auto indexingMapAttr =
+      rewriter.getAffineMapArrayAttr(peeledGenericOpIndexingMaps);
+  return rewriter.create<GenericOp>(
+      loc, resultTypes, insOperands, outsOperands, indexingMapAttr,
+      genericOp.getIteratorTypes(), /*doc=*/nullptr, /*libraryCall=*/nullptr,
+      [](OpBuilder, Location, ValueRange) {});
+}
+
+GenericOp
+DecomposeLinalgOp::createResidualGenericOp(GenericOp genericOp,
+                                           GenericOp peeledGenericOp,
+                                           PatternRewriter &rewriter) const {
+  // llvm::dbgs() << "INPUT generic op:\n";
+  // genericOp.dump();
+  /// Append all results from the peeledGenericOps as `ins` operand for the
+  /// residual generic op.
+  bool isTensor = genericOp.hasTensorSemantics();
+  SmallVector<Value> residualGenericOpOperands = genericOp.getInputs();
+  SmallVector<Value> origOuts = genericOp.getOutputs();
+  residualGenericOpOperands.append(origOuts);
+  unsigned origNumResults =
+      isTensor ? genericOp.getNumResults() : genericOp.getOutputs().size();
+  unsigned peeledGenericOpNumResults =
+      isTensor ? peeledGenericOp.getNumResults()
+               : peeledGenericOp.getOutputs().size();
+  // llvm::dbgs() << "origNumResults: " << origNumResults << "\n";
+  // llvm::dbgs() << "peeledGenericOpNumResults: " << peeledGenericOpNumResults
+  // << "\n";
+  SmallVector<Value> extraIns =
+      isTensor ? llvm::to_vector(
+                     llvm::map_range(peeledGenericOp->getResults(),
+                                     [](OpResult opr) -> Value { return opr; }))
+               : peeledGenericOp.getOutputs();
+  // // llvm::dbgs() << "resultNums: ";
+  // for (auto resultNum : llvm::seq<unsigned>(0, peeledGenericOpNumResults)) {
+  //   // llvm::dbgs() << resultNum << " ";
+  //   extraIns.push_back(isTensor ? peeledGenericOp->getResult(resultNum)
+  //                               : peeledGenericOp.getOutputs()[resultNum]);
+  // }
+  // // llvm::dbgs() << "\n";
+  residualGenericOpOperands.append(extraIns);
+
+  /// Add indexing maps for the newly added operands. Use the same map
+  /// as those used for the new results of the peeledGenericOp.
+  auto indexingMaps = llvm::to_vector(
+      llvm::map_range(genericOp.getDpsInputOperands(), [&](OpOperand *operand) {
+        return genericOp.getMatchingIndexingMap(operand);
+      }));
+  for (OpOperand *outOperand : genericOp.getDpsInitOperands())
+    indexingMaps.push_back(genericOp.getMatchingIndexingMap(outOperand));
+  for (auto resultNum : llvm::seq<unsigned>(0, peeledGenericOpNumResults)) {
+    if (isTensor) {
+      OpResult result = peeledGenericOp.getResult(resultNum).cast<OpResult>();
+      indexingMaps.push_back(
+          peeledGenericOp.getIndexingMapMatchingResult(result));
+    } else {
+      auto operand = peeledGenericOp.getDpsInitOperand(resultNum);
+      indexingMaps.push_back(peeledGenericOp.getMatchingIndexingMap(operand));
+    }
+  }
+  for (OpOperand *outOperand : genericOp.getDpsInitOperands())
+    indexingMaps.push_back(genericOp.getMatchingIndexingMap(outOperand));
+
+  auto indexingMapAttr = rewriter.getAffineMapArrayAttr(indexingMaps);
+  return rewriter.create<GenericOp>(
+      genericOp->getLoc(), genericOp->getResultTypes(),
+      residualGenericOpOperands, genericOp.getOutputs(), indexingMapAttr,
+      genericOp.getIteratorTypes(),
+      /*doc=*/nullptr, /*libraryCall=*/nullptr,
+      [](OpBuilder, Location, ValueRange) {});
+}
+
+LogicalResult
+DecomposeLinalgOp::matchAndRewrite(GenericOp genericOp,
+                                   PatternRewriter &rewriter) const {
+  /// For now only match on operations where the iterator types are all parallel
+  if (genericOp.getNumParallelLoops() != genericOp.getNumLoops()) {
+    return rewriter.notifyMatchFailure(genericOp,
+                                       "unhandled decomposition of operation "
+                                       "with non-parallel iterator types");
+  }
+
+  if (llvm::any_of(genericOp.getDpsInitOperands(), [&](OpOperand *outOperand) {
+        return !genericOp.getMatchingIndexingMap(outOperand).isPermutation();
+      })) {
+    return rewriter.notifyMatchFailure(
+        genericOp, "unhandled decomposition of generic op with out operand not "
+                   "accessed using a permutation");
+  }
+
+  /// If the op has only a single statement (apart from the yield), do nothing.
+  Block *body = genericOp.getBody();
+  if (body->getOperations().size() <= 2) {
+    return rewriter.notifyMatchFailure(genericOp,
+                                       "operation has less than 3 statements");
+  }
+
+  /// Check that the peeled statement has a scalar element type.
+  if (llvm::any_of(body->getOperations().begin()->getResultTypes(),
+                   [](Type t) { return !t.isIntOrIndexOrFloat(); })) {
+    return rewriter.notifyMatchFailure(
+        &(*body->getOperations().begin()),
+        "expected return type to be only int, index or float");
+  }
+
+  if (!tpp::utils::hasStaticShape(genericOp)) {
+    return rewriter.notifyMatchFailure(
+        genericOp, "expected all operands to have static shape");
+  }
+
+  if (!tpp::utils::allOperandsHaveSameShapeAndStrides(
+          genericOp->getOperands().getTypes())) {
+    return rewriter.notifyMatchFailure(
+        genericOp, "expected all operands to have the same shape and strides");
+  }
+
+  GenericOp peeledGenericOp = createPeeledGenericOp(genericOp, rewriter);
+  GenericOp residualGenericOp =
+      createResidualGenericOp(genericOp, peeledGenericOp, rewriter);
+  // llvm::dbgs() << "CREATED generic op:\n";
+  // residualGenericOp.dump();
+
+  /// Move the first statement of the original operation into the body of the
+  /// generic op for the peeled operation.
+  Block *peeledGenericOpBody = peeledGenericOp.getBody();
+  Block *residualGenericOpBody = residualGenericOp.getBody();
+  assert(peeledGenericOpBody->empty() && residualGenericOpBody->empty() &&
+         "expected split generic ops to have empty region");
+  peeledGenericOpBody->getOperations().splice(
+      peeledGenericOpBody->begin(), body->getOperations(), body->begin());
+  residualGenericOpBody->getOperations().splice(residualGenericOpBody->begin(),
+                                                body->getOperations());
+
+  // for (auto inputOp : residualGenericOp.getRegionInputArgs()) {
+  //   for (auto outputOp : residualGenericOp.getRegionOutputArgs()) {
+  //     llvm::dbgs() << "inputOp: " << inputOp << "\n";
+  //     llvm::dbgs() << "outputOp: " << outputOp << "\n";
+  //     if (residualGenericOp.getMatchingOpOperand(inputOp)->get() ==
+  //         residualGenericOp.getMatchingOpOperand(outputOp)->get()) {
+  //       llvm::dbgs() << "### Matched input and output\n";
+  //       // auto inArg = residualGenericOp.getMatchingBlockArgument(inputOp);
+  //       // auto outArg =
+  //       residualGenericOp.getMatchingBlockArgument(outputOp);
+  //       // inArg.replaceAllUsesWith(outArg);
+  //       inputOp.replaceAllUsesWith(outputOp);
+  //     }
+  //   }
+  // }
+
+  Operation *peeledScalarOperation = &(*peeledGenericOpBody->begin());
+  auto *yieldOp = residualGenericOpBody->getTerminator();
+  {
+    // Yield all the result of the peeled scalar operation.
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointToEnd(peeledGenericOpBody);
+    SmallVector<Value> yieldedVals;
+    for (auto origYield : yieldOp->getOperands()) {
+      if (origYield.getDefiningOp() == peeledScalarOperation) {
+        yieldedVals.push_back(origYield);
+      }
+    }
+    yieldedVals.append(llvm::to_vector(
+        llvm::map_range(peeledScalarOperation->getResults(),
+                        [](OpResult opr) -> Value { return opr; })));
+    rewriter.create<YieldOp>(genericOp.getLoc(), yieldedVals);
+  }
+
+  /// In the split operations, replace block arguments uses that refer to
+  /// original operation to the block arguments of the newly created operation.
+  unsigned origNumInputs = genericOp.getNumDpsInputs();
+  unsigned origNumOutputs = genericOp.getNumDpsInits();
+  // llvm::dbgs() << "Orig op:\n";
+  // genericOp.dump();
+  // llvm::dbgs() << "Peeled op:\n";
+  // peeledGenericOp.dump();
+  // llvm::dbgs() << "Residual op:\n";
+  // residualGenericOp.dump();
+  for (const auto &inputBlockArg :
+       llvm::enumerate(genericOp.getBody()->getArguments())) {
+    Value residualOpReplacementArg =
+        residualGenericOpBody->getArgument(inputBlockArg.index());
+    inputBlockArg.value().replaceUsesWithIf(
+        residualOpReplacementArg, [&](OpOperand &use) {
+          return use.getOwner()->getBlock() == residualGenericOpBody;
+        });
+
+    Value peeledOpReplacementArg =
+        peeledGenericOpBody->getArgument(inputBlockArg.index());
+
+    // llvm::dbgs() << "Replace #" << inputBlockArg.index() << "\n";
+    // llvm::dbgs() << "  - inputBlockArg: " << inputBlockArg.value() << "\n";
+    // llvm::dbgs() << "  - peeledOpReplacementArg: " << peeledOpReplacementArg
+    //              << "\n";
+
+    inputBlockArg.value().replaceUsesWithIf(
+        peeledOpReplacementArg, [&](OpOperand &use) {
+          if (use.getOwner()->getBlock() == peeledGenericOpBody) {
+            // llvm::dbgs() << "  -> Replaced #" << inputBlockArg.index() <<
+            // "\n";
+          }
+          return use.getOwner()->getBlock() == peeledGenericOpBody;
+        });
+  }
+
+  /// Before fixing up the residual operation, track what values are yielded. If
+  /// any of those are from the peeled scalar operation, the uses of the
+  /// corresponding result have to be remapped to result of the generic op for
+  /// the peeled operation.
+  SmallVector<Value> replacements;
+  for (const auto &yieldValue : llvm::enumerate(yieldOp->getOperands())) {
+    OpResult opr = yieldValue.value().dyn_cast<OpResult>();
+    if (!opr || opr.getOwner() != peeledScalarOperation)
+      replacements.push_back(residualGenericOp.getResult(yieldValue.index()));
+    else
+      replacements.push_back(peeledGenericOp->getResult(yieldValue.index()));
+  }
+
+  /// Update all uses of the peeled scalar operation results in the residual op
+  /// to the newly added arguments.
+  {
+    SmallVector<Value> scalarReplacements;
+    unsigned peeledScalarOpNumResults = peeledScalarOperation->getNumResults();
+    // llvm::dbgs() << "peeledScalarOpNumResults: " << peeledScalarOpNumResults
+    // << "\n";
+
+    scalarReplacements.reserve(peeledScalarOpNumResults);
+    for (auto num : llvm::seq<unsigned>(0, peeledScalarOpNumResults))
+      scalarReplacements.push_back(residualGenericOpBody->getArgument(
+          num + origNumInputs + origNumOutputs));
+    bool allUsesReplaced = false;
+    rewriter.replaceOpWithinBlock(peeledScalarOperation, scalarReplacements,
+                                  residualGenericOpBody, &allUsesReplaced);
+    assert(!allUsesReplaced &&
+           "peeled scalar operation is erased when it wasnt expected to be");
+  }
+
+  // llvm::dbgs() << "ARGS analysis\n";
+  // for (auto inputOp :
+  //      llvm::enumerate(residualGenericOp.getDpsInputOperands())) {
+  //   for (auto outputOp :
+  //        llvm::enumerate(residualGenericOp.getDpsInitOperands())) {
+  //     llvm::dbgs() << "inputOp: " << inputOp.value()->get() << "\n";
+  //     llvm::dbgs() << "outputOp: " << outputOp.value()->get() << "\n";
+  //     if (inputOp.value()->get() == outputOp.value()->get()) {
+  //       llvm::dbgs() << "### Matched input: "
+  //                    << residualGenericOpBody->getArgument(inputOp.index())
+  //                    << "\n";
+  //       llvm::dbgs() << "and output: "
+  //                    << residualGenericOpBody->getArgument(
+  //                           residualGenericOp.getNumDpsInputs() +
+  //                           outputOp.index())
+  //                    << "\n";
+  //       auto inArg = residualGenericOpBody->getArgument(inputOp.index());
+  //       auto outArg = residualGenericOpBody->getArgument(
+  //           residualGenericOp.getNumDpsInputs() + outputOp.index());
+  //       llvm::dbgs() << "InputNumUsers: "
+  //                    << std::distance(inArg.getUsers().begin(),
+  //                                     inArg.getUsers().end())
+  //                    << "\n";
+  //       llvm::dbgs() << "OutputNumUsers: "
+  //                    << std::distance(outArg.getUsers().begin(),
+  //                                     outArg.getUsers().end())
+  //                    << "\n";
+  //       // auto inArg = residualGenericOp.getMatchingBlockArgument(inputOp);
+  //       // auto outArg =
+  //       // residualGenericOp.getMatchingBlockArgument(outputOp);
+  //       inArg.replaceAllUsesWith(outArg);
+  //       // residualGenericOpBody->getArgument(inputOp.index())
+  //       //     .replaceAllUsesWith(residualGenericOpBody->getArgument(
+  //       //         residualGenericOp.getNumDpsInputs() + outputOp.index()));
+  //     }
+  //   }
+  // }
+
+  // llvm::dbgs() << "ARGS analysis\n";
+  for (auto inputOp : residualGenericOp.getRegionInputArgs()) {
+    for (auto outputOp : residualGenericOp.getRegionOutputArgs()) {
+      // llvm::dbgs() << "inputOp: " << inputOp << "\n";
+      // llvm::dbgs() << "outputOp: " << outputOp << "\n";
+      if (residualGenericOp.getMatchingOpOperand(inputOp)->get() ==
+          residualGenericOp.getMatchingOpOperand(outputOp)->get()) {
+        // llvm::dbgs() << "### Matched input and output\n";
+        // auto inArg = residualGenericOp.getMatchingBlockArgument(inputOp);
+        // auto outArg =
+        // residualGenericOp.getMatchingBlockArgument(outputOp);
+        // inArg.replaceAllUsesWith(outArg);
+        inputOp.replaceAllUsesWith(outputOp);
+      }
+    }
+  }
+
+  // llvm::dbgs() << "Peeled AFTER op:\n";
+  // peeledGenericOp.dump();
+  // llvm::dbgs() << "Residual AFTER op:\n";
+  // residualGenericOp.dump();
+
+  // Replace the original operation
+  // genericOp.getOperation()->getParentOp()->dump();
+  // llvm::dbgs() << "numReplacements: " << replacements.size() << "\n";
+  if (genericOp.hasTensorSemantics())
+    rewriter.replaceOp(genericOp, replacements);
+  else
+    rewriter.eraseOp(genericOp);
+  return success();
+}
+
+void mlir::linalgx::populateDecomposeLinalgOpsPattern(
+    RewritePatternSet &patterns, bool removeDeadArgsAndResults) {
+  patterns.insert<DecomposeLinalgOp>(patterns.getContext());
+  // Add the patterns to clean up the dead operands and results.
+  if (removeDeadArgsAndResults)
+    populateEraseUnusedOperandsAndResultsPatterns(patterns);
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::tpp::createDecomposeLinalgPass() {
+  return std::make_unique<DecomposeLinalgPass>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::tpp::createDecomposeDefaultPass() {
+  return std::make_unique<DecomposeDefaultPass>();
+}

--- a/lib/TPP/DecomposeLinalgOps.cpp
+++ b/lib/TPP/DecomposeLinalgOps.cpp
@@ -282,12 +282,17 @@ DecomposeLinalgOp::createPeeledGenericOp(GenericOp genericOp,
          llvm::equal(peeledOutSizes, origOutSizes))) {
       // llvm::dbgs() << "resultNumber: " << *resultNumber << "\n";
       resultNumber = resultNumber ? *resultNumber : scalarOpResult.index();
-      newInitValues.push_back(
-          genericOp.getDpsInitOperand(*resultNumber)->get());
-      OpResult result = genericOp.getResult(*resultNumber).cast<OpResult>();
-      newResultTypes.push_back(result.getType());
-      peeledGenericOpIndexingMaps.push_back(
-          genericOp.getIndexingMapMatchingResult(result));
+      auto origOutOp = genericOp.getDpsInitOperand(*resultNumber);
+      newInitValues.push_back(origOutOp->get());
+      if (genericOp.hasTensorSemantics()) {
+        OpResult result = genericOp.getResult(*resultNumber).cast<OpResult>();
+        newResultTypes.push_back(result.getType());
+        peeledGenericOpIndexingMaps.push_back(
+            genericOp.getIndexingMapMatchingResult(result));
+      } else {
+        peeledGenericOpIndexingMaps.push_back(
+            genericOp.getMatchingIndexingMap(origOutOp));
+      }
       continue;
     }
 

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -159,7 +159,7 @@ bool isZeroTensor(Value val) {
     // We need to find the argument to the linalg on the same order as this one
     auto *linalgOp = arg.getParentRegion()->getParentOp();
     if (!isa<linalg::GenericOp>(linalgOp))
-        return false;
+      return false;
     auto index = arg.getArgNumber();
     auto linalgArg = linalgOp->getOperand(index);
     defOp = linalgArg.getDefiningOp();
@@ -173,12 +173,8 @@ bool isZeroTensor(Value val) {
 // Returns true if the attribute represent "all zeros"
 bool isZeroAttr(Attribute attribute) {
   return TypeSwitch<Attribute, bool>(attribute)
-      .Case<FloatAttr>([](auto attr) {
-          return attr.getValueAsDouble() == 0.0;
-      })
-      .Case<IntegerAttr>([](auto attr) {
-          return attr.getInt() == 0;
-      })
+      .Case<FloatAttr>([](auto attr) { return attr.getValueAsDouble() == 0.0; })
+      .Case<IntegerAttr>([](auto attr) { return attr.getInt() == 0; })
       .Case<DenseElementsAttr>([](auto attr) {
         if (!attr.getElementType().isIntOrFloat())
           return false;
@@ -209,9 +205,8 @@ static bool isZeroOp(Operation *defOp) {
         return isZeroTensor(op.getInputs()[0]);
       })
       .Case<memref::CopyOp, memref::SubViewOp, tensor::CastOp,
-            tensor::ExtractSliceOp>([&](auto op) {
-        return isZeroTensor(op.getSource());
-      })
+            tensor::ExtractSliceOp>(
+          [&](auto op) { return isZeroTensor(op.getSource()); })
       .Case<memref::GetGlobalOp>([&](auto op) {
         auto name = op.getName();
         auto module = defOp->getParentOfType<ModuleOp>();
@@ -247,7 +242,7 @@ bool isTppMatmul(linalg::LinalgOp linalgOp) {
   return hasMatmulBody(linalgOp);
 }
 
-static bool allIndexingsAreProjectedPermutation(linalg::GenericOp genericOp) {
+bool allIndexingsAreProjectedPermutation(linalg::GenericOp genericOp) {
   return llvm::all_of(genericOp.getIndexingMapsArray(), [](AffineMap m) {
     return m.isProjectedPermutation(/*allowZeroInResults=*/true);
   });
@@ -262,12 +257,16 @@ bool hasMappingToTppConditions(linalg::GenericOp linalgOp) {
   return hasStaticShape(linalgOp);
 }
 
-static bool hasOneUser(Value val) {
-  return std::distance(val.getUsers().begin(), val.getUsers().end()) == 1;
+int getNumUsers(Value val) {
+  return std::distance(val.getUsers().begin(), val.getUsers().end());
 }
 
-static bool hasZeroUser(Value val) {
-  return std::distance(val.getUsers().begin(), val.getUsers().end()) == 0;
+bool hasOneUser(Value val) { return getNumUsers(val) == 1; }
+
+bool hasZeroUser(Value val) { return getNumUsers(val) == 0; }
+
+bool hasMaxNumUsers(Value val, int numUsers) {
+  return getNumUsers(val) <= numUsers;
 }
 
 // Return true if the operation is binary.
@@ -353,7 +352,17 @@ static bool isUnaryOp(linalg::GenericOp linalgOp) {
   return false;
 }
 
-static bool hasMaxfZeroOp(linalg::LinalgOp linalgOp) {
+bool isMaxfZeroOp(Operation *op) {
+  if (auto maxfOp = dyn_cast_or_null<arith::MaxFOp>(op)) {
+    // Check both operands if either one is a zero filled tensor.
+    if (isZeroTensor(maxfOp.getLhs()) || isZeroTensor(maxfOp.getRhs()))
+      return true;
+  }
+
+  return false;
+}
+
+bool hasMaxfZeroOp(linalg::LinalgOp linalgOp) {
   if (!isa<linalg::GenericOp>(linalgOp))
     return false;
 
@@ -362,11 +371,8 @@ static bool hasMaxfZeroOp(linalg::LinalgOp linalgOp) {
     return false;
 
   for (Operation &op : genOp.getRegion().front()) {
-    if (auto maxfOp = dyn_cast_or_null<arith::MaxFOp>(op)) {
-      // Check both operands if either one is a zero filled tensor.
-      if (isZeroTensor(maxfOp.getLhs()) || isZeroTensor(maxfOp.getRhs()))
-        return true;
-    }
+    if (isMaxfZeroOp(&op))
+      return true;
   }
 
   return false;

--- a/test/Passes/decompose-linalg-memref.mlir
+++ b/test/Passes/decompose-linalg-memref.mlir
@@ -1,0 +1,449 @@
+// RUN: tpp-opt %s -decompose-linalg -canonicalize -split-input-file | FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_adds() -> memref<28x32xf32> {
+  %cst = arith.constant 1.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    linalg.yield %g1 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// A simple produce-consume chain of operations.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @two_adds(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @add_max() -> memref<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %in2 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1, %in2 : memref<28x32xf32>, memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %in_1: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %in_1 : f32
+    %g1 = arith.maxf %g0, %cst : f32
+    linalg.yield %g1 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+  memref.dealloc %in2 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// A simple produce-consume chain of operations.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @add_max(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[IN1:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[IN1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_ops_output_consumer() -> memref<28x32xf32> {
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %out_0 : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    linalg.yield %g1 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// The initial values of the original output buffer are consumed by the first body op.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @two_ops_output_consumer(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_ops_output_consumer2() -> memref<28x32xf32> {
+  %cst = arith.constant 1.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %cst : f32
+    %g1 = arith.addf %out_0, %g0 : f32
+    linalg.yield %g1 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// The initial values of the original output buffer are consumed by the second body op.
+// The first partial result should be stored in a temporary buffer.
+
+// CHECK: func.func @two_ops_output_consumer2(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[G0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_ops_output_consumer3() -> memref<28x32xf32> {
+  %cst = arith.constant 1.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %out_0 : f32
+    %g1 = arith.addf %out_0, %g0 : f32
+    linalg.yield %g1 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// The initial values of the original output buffer have multiple consumers.
+// The first partial result should be stored in a temporary buffer.
+
+// CHECK: func.func @two_ops_output_consumer3(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[G0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @produce_consume_chain() -> memref<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    %g2 = arith.addf %in_0, %g1 : f32
+    %g3 = arith.addf %in_0, %g2 : f32
+    %g4 = arith.addf %g3, %in_0 : f32
+    linalg.yield %g4 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// A simple produce-consume chain of operations.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @produce_consume_chain(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @produce_multi_consume() -> memref<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    %g2 = arith.addf %in_0, %g1 : f32
+    %g3 = arith.addf %in_0, %g2 : f32
+    %g4 = arith.addf %g3, %g1 : f32
+    linalg.yield %g4 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// A partial result has multiple consumers.
+// The partial result is expected to be stored in a separate temporary buffer.
+
+// CHECK: func.func @produce_multi_consume(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+//   The result is consumed by G4 - keep this result separately.
+// CHECK: %[[G1:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   Partial result of G0 was already consumed by G1 - reuse the original output buffer.
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[G1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[G1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @produce_delayed_consume() -> memref<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    %g2 = arith.addf %in_0, %cst : f32
+    %g3 = arith.addf %in_0, %g2 : f32
+    %g4 = arith.addf %g3, %g1 : f32
+    linalg.yield %g4 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// A partial result is consumed later in the generic body.
+// The partial result is expected to be stored in a separate temporary buffer.
+
+// CHECK: func.func @produce_delayed_consume(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+//   The result is consumed by G4 - keep this result separately.
+// CHECK: %[[G1:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   Partial result of G0 was already consumed by G1 - reuse the original output buffer.
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[G1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @output_multi_consumers() -> memref<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %g0, %out_0 : f32
+    %g2 = arith.addf %out_0, %g1 : f32
+    %g3 = arith.addf %out_0, %g2 : f32
+    %g4 = arith.addf %g3, %out_0 : f32
+    linalg.yield %g4 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// The initial values of the original output buffer have multiple consumers.
+// The partial results are expected to be stored in multiple temporary buffer
+// to avoid corrupting the input values held by the original output buffer.
+
+// CHECK: func.func @output_multi_consumers(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: %[[G1:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[G0]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[G2:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[G1]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G2]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[G3:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[G2]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G3]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}ins(%[[G3]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @output_multi_consumers2() -> memref<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = memref.alloc() : memref<28x32xf32>
+  %out = memref.alloc() : memref<28x32xf32>
+
+  linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : memref<28x32xf32>) outs(%out : memref<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %g0, %out_0 : f32
+    %g2 = arith.addf %in_0, %g1 : f32
+    %g3 = arith.addf %out_0, %g2 : f32
+    %g4 = arith.addf %g3, %cst : f32
+    linalg.yield %g4 : f32
+  }
+
+  memref.dealloc %in1 : memref<28x32xf32>
+
+  return %out : memref<28x32xf32>
+}
+
+// The initial values of the original output buffer have multiple consumers.
+// The partial results are expected to be stored in multiple temporary buffer
+// to avoid corrupting the input values held by the original output buffer.
+
+// CHECK: func.func @output_multi_consumers2(
+// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: %[[G1:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[G0]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   The original output buffer still has remaining users so, store the result in a temp buffer.
+// CHECK: %[[G2:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[G1]] :{{.*}}){{.*}}outs(%[[G2]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   This is the last user of the output buffer so, it can be reused for the partial result.
+// CHECK: linalg.generic{{.*}}ins(%[[G2]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: linalg.generic{{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT]]

--- a/test/Passes/decompose-linalg-memref.mlir
+++ b/test/Passes/decompose-linalg-memref.mlir
@@ -2,10 +2,9 @@
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_adds() -> memref<28x32xf32> {
+func.func @two_adds(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 1.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -16,8 +15,6 @@ func.func @two_adds() -> memref<28x32xf32> {
     linalg.yield %g1 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -25,7 +22,7 @@ func.func @two_adds() -> memref<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @two_adds(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.addf
@@ -39,11 +36,9 @@ func.func @two_adds() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @add_max() -> memref<28x32xf32> {
+func.func @add_max(%in1 : memref<28x32xf32>, %in2 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
-  %in2 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -54,9 +49,6 @@ func.func @add_max() -> memref<28x32xf32> {
     linalg.yield %g1 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-  memref.dealloc %in2 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -64,8 +56,8 @@ func.func @add_max() -> memref<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @add_max(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
-// CHECK: %[[IN1:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>,
+// CHECK-SAME:    %[[IN1:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[IN1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.addf
@@ -79,8 +71,7 @@ func.func @add_max() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_ops_output_consumer() -> memref<28x32xf32> {
-  %in1 = memref.alloc() : memref<28x32xf32>
+func.func @two_ops_output_consumer(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -91,8 +82,6 @@ func.func @two_ops_output_consumer() -> memref<28x32xf32> {
     linalg.yield %g1 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -100,7 +89,7 @@ func.func @two_ops_output_consumer() -> memref<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @two_ops_output_consumer(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.addf
@@ -114,10 +103,9 @@ func.func @two_ops_output_consumer() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_ops_output_consumer2() -> memref<28x32xf32> {
+func.func @two_ops_output_consumer2(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 1.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -128,8 +116,6 @@ func.func @two_ops_output_consumer2() -> memref<28x32xf32> {
     linalg.yield %g1 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -137,7 +123,7 @@ func.func @two_ops_output_consumer2() -> memref<28x32xf32> {
 // The first partial result should be stored in a temporary buffer.
 
 // CHECK: func.func @two_ops_output_consumer2(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -152,10 +138,9 @@ func.func @two_ops_output_consumer2() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_ops_output_consumer3() -> memref<28x32xf32> {
+func.func @two_ops_output_consumer3(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 1.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -166,8 +151,6 @@ func.func @two_ops_output_consumer3() -> memref<28x32xf32> {
     linalg.yield %g1 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -175,7 +158,7 @@ func.func @two_ops_output_consumer3() -> memref<28x32xf32> {
 // The first partial result should be stored in a temporary buffer.
 
 // CHECK: func.func @two_ops_output_consumer3(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -190,10 +173,9 @@ func.func @two_ops_output_consumer3() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @produce_consume_chain() -> memref<28x32xf32> {
+func.func @produce_consume_chain(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -207,8 +189,6 @@ func.func @produce_consume_chain() -> memref<28x32xf32> {
     linalg.yield %g4 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -216,7 +196,7 @@ func.func @produce_consume_chain() -> memref<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @produce_consume_chain(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.maxf
@@ -239,10 +219,9 @@ func.func @produce_consume_chain() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @produce_multi_consume() -> memref<28x32xf32> {
+func.func @produce_multi_consume(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -256,8 +235,6 @@ func.func @produce_multi_consume() -> memref<28x32xf32> {
     linalg.yield %g4 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -265,7 +242,7 @@ func.func @produce_multi_consume() -> memref<28x32xf32> {
 // The partial result is expected to be stored in a separate temporary buffer.
 
 // CHECK: func.func @produce_multi_consume(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.maxf
@@ -291,10 +268,9 @@ func.func @produce_multi_consume() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @produce_delayed_consume() -> memref<28x32xf32> {
+func.func @produce_delayed_consume(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -308,8 +284,6 @@ func.func @produce_delayed_consume() -> memref<28x32xf32> {
     linalg.yield %g4 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -317,7 +291,7 @@ func.func @produce_delayed_consume() -> memref<28x32xf32> {
 // The partial result is expected to be stored in a separate temporary buffer.
 
 // CHECK: func.func @produce_delayed_consume(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.maxf
@@ -343,10 +317,9 @@ func.func @produce_delayed_consume() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @output_multi_consumers() -> memref<28x32xf32> {
+func.func @output_multi_consumers(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -360,8 +333,6 @@ func.func @output_multi_consumers() -> memref<28x32xf32> {
     linalg.yield %g4 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -370,7 +341,7 @@ func.func @output_multi_consumers() -> memref<28x32xf32> {
 // to avoid corrupting the input values held by the original output buffer.
 
 // CHECK: func.func @output_multi_consumers(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -397,10 +368,9 @@ func.func @output_multi_consumers() -> memref<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @output_multi_consumers2() -> memref<28x32xf32> {
+func.func @output_multi_consumers2(%in1 : memref<28x32xf32>) -> memref<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = memref.alloc() : memref<28x32xf32>
   %out = memref.alloc() : memref<28x32xf32>
 
   linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -414,8 +384,6 @@ func.func @output_multi_consumers2() -> memref<28x32xf32> {
     linalg.yield %g4 : f32
   }
 
-  memref.dealloc %in1 : memref<28x32xf32>
-
   return %out : memref<28x32xf32>
 }
 
@@ -424,7 +392,7 @@ func.func @output_multi_consumers2() -> memref<28x32xf32> {
 // to avoid corrupting the input values held by the original output buffer.
 
 // CHECK: func.func @output_multi_consumers2(
-// CHECK: %[[IN:.+]] = memref.alloc() : memref<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: memref<28x32xf32>
 // CHECK: %[[OUT:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: %[[G0:.+]] = memref.alloc() : memref<28x32xf32>
 // CHECK: linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -447,3 +415,66 @@ func.func @output_multi_consumers2() -> memref<28x32xf32> {
 // CHECK:   arith.addf
 // CHECK: }
 // CHECK: return %[[OUT]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+#map2 = affine_map<(d0, d1) -> (d1, d0)>
+func.func @different_shapes(%arg0 : memref<10x20xf32>, %arg1 : memref<10xi32>) -> memref<20x10xf64> {
+  %init = memref.alloc() : memref<20x10xf64>
+  linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg1 : memref<10x20xf32>, memref<10xi32>)
+    outs(%init : memref<20x10xf64>) {
+    ^bb0(%b0 : f32, %b1 : i32, %b2 : f64):
+      %1 = arith.sitofp %b1 : i32 to f64
+      %2 = arith.extf %b0 : f32 to f64
+      %3 = arith.addf %1, %2 : f64
+      linalg.yield %3 : f64
+    }
+  return %init : memref<20x10xf64>
+}
+
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d1, d0)>
+//      CHECK: func @different_shapes(
+// CHECK-SAME:     %[[ARG0:.+]]: memref<10x20xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: memref<10xi32>)
+//  CHECK-DAG:   %[[INIT0:.+]] = memref.alloc() : memref<20x10xf64>
+//  CHECK-DAG:   %[[INIT1:.+]] = memref.alloc() : memref<10x20xf64>
+//      CHECK:   linalg.generic
+// CHECK-SAME:       indexing_maps = [#[[MAP0]], #[[MAP1]]]
+// CHECK-SAME:       iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:       ins(%[[ARG1]] :
+// CHECK-SAME:       outs(%[[INIT1]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[B0:.+]]: i32
+// CHECK-SAME:         %[[B1:.+]]: f64
+// CHECK-NEXT:       %[[S0:.+]] = arith.sitofp %[[B0]] : i32 to f64
+// CHECK-NEXT:       linalg.yield %[[S0]]
+//  CHECK:       %[[INIT2:.+]] = memref.alloc() : memref<10x20xf64>
+//      CHECK:   linalg.generic
+// CHECK-SAME:       indexing_maps = [#[[MAP1]], #[[MAP1]]]
+// CHECK-SAME:       iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:       ins(%[[ARG0]] :
+// CHECK-SAME:       outs(%[[INIT2]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[B2:.+]]: f32
+// CHECK-SAME:         %[[B3:.+]]: f64
+// CHECK-NEXT:       %[[S1:.+]] = arith.extf %[[B2]] : f32 to f64
+// CHECK-NEXT:       linalg.yield %[[S1]]
+//      CHECK:   linalg.generic
+// CHECK-SAME:       indexing_maps = [#[[MAP1]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:       iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:       ins(%[[INIT1]], %[[INIT2]] :
+// CHECK-SAME:       outs(%[[INIT0]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[B4:[a-zA-Z0-9_]+]]: f64
+// CHECK-SAME:         %[[B5:[a-zA-Z0-9_]+]]: f64
+// CHECK-SAME:         %[[B6:.+]]: f64
+// CHECK-NEXT:       %[[S2:.+]] = arith.addf %[[B4]], %[[B5]] : f64
+// CHECK-NEXT:       linalg.yield %[[S2]]
+//      CHECK:   return %[[INIT0]]

--- a/test/Passes/decompose-linalg-tensor.mlir
+++ b/test/Passes/decompose-linalg-tensor.mlir
@@ -1,0 +1,429 @@
+// RUN: tpp-opt %s -decompose-linalg -canonicalize -split-input-file | FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_adds() -> tensor<28x32xf32> {
+  %cst = arith.constant 1.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    linalg.yield %g1 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// A simple produce-consume chain of operations.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @two_adds(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @add_max() -> tensor<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %in2 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1, %in2 : tensor<28x32xf32>, tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %in_1: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %in_1 : f32
+    %g1 = arith.maxf %g0, %cst : f32
+    linalg.yield %g1 : f32
+  } -> tensor<28x32xf32>
+
+
+  return %0 : tensor<28x32xf32>
+}
+
+// A simple produce-consume chain of operations.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @add_max(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[IN1:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[IN1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_ops_output_consumer() -> tensor<28x32xf32> {
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %out_0 : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    linalg.yield %g1 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// The initial values of the original output buffer are consumed by the first body op.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @two_ops_output_consumer(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_ops_output_consumer2() -> tensor<28x32xf32> {
+  %cst = arith.constant 1.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %cst : f32
+    %g1 = arith.addf %out_0, %g0 : f32
+    linalg.yield %g1 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// The initial values of the original output buffer are consumed by the second body op.
+// The first partial result should be stored in a temporary buffer.
+
+// CHECK: func.func @two_ops_output_consumer2(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @two_ops_output_consumer3() -> tensor<28x32xf32> {
+  %cst = arith.constant 1.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.addf %in_0, %out_0 : f32
+    %g1 = arith.addf %out_0, %g0 : f32
+    linalg.yield %g1 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// The initial values of the original output buffer have multiple consumers.
+// The first partial result should be stored in a temporary buffer.
+
+// CHECK: func.func @two_ops_output_consumer3(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @produce_consume_chain() -> tensor<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    %g2 = arith.addf %in_0, %g1 : f32
+    %g3 = arith.addf %in_0, %g2 : f32
+    %g4 = arith.addf %g3, %in_0 : f32
+    linalg.yield %g4 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// A simple produce-consume chain of operations.
+// The original output buffer should be reused in all generics.
+
+// CHECK: func.func @produce_consume_chain(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: %[[OUT_1:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_0]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_2:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_3:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_2]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_3]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @produce_multi_consume() -> tensor<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    %g2 = arith.addf %in_0, %g1 : f32
+    %g3 = arith.addf %in_0, %g2 : f32
+    %g4 = arith.addf %g3, %g1 : f32
+    linalg.yield %g4 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// A partial result has multiple consumers.
+// The partial result is expected to be stored in a separate temporary buffer.
+
+// CHECK: func.func @produce_multi_consume(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+//   The result is consumed by G4 - keep this result separately.
+// CHECK: %[[G1:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_1:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_0]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   Partial result of G0 was already consumed by G1 - reuse the original output buffer.
+// CHECK: %[[OUT_2:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_3:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_2]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_1]], %[[OUT_3]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @produce_delayed_consume() -> tensor<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %in_0, %g0 : f32
+    %g2 = arith.addf %in_0, %cst : f32
+    %g3 = arith.addf %in_0, %g2 : f32
+    %g4 = arith.addf %g3, %g1 : f32
+    linalg.yield %g4 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// A partial result is consumed later in the generic body.
+// The partial result is expected to be stored in a separate temporary buffer.
+
+// CHECK: func.func @produce_delayed_consume(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+//   The result is consumed by G4 - keep this result separately.
+// CHECK: %[[G1:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_1:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_0]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   Partial result of G0 was already consumed by G1 - reuse the original output buffer.
+// CHECK: %[[OUT_2:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_3:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_2]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_1]], %[[OUT_3]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @output_multi_consumers() -> tensor<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %g0, %out_0 : f32
+    %g2 = arith.addf %out_0, %g1 : f32
+    %g3 = arith.addf %out_0, %g2 : f32
+    %g4 = arith.addf %g3, %out_0 : f32
+    linalg.yield %g4 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// The initial values of the original output buffer have multiple consumers.
+// The partial results are expected to be stored in multiple temporary buffer
+// to avoid corrupting the input values held by the original output buffer.
+
+// CHECK: func.func @output_multi_consumers(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: %[[G1:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_1:.+]] = linalg.generic{{.*}}ins(%[[OUT_0]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[G2:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_2:.+]] = linalg.generic{{.*}}ins(%[[OUT_1]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G2]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[G3:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_3:.+]] = linalg.generic{{.*}}ins(%[[OUT_2]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G3]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_3]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @output_multi_consumers2() -> tensor<28x32xf32> {
+  %cst = arith.constant 0.0 : f32
+
+  %in1 = tensor.empty() : tensor<28x32xf32>
+  %out = tensor.empty() : tensor<28x32xf32>
+
+  %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
+  ins(%in1 : tensor<28x32xf32>) outs(%out : tensor<28x32xf32>) {
+  ^bb0(%in_0: f32, %out_0: f32):
+    %g0 = arith.maxf %in_0, %cst : f32
+    %g1 = arith.addf %g0, %out_0 : f32
+    %g2 = arith.addf %in_0, %g1 : f32
+    %g3 = arith.addf %out_0, %g2 : f32
+    %g4 = arith.addf %g3, %cst : f32
+    linalg.yield %g4 : f32
+  } -> tensor<28x32xf32>
+
+  return %0 : tensor<28x32xf32>
+}
+
+// The initial values of the original output buffer have multiple consumers.
+// The partial results are expected to be stored in multiple temporary buffer
+// to avoid corrupting the input values held by the original output buffer.
+
+// CHECK: func.func @output_multi_consumers2(
+// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
+// CHECK:   arith.maxf
+// CHECK: }
+// CHECK: %[[G1:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_1:.+]] = linalg.generic{{.*}}ins(%[[OUT_0]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G1]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   The original output buffer still has remaining users so, store the result in a temp buffer.
+// CHECK: %[[G2:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK: %[[OUT_2:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT_1]] :{{.*}}){{.*}}outs(%[[G2]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+//   This is the last user of the output buffer so, it can be reused for the partial result.
+// CHECK: %[[OUT_3:.+]] = linalg.generic{{.*}}ins(%[[OUT_2]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: %[[OUT_RES:.+]] = linalg.generic{{.*}}ins(%[[OUT_3]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
+// CHECK:   arith.addf
+// CHECK: }
+// CHECK: return %[[OUT_RES]]

--- a/test/Passes/decompose-linalg-tensor.mlir
+++ b/test/Passes/decompose-linalg-tensor.mlir
@@ -2,10 +2,9 @@
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_adds() -> tensor<28x32xf32> {
+func.func @two_adds(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 1.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -23,7 +22,7 @@ func.func @two_adds() -> tensor<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @two_adds(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.addf
@@ -37,11 +36,9 @@ func.func @two_adds() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @add_max() -> tensor<28x32xf32> {
+func.func @add_max(%in1 : tensor<28x32xf32>, %in2 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
-  %in2 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -60,8 +57,8 @@ func.func @add_max() -> tensor<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @add_max(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
-// CHECK: %[[IN1:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>,
+// CHECK-SAME:    %[[IN1:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[IN1]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.addf
@@ -75,8 +72,7 @@ func.func @add_max() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_ops_output_consumer() -> tensor<28x32xf32> {
-  %in1 = tensor.empty() : tensor<28x32xf32>
+func.func @two_ops_output_consumer(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -94,7 +90,7 @@ func.func @two_ops_output_consumer() -> tensor<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @two_ops_output_consumer(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.addf
@@ -108,10 +104,9 @@ func.func @two_ops_output_consumer() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_ops_output_consumer2() -> tensor<28x32xf32> {
+func.func @two_ops_output_consumer2(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 1.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -129,7 +124,7 @@ func.func @two_ops_output_consumer2() -> tensor<28x32xf32> {
 // The first partial result should be stored in a temporary buffer.
 
 // CHECK: func.func @two_ops_output_consumer2(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -144,10 +139,9 @@ func.func @two_ops_output_consumer2() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @two_ops_output_consumer3() -> tensor<28x32xf32> {
+func.func @two_ops_output_consumer3(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 1.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -165,7 +159,7 @@ func.func @two_ops_output_consumer3() -> tensor<28x32xf32> {
 // The first partial result should be stored in a temporary buffer.
 
 // CHECK: func.func @two_ops_output_consumer3(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]], %[[OUT]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -180,10 +174,9 @@ func.func @two_ops_output_consumer3() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @produce_consume_chain() -> tensor<28x32xf32> {
+func.func @produce_consume_chain(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -204,7 +197,7 @@ func.func @produce_consume_chain() -> tensor<28x32xf32> {
 // The original output buffer should be reused in all generics.
 
 // CHECK: func.func @produce_consume_chain(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.maxf
@@ -227,10 +220,9 @@ func.func @produce_consume_chain() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @produce_multi_consume() -> tensor<28x32xf32> {
+func.func @produce_multi_consume(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -251,7 +243,7 @@ func.func @produce_multi_consume() -> tensor<28x32xf32> {
 // The partial result is expected to be stored in a separate temporary buffer.
 
 // CHECK: func.func @produce_multi_consume(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.maxf
@@ -277,10 +269,9 @@ func.func @produce_multi_consume() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @produce_delayed_consume() -> tensor<28x32xf32> {
+func.func @produce_delayed_consume(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -301,7 +292,7 @@ func.func @produce_delayed_consume() -> tensor<28x32xf32> {
 // The partial result is expected to be stored in a separate temporary buffer.
 
 // CHECK: func.func @produce_delayed_consume(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[OUT]] :{{.*}}) {
 // CHECK:   arith.maxf
@@ -327,10 +318,9 @@ func.func @produce_delayed_consume() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @output_multi_consumers() -> tensor<28x32xf32> {
+func.func @output_multi_consumers(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -352,7 +342,7 @@ func.func @output_multi_consumers() -> tensor<28x32xf32> {
 // to avoid corrupting the input values held by the original output buffer.
 
 // CHECK: func.func @output_multi_consumers(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -379,10 +369,9 @@ func.func @output_multi_consumers() -> tensor<28x32xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @output_multi_consumers2() -> tensor<28x32xf32> {
+func.func @output_multi_consumers2(%in1 : tensor<28x32xf32>) -> tensor<28x32xf32> {
   %cst = arith.constant 0.0 : f32
 
-  %in1 = tensor.empty() : tensor<28x32xf32>
   %out = tensor.empty() : tensor<28x32xf32>
 
   %0 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]}
@@ -404,7 +393,7 @@ func.func @output_multi_consumers2() -> tensor<28x32xf32> {
 // to avoid corrupting the input values held by the original output buffer.
 
 // CHECK: func.func @output_multi_consumers2(
-// CHECK: %[[IN:.+]] = tensor.empty() : tensor<28x32xf32>
+// CHECK-SAME:    %[[IN:.+]]: tensor<28x32xf32>
 // CHECK: %[[OUT:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[G0:.+]] = tensor.empty() : tensor<28x32xf32>
 // CHECK: %[[OUT_0:.+]] = linalg.generic{{.*}}ins(%[[IN]] :{{.*}}){{.*}}outs(%[[G0]] :{{.*}}) {
@@ -427,3 +416,66 @@ func.func @output_multi_consumers2() -> tensor<28x32xf32> {
 // CHECK:   arith.addf
 // CHECK: }
 // CHECK: return %[[OUT_RES]]
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0)>
+#map2 = affine_map<(d0, d1) -> (d1, d0)>
+func.func @different_shapes(%arg0 : tensor<10x20xf32>, %arg1 : tensor<10xi32>) -> tensor<20x10xf64> {
+  %init = tensor.empty() : tensor<20x10xf64>
+  %0 = linalg.generic {
+    indexing_maps = [#map0, #map1, #map2],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg1 : tensor<10x20xf32>, tensor<10xi32>)
+    outs(%init : tensor<20x10xf64>) {
+    ^bb0(%b0 : f32, %b1 : i32, %b2 : f64):
+      %1 = arith.sitofp %b1 : i32 to f64
+      %2 = arith.extf %b0 : f32 to f64
+      %3 = arith.addf %1, %2 : f64
+      linalg.yield %3 : f64
+    } -> tensor<20x10xf64>
+  return %0 : tensor<20x10xf64>
+}
+
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1) -> (d1, d0)>
+//      CHECK: func @different_shapes(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<10x20xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<10xi32>)
+//  CHECK-DAG:   %[[INIT0:.+]] = tensor.empty() : tensor<20x10xf64>
+//  CHECK-DAG:   %[[INIT1:.+]] = tensor.empty() : tensor<10x20xf64>
+//      CHECK:   %[[GENERIC0:.+]] = linalg.generic
+// CHECK-SAME:       indexing_maps = [#[[MAP0]], #[[MAP1]]]
+// CHECK-SAME:       iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:       ins(%[[ARG1]] :
+// CHECK-SAME:       outs(%[[INIT1]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[B0:.+]]: i32
+// CHECK-SAME:         %[[B1:.+]]: f64
+// CHECK-NEXT:       %[[S0:.+]] = arith.sitofp %[[B0]] : i32 to f64
+// CHECK-NEXT:       linalg.yield %[[S0]]
+//  CHECK:       %[[INIT2:.+]] = tensor.empty() : tensor<10x20xf64>
+//      CHECK:   %[[GENERIC1:.+]] = linalg.generic
+// CHECK-SAME:       indexing_maps = [#[[MAP1]], #[[MAP1]]]
+// CHECK-SAME:       iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:       ins(%[[ARG0]] :
+// CHECK-SAME:       outs(%[[INIT2]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[B2:.+]]: f32
+// CHECK-SAME:         %[[B3:.+]]: f64
+// CHECK-NEXT:       %[[S1:.+]] = arith.extf %[[B2]] : f32 to f64
+// CHECK-NEXT:       linalg.yield %[[S1]]
+//      CHECK:   %[[GENERIC2:.+]] = linalg.generic
+// CHECK-SAME:       indexing_maps = [#[[MAP1]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:       iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:       ins(%[[GENERIC0]], %[[GENERIC1]] :
+// CHECK-SAME:       outs(%[[INIT0]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[B4:[a-zA-Z0-9_]+]]: f64
+// CHECK-SAME:         %[[B5:[a-zA-Z0-9_]+]]: f64
+// CHECK-SAME:         %[[B6:.+]]: f64
+// CHECK-NEXT:       %[[S2:.+]] = arith.addf %[[B4]], %[[B5]] : f64
+// CHECK-NEXT:       linalg.yield %[[S2]]
+//      CHECK:   return %[[GENERIC2]]


### PR DESCRIPTION
Adds a custom linalg generic decomposition pass which builds on top of the upstream linalg decomposition pattern. The logic is validated for both tensors and memrefs.
For convenience, the upstream decomposition is also exposed as a separate pass.
Additionally, adds, tweaks, and makes public more of the existing TPP utilities.

Notable decomposition changes:
  - generalized to work on both tensors and memrefs
  - reuses the original output buffer whenever possible
  to limit the number of temporary allocations
  - removes the need for temporary buffer initialization
  - correctly propagates output buffer between split ops
  when it is used as an input by any scalar operations

The custom pass limitations:
  - only accepts static shapes

Resolves #352 