### PR TITLE
Fix leading dimension for 1d memref

### DIFF
--- a/lib/TPP/ConvertTppToXsmm.cpp
+++ b/lib/TPP/ConvertTppToXsmm.cpp
@@ -27,6 +27,11 @@ using namespace mlir;
 namespace {
 
 static FailureOr<int64_t> getLeadingDim(MemRefType memref, size_t pos = 0) {
+  // For 1d memref we cannot use the stride as leading dimension, but the
+  // leading dimension is the dimension itself.
+  if (memref.getRank() == 1)
+    return memref.getShape()[0];
+
   SmallVector<int64_t> strides;
   int64_t offset;
   if (failed(getStridesAndOffset(memref, strides, offset)))

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm.mlir
@@ -175,7 +175,7 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
 
 // CHECK-LABEL: func.func @add_to_xsmm_1d
 func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: memref<32xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 32, 32, 32](dataType f32, broadcast none)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 32, 32, 32](broadcast none dataType f32)
   // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<32xf32>, memref<32xf32>, memref<32xf32>) -> ()
   tpp.add ins(%arg0: memref<32xf32>, %arg1: memref<32xf32>) out(%arg2: memref<32xf32>)
   return 
@@ -186,7 +186,7 @@ func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: m
 // CHECK-LABEL: func.func @relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>)
 func.func @relu_to_xsmm(%arg0: memref<32xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32](dataType f32, broadcast none)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32](broadcast none dataType f32)
   // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<32xf32>) out(%arg0: memref<32xf32>)
   return
@@ -194,18 +194,9 @@ func.func @relu_to_xsmm(%arg0: memref<32xf32>) {
 
 // -----
 
-func.func @relu_to_xsmm(%arg0: memref<32xi64>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32](dataType i64, broadcast none)
-  // CHECK-NEXT: xsmm.unary relu(dataType i64, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
-  tpp.relu ins(%arg0: memref<32xi64>) out(%arg0: memref<32xi64>)
-  return
-}
-
-// -----
-
 // CHECK-LABEL: add_to_xsmm_2d
 func.func @add_to_xsmm_2d(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>, %arg2: memref<3x4xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [3, 4, 4, 4, 4](dataType f32, broadcast none)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [3, 4, 4, 4, 4](broadcast none dataType f32)
   // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<3x4xf32>, memref<3x4xf32>, memref<3x4xf32>) -> ()
   tpp.add ins(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>) out(%arg2: memref<3x4xf32>)
   return

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm.mlir
@@ -173,12 +173,10 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
 
 // -----
 
-// CHECK-LABEL: func.func @add_to_xsmm(
-// CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>, %[[ARG1:.+]]: memref<32xf32>, 
-// CHECK-SAME:  %[[ARG2:.+]]: memref<32xf32>)
-func.func @add_to_xsmm(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: memref<32xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 1, 1, 1](broadcast none dataType f32)
-  // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK-LABEL: func.func @add_to_xsmm_1d
+func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: memref<32xf32>) {
+  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 32, 32, 32](dataType f32, broadcast none)
+  // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<32xf32>, memref<32xf32>, memref<32xf32>) -> ()
   tpp.add ins(%arg0: memref<32xf32>, %arg1: memref<32xf32>) out(%arg2: memref<32xf32>)
   return 
 }
@@ -188,8 +186,27 @@ func.func @add_to_xsmm(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: memr
 // CHECK-LABEL: func.func @relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>)
 func.func @relu_to_xsmm(%arg0: memref<32xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 1, 1](broadcast none dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32](dataType f32, broadcast none)
   // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<32xf32>) out(%arg0: memref<32xf32>)
+  return
+}
+
+// -----
+
+func.func @relu_to_xsmm(%arg0: memref<32xi64>) {
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32](dataType i64, broadcast none)
+  // CHECK-NEXT: xsmm.unary relu(dataType i64, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
+  tpp.relu ins(%arg0: memref<32xi64>) out(%arg0: memref<32xi64>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: add_to_xsmm_2d
+func.func @add_to_xsmm_2d(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>, %arg2: memref<3x4xf32>) {
+  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [3, 4, 4, 4, 4](dataType f32, broadcast none)
+  // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<3x4xf32>, memref<3x4xf32>, memref<3x4xf32>) -> ()
+  tpp.add ins(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>) out(%arg2: memref<3x4xf32>)
   return
 }

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -1384,7 +1384,7 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
   // CHECK: %[[subview:.*]] = memref.subview
   // CHECK: %[[subview1:.*]] = memref.subview
   // CHECK: %[[subview2:.*]] = memref.subview
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c1_i64]], %[[c1_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
   // CHECK: %[[cast:.*]] = memref.cast %[[subview]]
   // CHECK: %[[cast1:.*]] = memref.cast %[[subview1]]
   // CHECK: %[[cast2:.*]] = memref.cast %[[subview2]]


### PR DESCRIPTION
If the memref is 1d computing the leading dimension using the stride is wrong. What you want to pass here is the full dimension of your vector.