### PR TITLE
Splat replacement with random init

### DIFF
--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -21,8 +21,20 @@
 struct TensorInit {
   /// Data type (TODO: Support 64/8-bit data types)
   enum DataType {
-    FP32, BF16
+    INVALID, FP32, BF16
   };
+
+  /// Get the data type for the float with width bits
+  static DataType getFloatDataType(unsigned widthInBits) {
+    switch (widthInBits) {
+      case 16:
+        return BF16;
+      case 32:
+        return FP32;
+      default:
+        return INVALID;
+    }
+  }
 
 protected:
   /// BF16 conversion (by reference)

--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -7,7 +7,11 @@ DenseElementsAttr TensorInit::get(ShapedType shape) {
   for (size_t dim=0, rank = shape.getRank(); dim<rank; dim++)
     size *= shape.getDimSize(dim);
   fillData();
-  return mlir::DenseElementsAttr::get(shape, buffer);
+  // For some reason, memref global op needs dense tensor type
+  // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
+  auto tensorType =
+      RankedTensorType::get(shape.getShape(), shape.getElementType());
+  return mlir::DenseElementsAttr::get(tensorType, buffer);
 }
 
 void TensorInit::insert(size_t index, float value) {

--- a/test/Integration/tpp-run-splat-memref.mlir
+++ b/test/Integration/tpp-run-splat-memref.mlir
@@ -1,0 +1,33 @@
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir 2>&1 | \
+// RUN: FileCheck %s --check-prefix=SPLAT
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 2>&1 | \
+// RUN: FileCheck %s --check-prefix=RANDOM
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random 2>&1 | \
+// RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
+
+memref.global "private" constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00> {alignment = 128 : i64}
+memref.global "private" constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00> {alignment = 128 : i64}
+memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00> {alignment = 128 : i64}
+func.func @entry(%input: memref<4x2xf32>) {
+  %0 = memref.get_global @__constant_2x16xf32 : memref<2x16xf32>
+  %1 = memref.get_global @__constant_4x16xf32 : memref<4x16xf32>
+  %2 = memref.get_global @__constant_4x8xf32 : memref<4x8xf32>
+  return
+}
+// SPLAT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+// SPLAT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
+// SPLAT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
+// SPLAT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// SPLAT-LABEL: @_entry
+
+// RANDOM-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+// RANDOM: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
+// RANDOM: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
+// RANDOM: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// RANDOM-LABEL: @_entry
+
+// RANDOM-SPLAT-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+// RANDOM-SPLAT-NOT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
+// RANDOM-SPLAT-NOT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
+// RANDOM-SPLAT-NOT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// RANDOM-SPLAT-LABEL: @_entry

--- a/test/Integration/tpp-run-splat-memref.mlir
+++ b/test/Integration/tpp-run-splat-memref.mlir
@@ -6,8 +6,10 @@
 // RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
 
 memref.global "private" constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00> {alignment = 128 : i64}
-memref.global "private" constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00> {alignment = 128 : i64}
-memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00> {alignment = 128 : i64}
+memref.global "private" constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.0> {alignment = 128 : i64}
+memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.0> {alignment = 128 : i64}
+memref.global "private" constant @__constant_non_splat : memref<2x2xf32> = dense<[[0.0, 1.0],[2.0, 3.0]]> {alignment = 128 : i64}
+memref.global "private" constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0> {alignment = 128 : i64}
 func.func @entry(%input: memref<4x2xf32>) {
   %0 = memref.get_global @__constant_2x16xf32 : memref<2x16xf32>
   %1 = memref.get_global @__constant_4x16xf32 : memref<4x16xf32>
@@ -18,16 +20,22 @@ func.func @entry(%input: memref<4x2xf32>) {
 // SPLAT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // SPLAT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
 // SPLAT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// SPLAT: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// SPLAT: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
 // SPLAT-LABEL: @_entry
 
 // RANDOM-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // RANDOM: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // RANDOM: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
 // RANDOM: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// RANDOM: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// RANDOM: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
 // RANDOM-LABEL: @_entry
 
 // RANDOM-SPLAT-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// RANDOM-SPLAT: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// RANDOM-SPLAT: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
 // RANDOM-SPLAT-LABEL: @_entry

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -1,0 +1,39 @@
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir 2>&1 | \
+// RUN: FileCheck %s --check-prefix=SPLAT
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 2>&1 | \
+// RUN: FileCheck %s --check-prefix=RANDOM
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random 2>&1 | \
+// RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
+
+func.func @entry(%input: tensor<4x2xf32>) {
+  %0 = arith.constant dense<1.0> : tensor<2x16xf32>
+  %1 = arith.constant dense<2.0> : tensor<4x16xf32>
+  %2 = arith.constant dense<0.0> : tensor<4x8xf32>
+  return
+}
+// Constants
+// SPLAT-LABEL: @_entry
+// SPLAT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
+// SPLAT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
+// SPLAT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// Input
+// SPLAT-LABEL: @entry
+// SPLAT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
+
+// Constants
+// RANDOM-LABEL: @_entry
+// RANDOM: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
+// RANDOM: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
+// RANDOM: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// Input
+// RANDOM-LABEL: @entry
+// RANDOM-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
+
+// Constants
+// RANDOM-SPLAT-LABEL: @_entry
+// RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
+// RANDOM-SPLAT-NOT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
+// RANDOM-SPLAT-NOT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// Input
+// RANDOM-SPLAT-LABEL: @entry
+// RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -9,6 +9,8 @@ func.func @entry(%input: tensor<4x2xf32>) {
   %0 = arith.constant dense<1.0> : tensor<2x16xf32>
   %1 = arith.constant dense<2.0> : tensor<4x16xf32>
   %2 = arith.constant dense<0.0> : tensor<4x8xf32>
+  %3 = arith.constant dense<[[0.0, 1.0],[2.0, 3.0]]> : tensor<2x2xf32>
+  %4 = arith.constant dense<0> : tensor<4x8xi32>
   return
 }
 // Constants
@@ -16,6 +18,8 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // SPLAT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // SPLAT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
 // SPLAT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// SPLAT: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // SPLAT-LABEL: @entry
 // SPLAT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
@@ -25,6 +29,8 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // RANDOM: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
 // RANDOM: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// RANDOM: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// RANDOM: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // RANDOM-LABEL: @entry
 // RANDOM-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
@@ -34,6 +40,8 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM-SPLAT-NOT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
 // RANDOM-SPLAT-NOT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// RANDOM-SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// RANDOM-SPLAT: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // RANDOM-SPLAT-LABEL: @entry
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -99,6 +99,9 @@ public:
   /// Renames the kernel to _name, so that we can create the wrapper
   LogicalResult renameKernel();
 
+  /// Replace all dense splat tensors/memrefs with random values in the kernel
+  LogicalResult replaceSplatWithRandom();
+
   /// Create and initialize the kernel input arguments
   /// The values are cached locally in a kernel argument list, in order
   LogicalResult createKernelArgs();


### PR DESCRIPTION
New option to `tpp-run` that allows us to replace splat tensors on the kernel function with random init, so that we can write tests with `dense<1.0>` and let the runner replace with actual random values (from a normal distribution).

The option is `-splat-to-random` and needs `-seed` to be enabled, too.

Incidentally fixes #346