### PR TITLE
Random initialization of tensors

### DIFF
--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -1,0 +1,134 @@
+#ifndef TPP_RUN_TENSORINIT_H
+#define TPP_RUN_TENSORINIT_H
+
+//===- TensorInit.h - MLIR Tensor Initialization --------------------------===//
+//
+// Initializes tensors for kernel input/output handling with some reasonable
+// distribution to allow for layout testing (reorder, pad) without vanishing
+// or exploding values at the end of a large model (0.0 ~ 1.0).
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/BuiltinOps.h"
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+/// Base class
+/// Assumes float (32) as base type.
+/// TODO: Add a template parameter if/when we support double.
+struct TensorInit {
+  /// Data type (TODO: Support 64/8-bit data types)
+  enum DataType {
+    FP32, BF16
+  };
+
+protected:
+  /// BF16 conversion (by reference)
+  static void toBF16(llvm::APFloat& value) {
+    bool ignored;
+    value.convert(llvm::APFloat::BFloat(), llvm::APFloat::rmNearestTiesToEven,
+                       &ignored);
+  }
+
+  /// Data type
+  DataType type;
+  /// Number of elements in the shape
+  size_t size;
+  /// Data pointer
+  std::vector<llvm::APFloat> buffer;
+
+  /// Resize the buffer with the total allocation size
+  void allocateBuffer();
+
+  /// Insert element indexed on the buffer
+  void insert(size_t index, float value);
+
+  /// Insert element at the end of the buffer
+  void push_back(float value);
+
+  /// Actual implementation that fills the buffer
+  /// To be implemented by derived classes.
+  virtual void fillData() = 0;
+
+public:
+  /// Returns a dense attribute with a specified shape, initialized
+  /// with a particular implementation (see derived classes) with
+  /// a reasonable distribution (0.0 ~ 1.0)
+  virtual mlir::DenseElementsAttr get(mlir::ShapedType shape);
+
+  /// DEBUG ONLY: Print a specific value as an fp32 (regardless of data type)
+  float at(size_t index);
+
+  TensorInit(DataType type) : type(type), size(1) {}
+  virtual ~TensorInit() {}
+};
+
+/// Constant init (all-ones, do not use!)
+struct ConstantTensorInit : TensorInit {
+  ConstantTensorInit(DataType type) : TensorInit(type) {}
+
+  /// Return a dense<1.0> repeated throughout the shape
+  mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
+
+  void fillData() override;
+};
+
+/// Simple init (basic example, not useful)
+struct SimpleTensorInit : TensorInit {
+  SimpleTensorInit(DataType type) : TensorInit(type) {}
+
+  /// Return a dense<0.3, 0.6, 0.9> repeated throughout the shape
+  void fillData() override;
+};
+
+/// Continuous init (normalized affine range)
+struct ContinuousTensorInit : TensorInit {
+  ContinuousTensorInit(DataType type) : TensorInit(type) {}
+
+  /// Return a dense<0.0 ... 1.0> throughout the shape
+  void fillData() override;
+};
+
+/// Random init (uniform)
+struct RandomTensorInit : TensorInit {
+  RandomTensorInit(DataType type, int seed)
+      : TensorInit(type), generator(seed), distribution(0.0, 1.0) {}
+
+  /// Random generator
+  std::default_random_engine generator;
+  /// Random distribution
+  std::uniform_real_distribution<float> distribution;
+
+  /// Next random uniform number
+  float next() {
+    return distribution(generator);
+  }
+
+  /// Return a dense<uniform(0.0, 1.0)> throughout the shape
+  void fillData() override;
+};
+
+/// Random init (normal)
+struct NormalTensorInit : TensorInit {
+  NormalTensorInit(DataType type, int seed)
+      : TensorInit(type), generator(seed), distribution(0.0, 0.2) {}
+
+  /// Random generator
+  std::default_random_engine generator;
+  /// Random distribution
+  std::normal_distribution<float> distribution;
+
+  /// Next random number
+  float next() {
+    auto value = distribution(generator);
+    value = std::clamp(value, 0.0f, 1.0f);
+    return value;
+  }
+
+  /// Return a dense<normal(0.0, 1.0)> throughout the shape
+  void fillData() override;
+};
+
+#endif

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_library(MLIRTPP
     ConvInitSimplify.cpp
 
   # Utils
+    TensorInit.cpp
     TransformUtils.cpp
     VNNIUtils.cpp
 

--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -1,0 +1,74 @@
+#include "TPP/TensorInit.h"
+
+using namespace mlir;
+
+DenseElementsAttr TensorInit::get(ShapedType shape) {
+  buffer.clear();
+  for (size_t dim=0, rank = shape.getRank(); dim<rank; dim++)
+    size *= shape.getDimSize(dim);
+  fillData();
+  return mlir::DenseElementsAttr::get(shape, buffer);
+}
+
+void TensorInit::insert(size_t index, float value) {
+  buffer[index] = llvm::APFloat(value);
+  if (type == DataType::BF16)
+    toBF16(buffer[index]);
+}
+
+void TensorInit::push_back(float value) {
+  buffer.push_back(llvm::APFloat(value));
+  if (type == DataType::BF16)
+    toBF16(buffer.back());
+}
+
+float TensorInit::at(size_t index) {
+  return buffer[index].convertToFloat();
+}
+
+DenseElementsAttr ConstantTensorInit::get(ShapedType shape) {
+  auto floatValue = APFloat(1.0F);
+  if (shape.getElementType().isBF16()) {
+    bool ignored;
+    floatValue.convert(APFloat::BFloat(), APFloat::rmNearestTiesToEven,
+                       &ignored);
+  } else {
+    assert(shape.getElementType().isF32() && "Element type not supported");
+  }
+
+  // For some reason, memref global op needs dense tensor type
+  // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
+  auto tensorType =
+      RankedTensorType::get(shape.getShape(), shape.getElementType());
+  return mlir::DenseElementsAttr::get(tensorType, floatValue);
+}
+
+void ConstantTensorInit::fillData() {
+  assert(false && "Should not be called");
+}
+
+void SimpleTensorInit::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  float data[3] = { 0.3f, 0.6f, 0.9f };
+  for (size_t i=0; i<size; i++)
+    push_back(data[i % 3]);
+}
+
+void ContinuousTensorInit::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  float normFactor = static_cast<float>(buffer.size());
+  for (size_t i=0; i<size; i++)
+    push_back(static_cast<float>(i) / normFactor);
+}
+
+void RandomTensorInit::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  for (size_t i=0; i<size; i++)
+    push_back(next());
+}
+
+void NormalTensorInit::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  for (size_t i=0; i<size; i++)
+    push_back(next());
+}

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -134,7 +134,7 @@ public:
   LogicalResult printResult(Operation *kernelCall);
 
   /// Terminates the function, issuing a return, lower to LLVM
