### PR TITLE
Use print() instead of dump()

### DIFF
--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -370,7 +370,7 @@ LogicalResult MLIRBench::finalize(bool dumpMLIR) {
   }
 
   if (dumpMLIR)
-    module->dump();
+    module->print(llvm::outs());
 
   // A set of default passes that lower any input IR to LLVM
   PassManager passManager(module->getContext());
@@ -407,7 +407,7 @@ LogicalResult MLIRBench::finalize(bool dumpMLIR) {
   auto result = passManager.run(module);
   if (failed(result)) {
     llvm::errs() << "ERROR: Failed to lower Module to LLVM dialect\n";
-    module->dump();
+    module->print(llvm::errs());
   }
 
   return result;

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -216,7 +216,7 @@ lowerToLLVMIR(Operation* module, llvm::LLVMContext &llvmContext) {
   auto optPipeline =
       makeOptimizingTransformer(optLevel, sizeLevel, targetMachine.get());
   if (auto err = optPipeline(llvmModule.get())) {
-    llvmModule->dump();
+    llvmModule->print(llvm::errs(), nullptr);
     llvm::errs() << "Error while passing through the LLVM pipeline: ";
     llvm::errs() << err << "\n";
     return nullptr;
@@ -229,7 +229,7 @@ lowerToLLVMIR(Operation* module, llvm::LLVMContext &llvmContext) {
   }
 
   if (dumpLLVM)
-    llvmModule->dump();
+    llvmModule->print(llvm::outs(), nullptr);
 
   return llvmModule;
 }


### PR DESCRIPTION
LLVM Dump methods are not compiled on release builds, so we should really use `print(errs)` instead. Also changing the actual printing of IR to stdout with `print(outs)`.

Fixes #350