### PR TITLE
Fix mapping for `tpp.identity`

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -86,6 +86,19 @@ bool isZeroTensor(Value val);
 // allOperandsHaveSameShape(A, C) return false.
 bool allOperandsHaveSameShapeAndStrides(TypeRange types);
 
+// Check if tpp.identity satisfies broadcasting rules.
+// see: https://numpy.org/doc/stable/reference/ufuncs.html#broadcasting
+// TODO: Make this function general enough for other tpp ops when we support
+// broadcasting.
+enum class MatchBroadcastRuleResult {
+  Success = 0,
+  OutputNotShapedType,
+  WrongOutputRank,
+  FailedToVerifyRules,
+};
+MatchBroadcastRuleResult verifyTppIdentityBroadcastingRules(Type input,
+                                                            Type output);
+
 } // namespace utils
 } // namespace tpp
 } // namespace mlir


### PR DESCRIPTION
The mapping logic for `tpp.identity` was too naive. So now we check the affine maps and require them to be projected permutation. Additionally, we ensure before mapping that the linalg op verifies "our" broadcasting rules and rejects candidate ops that do not satisfy these requirements. Current mapping is still not optimal, and more effort needs to be spent on mapping and broadcast support.