-  LogicalResult finalize();
+  LogicalResult finalize(bool dump);
 
   /// Reports error on the current module's location
   LogicalResult emitError(llvm::Twine);

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -118,7 +118,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
     return bench.emitError("Cannot find kernel '" + options.mainFuncName + "'");
 
   if (failed(bench.checkKernelSignature()))
-    return bench.finalize();
+    return bench.finalize(dumpMLIR);
 
   // Move the kernel to a local name, so we can create `main` with the same
   // name as the pre-defined entry point (since we can't change it)
@@ -154,14 +154,11 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   }
 
   // Finally lower to LLVM Dialect
-  return bench.finalize();
+  return bench.finalize(dumpMLIR);
 }
 
 std::unique_ptr<llvm::Module>
 lowerToLLVMIR(Operation* module, llvm::LLVMContext &llvmContext) {
-  if (dumpMLIR)
-    module->dump();
-
   // Default lowering for mlir-cpu-runner
   auto llvmModule = translateModuleToLLVMIR(module, llvmContext);
   assert(llvmModule);


### PR DESCRIPTION
Wrote a simple class structure to initialize tensors in various ways, including the existing `dense<1.0>`, some odd patterns and two random splats.

The random init creates a `dense<0x...>` with random values with a library that can be used by both `tpp-run` and the C++ benchmarks.

Using the same seed, we can make sure we generate the same tensors on both sides.

Fixes #229