### PR TITLE
Make tensor init type selectable

### DIFF
--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -114,7 +114,7 @@ void SimpleTensorInit::fillData() {
 
 void ContinuousTensorInit::fillData() {
   assert(buffer.size() == 0 && "Buffer not empty");
-  float normFactor = static_cast<float>(buffer.size());
+  float normFactor = static_cast<float>(size);
   for (size_t i=0; i<size; i++)
     push(static_cast<float>(i) / normFactor);
 }

--- a/test/Integration/tpp-run-splat-memref.mlir
+++ b/test/Integration/tpp-run-splat-memref.mlir
@@ -35,7 +35,7 @@ func.func @entry(%input: memref<4x2xf32>) {
 // RANDOM-SPLAT-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
-// RANDOM-SPLAT-NOT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
+// RANDOM-SPLAT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
 // RANDOM-SPLAT: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // RANDOM-SPLAT: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
 // RANDOM-SPLAT-LABEL: @_entry

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -73,8 +73,8 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // OPT-SIMPLE: arith.constant dense<0> : tensor<4x8xi32>
 
 // OPT-CONT-LABEL: @_entry
-// OPT-CONT: arith.constant dense<{{.*}}0xFFC00000, 0x7F800000, 0x7F800000, {{.*}}> : tensor<2x16xf32>
-// OPT-CONT: arith.constant dense<{{.*}}0xFFC00000, 0x7F800000, 0x7F800000, {{.*}}> : tensor<4x16xf32>
+// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<2x16xf32>
+// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.562500e-02, 3.125000e-02,  {{.*}}> : tensor<4x16xf32>
 // OPT-CONT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // OPT-CONT: arith.constant dense<0> : tensor<4x8xi32>

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -5,6 +5,18 @@
 // RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random 2>&1 | \
 // RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
 
+// Options for -init-type
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=const 2>&1 | \
+// RUN: FileCheck %s --check-prefix=OPT-CONST
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=simple 2>&1 | \
+// RUN: FileCheck %s --check-prefix=OPT-SIMPLE
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=cont 2>&1 | \
+// RUN: FileCheck %s --check-prefix=OPT-CONT
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=random 2>&1 | \
+// RUN: FileCheck %s --check-prefix=OPT-RANDOM
+// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=normal 2>&1 | \
+// RUN: FileCheck %s --check-prefix=OPT-NORMAL
+
 func.func @entry(%input: tensor<4x2xf32>) {
   %0 = arith.constant dense<1.0> : tensor<2x16xf32>
   %1 = arith.constant dense<2.0> : tensor<4x16xf32>
@@ -39,9 +51,44 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // RANDOM-SPLAT-LABEL: @_entry
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM-SPLAT-NOT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
-// RANDOM-SPLAT-NOT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// RANDOM-SPLAT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // RANDOM-SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // RANDOM-SPLAT: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // RANDOM-SPLAT-LABEL: @entry
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
+
+// OPT-CONST-LABEL: @_entry
+// OPT-CONST: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
+// OPT-CONST: arith.constant dense<1.000000e+00> : tensor<4x16xf32>
+// OPT-CONST: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// OPT-CONST: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// OPT-CONST: arith.constant dense<0> : tensor<4x8xi32>
+
+// OPT-SIMPLE-LABEL: @_entry
+// OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<2x16xf32>
+// OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<4x16xf32>
+// OPT-SIMPLE: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// OPT-SIMPLE: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// OPT-SIMPLE: arith.constant dense<0> : tensor<4x8xi32>
+
+// OPT-CONT-LABEL: @_entry
+// OPT-CONT: arith.constant dense<{{.*}}0xFFC00000, 0x7F800000, 0x7F800000, {{.*}}> : tensor<2x16xf32>
+// OPT-CONT: arith.constant dense<{{.*}}0xFFC00000, 0x7F800000, 0x7F800000, {{.*}}> : tensor<4x16xf32>
+// OPT-CONT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// OPT-CONT: arith.constant dense<0> : tensor<4x8xi32>
+
+// OPT-RANDOM-LABEL: @_entry
+// OPT-RANDOM: arith.constant dense<{{.*}}9.62642952E-4, 0.179147944, 0.939454615, {{.*}}> : tensor<2x16xf32>
+// OPT-RANDOM: arith.constant dense<{{.*}}9.62642952E-4, 0.179147944, 0.939454615, {{.*}}> : tensor<4x16xf32>
+// OPT-RANDOM: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// OPT-RANDOM: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// OPT-RANDOM: arith.constant dense<0> : tensor<4x8xi32>
+
+// OPT-NORMAL-LABEL: @_entry
+// OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.303520e-01, 0.151291341, {{.*}}> : tensor<2x16xf32>
+// OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.303520e-01, 0.151291341, {{.*}}> : tensor<4x16xf32>
+// OPT-NORMAL: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
+// OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// OPT-NORMAL: arith.constant dense<0> : tensor<4x8xi32>

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -18,6 +18,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "TPP/TensorInit.h"
+
 namespace mlir {
 class ModuleOp;
 class MemRefType;
@@ -64,6 +66,9 @@ class MLIRBench {
   /// Lower TPP to loops for validation purposes
   bool tppToLoops;
 
+  /// Tensor init type
+  TensorInitType initType;
+
   /// Create a random global based on the memref type
   llvm::StringRef createGlobal(MemRefType);
 
@@ -87,7 +92,7 @@ class MLIRBench {
 
 public:
   /// Creates context, builder
-  MLIRBench(Operation *op, int seed, bool tppToLoops);
+  MLIRBench(Operation *op, int seed, bool tppToLoops, TensorInitType initType);
 
   /// Finds the kernel method, checks correct name and shape
   LogicalResult findKernel(llvm::StringRef);


### PR DESCRIPTION
Adding a helper to get tensor init type, data type and parsing from string, so we can have an option in `tpp-run` that select the initialization type of the tensors, including constant ones.

Adding tests for each type.