### PR TITLE
Default pipeline - linalg to loops

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -85,7 +85,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createTileConsumerAndFuseProducersPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteConvToMatmulOrBrgemmPass();
-std::unique_ptr<OperationPass<ModuleOp>> createDefaultTppPass(bool loops=false);
+std::unique_ptr<OperationPass<ModuleOp>>
+createDefaultTppPass(bool tppLoops = false, bool linalgLoops = false);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGeneralizeTensorPackAndUnPackPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createRaiseToParallelLoopPass();

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -234,6 +234,9 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     Option<"tppToLoops", "tpp-to-loops",
            "bool", /*default=*/"0",
            "By default TPP ops are lowered to XSMM. Lower TPP to loops instead.">,
+    Option<"linalgToLoops", "linalg-to-loops",
+           "bool", /*default=*/"0",
+           "By default linalg ops are lowered to TPP. Lower linalg to loops instead.">,
   ];
 }
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -236,7 +236,7 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
            "By default TPP ops are lowered to XSMM. Lower TPP to loops instead.">,
     Option<"linalgToLoops", "linalg-to-loops",
            "bool", /*default=*/"0",
-           "By default linalg ops are lowered to TPP. Lower linalg to loops instead.">,
+           "Skip all TPP transformations. Lower linalg directly to loops.">,
   ];
 }
 

--- a/test/Integration/conv-to-matmul.mlir
+++ b/test/Integration/conv-to-matmul.mlir
@@ -20,8 +20,11 @@
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 
-// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" | \
-// RUN: tpp-run -print \
+// RUN: tpp-run %s -tpp-to-loops -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// RUN: tpp-run %s -linalg-to-loops -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/relayout-gemm.mlir
+++ b/test/Integration/relayout-gemm.mlir
@@ -6,8 +6,11 @@
 //
 
 // Validate default pipeline
-// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" | \
-// RUN: tpp-run -print \
+// RUN: tpp-run %s -tpp-to-loops -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// RUN: tpp-run %s -linalg-to-loops -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/relayout-more-interesting.mlir
+++ b/test/Integration/relayout-more-interesting.mlir
@@ -6,8 +6,11 @@
 //
 
 // Validate default pipeline
-// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" | \
-// RUN: tpp-run -print \
+// RUN: tpp-run %s -tpp-to-loops -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// RUN: tpp-run %s -linalg-to-loops -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/smoke.mlir
+++ b/test/Integration/smoke.mlir
@@ -11,6 +11,11 @@
 //
 
 // Validate default pipeline
+// RUN: tpp-opt %s -linalg-generalize-named-ops -default-tpp-passes="linalg-to-loops" | \
+// RUN: tpp-run -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 // RUN: tpp-opt %s -linalg-generalize-named-ops -default-tpp-passes="tpp-to-loops" | \
 // RUN: tpp-run -print \
 // RUN:  -e entry -entry-point-result=void | \

--- a/test/Passes/DefaultPipeline/linalg-to-loops.mlir
+++ b/test/Passes/DefaultPipeline/linalg-to-loops.mlir
@@ -1,5 +1,49 @@
 // RUN: tpp-opt %s -default-tpp-passes="linalg-to-loops" -split-input-file | FileCheck %s
 
+// Direct linalg lowering to loops should leave all TPP operations untouched.
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @tpp_ops(
+// CHECK-SAME:  %[[ARG0:[^ ]+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:[^ ]+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG2:[^ ]+]]: memref<1x1xf32>)
+func.func @tpp_ops(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<1x1xf32>) {
+  // CHECK: tpp.identity
+  // CHECK: tpp.add
+  // CHECK: tpp.relu
+  tpp.identity ins(%arg2 : memref<1x1xf32>) out(%arg0 : memref<3x3xf32>)
+  tpp.add ins(%arg0 : memref<3x3xf32>, %arg1 : memref<3x3xf32>) out(%arg1 : memref<3x3xf32>)
+  tpp.relu ins(%arg0 : memref<3x3xf32>) out(%arg0 : memref<3x3xf32>)
+
+  return
+}
+
+// -----
+
+// Direct linalg lowering to loops should leave all VNNI operations untouched.
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @vnni_ops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<128x1024xbf16>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<512x2048x2xbf16>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<128x2048xbf16>,
+// CHECK-SAME:  %[[ARG3:.+]]: memref<4x256x512xbf16>,
+// CHECK-SAME:  %[[ARG4:.+]]: memref<4x256x1024x2xbf16>,
+// CHECK-SAME:  %[[ARG5:.+]]: memref<256x1024xbf16>)
+func.func @vnni_ops(%arg0: tensor<128x1024xbf16>,
+                  %arg1: tensor<512x2048x2xbf16>,
+                  %arg2: tensor<128x2048xbf16>,
+                  %arg3: tensor<4x256x512xbf16>,
+                  %arg4: tensor<4x256x1024x2xbf16>,
+                  %arg5: tensor<256x1024xbf16>) -> (tensor<128x2048xbf16>, tensor<256x1024xbf16>) {
+  // CHECK: vnni.matmul
+  // CHECK: vnni.brgemm
+  %0 = vnni.matmul ins(%arg0 : tensor<128x1024xbf16>, %arg1 : tensor<512x2048x2xbf16>) out(%arg2 : tensor<128x2048xbf16>) -> tensor<128x2048xbf16>
+  %1 = vnni.brgemm ins(%arg3 : tensor<4x256x512xbf16>, %arg4 : tensor<4x256x1024x2xbf16>) out(%arg5 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+
+  return %0, %1 : tensor<128x2048xbf16>, tensor<256x1024xbf16>
+}
+
+// -----
+
 // CHECK-NOT: func.func private @xsmm_
 // CHECK: func.func @matmul(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,
@@ -12,7 +56,7 @@ func.func @matmul(%A: tensor<4x8xf32>,
   // CHECK:     scf.for
   // CHECK:       arith.mulf
   // CHECK:       arith.addf
-  %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+  %D = linalg.matmul ins(%A, %B : tensor<4x8xf32>, tensor<8x4xf32>) outs(%C : tensor<4x4xf32>) -> tensor<4x4xf32>
 
   return %D : tensor<4x4xf32>
 }

--- a/test/Passes/DefaultPipeline/linalg-to-loops.mlir
+++ b/test/Passes/DefaultPipeline/linalg-to-loops.mlir
@@ -1,0 +1,193 @@
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-loops" -split-input-file | FileCheck %s
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @matmul(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<8x4xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<4x4xf32>)
+func.func @matmul(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       arith.mulf
+  // CHECK:       arith.addf
+  %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+
+  return %D : tensor<4x4xf32>
+}
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK-LABEL: func.func @blocked_matmul(
+// CHECK-SAME: %[[ARG0:.+]]: memref<4x16x32x32xf32>,
+// CHECK-SAME: %[[ARG1:.+]]: memref<8x16x32x32xf32>,
+// CHECK-SAME: %[[ARG2:.+]]: memref<4x8x32x32xf32>)
+func.func @blocked_matmul(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor<8x16x32x32xf32>, %arg2: tensor<4x8x32x32xf32>) -> tensor<4x8x32x32xf32> {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         scf.for
+  // CHECK:           scf.for
+  // CHECK:             arith.mulf
+  // CHECK:             arith.addf
+  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x16x32x32xf32>, tensor<8x16x32x32xf32>) outs(%arg2 : tensor<4x8x32x32xf32>) {
+    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+      %8 = arith.mulf %arg3, %arg4 : f32
+      %9 = arith.addf %arg5, %8 : f32
+      linalg.yield %9 : f32
+    } -> tensor<4x8x32x32xf32>
+
+  return %1 :  tensor<4x8x32x32xf32>
+}
+
+// -----
+
+// 1x1 Conv2D shapes
+!conv1x1_input_tensor_t  = tensor<1x7x7x2048xf32> // N,H,W,Ic
+!conv1x1_filter_tensor_t = tensor<1x1x2048x512xf32> // H,W,Ic,Oc
+!conv1x1_output_tensor_t = tensor<1x7x7x512xf32> // N,H,W,Oc
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK-LABEL: @conv2d_1x1(
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
+func.func @conv2d_1x1(
+      %arg0 : !conv1x1_input_tensor_t) -> !conv1x1_output_tensor_t {
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_9 = arith.constant dense<0.000000e+00> : !conv1x1_output_tensor_t
+
+  // Conv2D weights
+  %cst = arith.constant dense<0.00332225906> : !conv1x1_filter_tensor_t
+
+  // 1x1 Conv2D
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       memref.store
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         arith.mulf
+  // CHECK:         arith.addf
+  %0 = tensor.empty() : !conv1x1_output_tensor_t
+  %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : !conv1x1_output_tensor_t) -> !conv1x1_output_tensor_t
+  %2 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+              ins(%arg0, %cst : !conv1x1_input_tensor_t, !conv1x1_filter_tensor_t)
+              outs(%1 : !conv1x1_output_tensor_t) -> !conv1x1_output_tensor_t
+
+  // CHECK: return {{.*}} : memref<1x7x7x512xf32>
+  return %2 : !conv1x1_output_tensor_t
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0 + d1)>
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK-LABEL: @conv2d_1x1_decomposed(
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
+func.func @conv2d_1x1_decomposed(
+      %arg0 : tensor<1x7x7x2048xf32>) -> tensor<1x7x7x512xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c7 = arith.constant 7 : index
+
+  // Conv2D weights
+  %cst = arith.constant dense<0.00332225906> : tensor<2048x512xf32>
+
+  // 1x1 Conv2D
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       memref.store
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         arith.mulf
+  // CHECK:         arith.addf
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<1x7x7x512xf32>
+  %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+  %2 = scf.for %arg1 = %c0 to %c1 step %c1 iter_args(%arg2 = %1) -> (tensor<1x7x7x512xf32>) {
+    %3 = scf.for %arg3 = %c0 to %c7 step %c1 iter_args(%arg4 = %arg2) -> (tensor<1x7x7x512xf32>) {
+      %4 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg6 = %arg4) -> (tensor<1x7x7x512xf32>) {
+        %5 = scf.for %arg7 = %c0 to %c1 step %c1 iter_args(%arg8 = %arg6) -> (tensor<1x7x7x512xf32>) {
+          %6 = affine.apply #map(%arg3, %arg5)
+          %extracted_slice = tensor.extract_slice %arg0[%arg1, %6, %arg7, 0] [1, 1, 7, 2048] [1, 1, 1, 1] : tensor<1x7x7x2048xf32> to tensor<7x2048xf32>
+          %extracted_slice_1 = tensor.extract_slice %arg8[%arg1, %arg3, 0, 0] [1, 1, 7, 512] [1, 1, 1, 1] : tensor<1x7x7x512xf32> to tensor<7x512xf32>
+          %7 = linalg.matmul ins(%extracted_slice, %cst : tensor<7x2048xf32>, tensor<2048x512xf32>) outs(%extracted_slice_1 : tensor<7x512xf32>) -> tensor<7x512xf32>
+          %inserted_slice = tensor.insert_slice %7 into %arg8[%arg1, %arg3, 0, 0] [1, 1, 7, 512] [1, 1, 1, 1] : tensor<7x512xf32> into tensor<1x7x7x512xf32>
+          scf.yield %inserted_slice : tensor<1x7x7x512xf32>
+        }
+        scf.yield %5 : tensor<1x7x7x512xf32>
+      }
+      scf.yield %4 : tensor<1x7x7x512xf32>
+    }
+    scf.yield %3 : tensor<1x7x7x512xf32>
+  }
+
+  // CHECK: return {{.*}} : memref<1x7x7x512xf32>
+  return %2 : tensor<1x7x7x512xf32>
+}
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d1)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @mlp(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<128x256xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<256x512xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<512xf32>,
+// CHECK-SAME:  %[[ARG3:.+]]: memref<128x512xf32>)
+func.func @mlp(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
+  %arg2: tensor<512xf32>,  %output: tensor<128x512xf32>) -> tensor<128x512xf32> {
+
+  // Identity
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     memref.load
+  // CHECK:     memref.store
+  %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<512xf32>) outs(%output : tensor<128x512xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+  } -> tensor<128x512xf32>
+
+  // Matmul
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       arith.mulf
+  // CHECK:       arith.addf
+  %2 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>) outs(%1 : tensor<128x512xf32>) attrs =  {iterator_ranges = [128, 512, 256]} {
+    ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
+      %16 = arith.mulf %arg9, %arg10 : f32
+      %17 = arith.addf %arg11, %16 : f32
+      linalg.yield %17 : f32
+  } -> tensor<128x512xf32>
+
+  // Relu
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     arith.maxf
+  %c0 = arith.constant 0.0 : f32
+  %3 = linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} outs(%2 : tensor<128x512xf32>) {
+    ^bb0(%arg9: f32):
+      %16 = arith.maxf %arg9, %c0 : f32
+      linalg.yield %16 : f32
+  } -> tensor<128x512xf32>
+
+  return %3 : tensor<128x512xf32>
+}

--- a/test/Passes/DefaultPipeline/tpp-to-loops.mlir
+++ b/test/Passes/DefaultPipeline/tpp-to-loops.mlir
@@ -1,0 +1,186 @@
+// RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" -split-input-file | FileCheck %s
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @matmul(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<8x4xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<4x4xf32>)
+func.func @matmul(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       arith.mulf
+  // CHECK:       arith.addf
+  %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+
+  return %D : tensor<4x4xf32>
+}
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK-LABEL: func.func @blocked_matmul(
+// CHECK-SAME: %[[ARG0:.+]]: memref<4x16x32x32xf32>,
+// CHECK-SAME: %[[ARG1:.+]]: memref<8x16x32x32xf32>,
+// CHECK-SAME: %[[ARG2:.+]]: memref<4x8x32x32xf32>)
+func.func @blocked_matmul(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor<8x16x32x32xf32>, %arg2: tensor<4x8x32x32xf32>) -> tensor<4x8x32x32xf32> {
+  // CHECK: scf.parallel
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         scf.for
+  // CHECK:           arith.mulf
+  // CHECK:           arith.addf
+  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x16x32x32xf32>, tensor<8x16x32x32xf32>) outs(%arg2 : tensor<4x8x32x32xf32>) {
+    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+      %8 = arith.mulf %arg3, %arg4 : f32
+      %9 = arith.addf %arg5, %8 : f32
+      linalg.yield %9 : f32
+    } -> tensor<4x8x32x32xf32>
+
+  return %1 :  tensor<4x8x32x32xf32>
+}
+
+// -----
+
+// 1x1 Conv2D shapes
+!conv1x1_input_tensor_t  = tensor<1x7x7x2048xf32> // N,H,W,Ic
+!conv1x1_filter_tensor_t = tensor<1x1x2048x512xf32> // H,W,Ic,Oc
+!conv1x1_output_tensor_t = tensor<1x7x7x512xf32> // N,H,W,Oc
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK-LABEL: @conv2d_1x1(
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
+func.func @conv2d_1x1(
+      %arg0 : !conv1x1_input_tensor_t) -> !conv1x1_output_tensor_t {
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_9 = arith.constant dense<0.000000e+00> : !conv1x1_output_tensor_t
+
+  // Conv2D weights
+  %cst = arith.constant dense<0.00332225906> : !conv1x1_filter_tensor_t
+
+  // 1x1 Conv2D
+  // CHECK: linalg.fill
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         arith.mulf
+  // CHECK:         arith.addf
+  %0 = tensor.empty() : !conv1x1_output_tensor_t
+  %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : !conv1x1_output_tensor_t) -> !conv1x1_output_tensor_t
+  %2 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+              ins(%arg0, %cst : !conv1x1_input_tensor_t, !conv1x1_filter_tensor_t)
+              outs(%1 : !conv1x1_output_tensor_t) -> !conv1x1_output_tensor_t
+
+  // CHECK: return {{.*}} : memref<1x7x7x512xf32>
+  return %2 : !conv1x1_output_tensor_t
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0 + d1)>
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK-LABEL: @conv2d_1x1_decomposed(
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
+func.func @conv2d_1x1_decomposed(
+      %arg0 : tensor<1x7x7x2048xf32>) -> tensor<1x7x7x512xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c7 = arith.constant 7 : index
+
+  // Conv2D weights
+  %cst = arith.constant dense<0.00332225906> : tensor<2048x512xf32>
+
+  // 1x1 Conv2D
+  // CHECK: linalg.fill
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         arith.mulf
+  // CHECK:         arith.addf
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<1x7x7x512xf32>
+  %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+  %2 = scf.for %arg1 = %c0 to %c1 step %c1 iter_args(%arg2 = %1) -> (tensor<1x7x7x512xf32>) {
+    %3 = scf.for %arg3 = %c0 to %c7 step %c1 iter_args(%arg4 = %arg2) -> (tensor<1x7x7x512xf32>) {
+      %4 = scf.for %arg5 = %c0 to %c1 step %c1 iter_args(%arg6 = %arg4) -> (tensor<1x7x7x512xf32>) {
+        %5 = scf.for %arg7 = %c0 to %c1 step %c1 iter_args(%arg8 = %arg6) -> (tensor<1x7x7x512xf32>) {
+          %6 = affine.apply #map(%arg3, %arg5)
+          %extracted_slice = tensor.extract_slice %arg0[%arg1, %6, %arg7, 0] [1, 1, 7, 2048] [1, 1, 1, 1] : tensor<1x7x7x2048xf32> to tensor<7x2048xf32>
+          %extracted_slice_1 = tensor.extract_slice %arg8[%arg1, %arg3, 0, 0] [1, 1, 7, 512] [1, 1, 1, 1] : tensor<1x7x7x512xf32> to tensor<7x512xf32>
+          %7 = linalg.matmul ins(%extracted_slice, %cst : tensor<7x2048xf32>, tensor<2048x512xf32>) outs(%extracted_slice_1 : tensor<7x512xf32>) -> tensor<7x512xf32>
+          %inserted_slice = tensor.insert_slice %7 into %arg8[%arg1, %arg3, 0, 0] [1, 1, 7, 512] [1, 1, 1, 1] : tensor<7x512xf32> into tensor<1x7x7x512xf32>
+          scf.yield %inserted_slice : tensor<1x7x7x512xf32>
+        }
+        scf.yield %5 : tensor<1x7x7x512xf32>
+      }
+      scf.yield %4 : tensor<1x7x7x512xf32>
+    }
+    scf.yield %3 : tensor<1x7x7x512xf32>
+  }
+
+  // CHECK: return {{.*}} : memref<1x7x7x512xf32>
+  return %2 : tensor<1x7x7x512xf32>
+}
+
+// -----
+
+#map0 = affine_map<(d0, d1) -> (d1)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @mlp(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<128x256xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<256x512xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<512xf32>,
+// CHECK-SAME:  %[[ARG3:.+]]: memref<128x512xf32>)
+func.func @mlp(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
+  %arg2: tensor<512xf32>,  %output: tensor<128x512xf32>) -> tensor<128x512xf32> {
+
+  // Identity
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     memref.load
+  // CHECK:     memref.store
+  %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<512xf32>) outs(%output : tensor<128x512xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+  } -> tensor<128x512xf32>
+
+  // Matmul
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       arith.mulf
+  // CHECK:       arith.addf
+  %2 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>) outs(%1 : tensor<128x512xf32>) attrs =  {iterator_ranges = [128, 512, 256]} {
+    ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
+      %16 = arith.mulf %arg9, %arg10 : f32
+      %17 = arith.addf %arg11, %16 : f32
+      linalg.yield %17 : f32
+  } -> tensor<128x512xf32>
+
+  // Relu
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     arith.maxf
+  %c0 = arith.constant 0.0 : f32
+  %3 = linalg.generic {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]} outs(%2 : tensor<128x512xf32>) {
+    ^bb0(%arg9: f32):
+      %16 = arith.maxf %arg9, %c0 : f32
+      linalg.yield %16 : f32
+  } -> tensor<128x512xf32>
+
+  return %3 : tensor<128x512xf32>
+}

--- a/test/Passes/DefaultPipeline/tpp-to-loops.mlir
+++ b/test/Passes/DefaultPipeline/tpp-to-loops.mlir
@@ -1,6 +1,89 @@
 // RUN: tpp-opt %s -default-tpp-passes="tpp-to-loops" -split-input-file | FileCheck %s
 
 // CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @tpp_add(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<3x3xf32>
+func.func @tpp_add(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     arith.addf
+  tpp.add ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) out(%arg1: memref<3x3xf32>)
+
+  return
+}
+
+// -----
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @tpp_identity(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<1x1xf32>
+func.func @tpp_identity(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     memref.load
+  // CHECK:     memref.store
+  tpp.identity ins(%arg1: memref<1x1xf32>) out(%arg0: memref<3x3xf32>)
+
+  return
+}
+
+// -----
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @tpp_relu(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>
+func.func @tpp_relu(%arg0: memref<3x3xf32>) {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     arith.maxf
+  tpp.relu ins(%arg0: memref<3x3xf32>) out(%arg0: memref<3x3xf32>)
+
+  return
+}
+
+// -----
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @tpp_brgemm(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<2x3x4xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<2x4x3xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<3x3xf32>
+func.func @tpp_brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       scf.for
+  // CHECK:         arith.mulf
+  // CHECK:         arith.addf
+  tpp.brgemm ins(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>) out(%arg2: memref<3x3xf32>)
+
+  return
+}
+
+// -----
+
+// CHECK-NOT: func.func private @xsmm_
+// CHECK: func.func @tpp_matmul(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<8x4xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<4x4xf32>)
+func.func @tpp_matmul(%A: memref<4x8xf32>,
+          %B: memref<8x4xf32>, %C: memref<4x4xf32>) {
+  // CHECK: scf.for
+  // CHECK:   scf.for
+  // CHECK:     scf.for
+  // CHECK:       arith.mulf
+  // CHECK:       arith.addf
+  tpp.matmul ins(%A : memref<4x8xf32>, %B : memref<8x4xf32>) out(%C : memref<4x4xf32>)
+
+  return
+}
+
+// -----
+
+// CHECK-NOT: func.func private @xsmm_
 // CHECK: func.func @matmul(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,
 // CHECK-SAME:  %[[ARG1:.+]]: memref<8x4xf32>,

--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -36,9 +36,9 @@
 using namespace mlir;
 
 MLIRBench::MLIRBench(mlir::Operation *op, int seed, bool tppToLoops,
-                     TensorInitType initType)
+                     bool linalgToLoops, TensorInitType initType)
     : builder(op->getContext()), unkLoc(builder.getUnknownLoc()), seed(seed),
-      tppToLoops(tppToLoops), initType(initType) {
+      tppToLoops(tppToLoops), linalgToLoops(linalgToLoops), initType(initType) {
   module = dyn_cast<ModuleOp>(op);
   assert(module && "expected a 'builtin.Module' op");
   auto *ctx = module->getContext();
@@ -134,7 +134,6 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
     auto newAttr = replaceSplat(constant.getType(), constant.getValueAttr());
     constant.setValueAttr(newAttr);
   }
-
 
   return success();
 }
@@ -376,7 +375,7 @@ LogicalResult MLIRBench::finalize(bool dumpMLIR) {
   applyPassManagerCLOptions(passManager);
 
   // Apply the default preprocessing pass
-  passManager.addPass(tpp::createDefaultTppPass(tppToLoops));
+  passManager.addPass(tpp::createDefaultTppPass(tppToLoops, linalgToLoops));
 
   // Bufferization, if needed
   passManager.addNestedPass<func::FuncOp>(createTensorBufferizePass());

--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -35,10 +35,13 @@
 
 using namespace mlir;
 
-MLIRBench::MLIRBench(mlir::Operation *op, int seed, bool tppToLoops,
-                     bool linalgToLoops, TensorInitType initType)
-    : builder(op->getContext()), unkLoc(builder.getUnknownLoc()), seed(seed),
-      tppToLoops(tppToLoops), linalgToLoops(linalgToLoops), initType(initType) {
+MLIRBench::MLIRBench(mlir::Operation *op, const MLIRBenchConfig &config)
+    : builder(op->getContext()), unkLoc(builder.getUnknownLoc()) {
+  seed = config.seed;
+  tppToLoops = config.tppToLoops;
+  linalgToLoops = config.linalgToLoops;
+  initType = config.initType;
+
   module = dyn_cast<ModuleOp>(op);
   assert(module && "expected a 'builtin.Module' op");
   auto *ctx = module->getContext();

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -29,6 +29,21 @@ namespace func {
 class FuncOp;
 } // namespace func
 
+// MLIRBench settings that control benchmark code generation and lowering
+// pipeline.
+struct MLIRBenchConfig {
+  MLIRBenchConfig() = default;
+  MLIRBenchConfig(int seed, bool tppToLoops, bool linalgToLoops,
+                  TensorInitType initType)
+      : seed(seed), tppToLoops(tppToLoops), linalgToLoops(linalgToLoops),
+        initType(initType) {}
+
+  int seed = 0;
+  bool tppToLoops = false;
+  bool linalgToLoops = false;
+  TensorInitType initType = TensorInitType::Auto;
+};
+
 /// MLIRBench - Creates wrapper for calling kernel methods.
 ///
 /// Note: This class is a mix between a utility class and a driver
@@ -95,8 +110,7 @@ class MLIRBench {
 
 public:
   /// Creates context, builder
-  MLIRBench(Operation *op, int seed, bool tppToLoops, bool linalgToLoops,
-            TensorInitType initType);
+  MLIRBench(Operation *op, const MLIRBenchConfig &config);
 
   /// Finds the kernel method, checks correct name and shape
   LogicalResult findKernel(llvm::StringRef);

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -66,6 +66,9 @@ class MLIRBench {
   /// Lower TPP to loops for validation purposes
   bool tppToLoops;
 
+  /// Lower linalg to loops for validation purposes
+  bool linalgToLoops;
+
   /// Tensor init type
   TensorInitType initType;
 
@@ -92,7 +95,8 @@ class MLIRBench {
 
 public:
   /// Creates context, builder
-  MLIRBench(Operation *op, int seed, bool tppToLoops, TensorInitType initType);
+  MLIRBench(Operation *op, int seed, bool tppToLoops, bool linalgToLoops,
+            TensorInitType initType);
 
   /// Finds the kernel method, checks correct name and shape
   LogicalResult findKernel(llvm::StringRef);

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -127,8 +127,9 @@ llvm::cl::opt<bool> dumpLLVM("dump-llvm",
 static LogicalResult prepareMLIRKernel(Operation *op,
                                        JitRunnerOptions &options) {
   // Benchmark object
-  MLIRBench bench(op, seed, tppToLoops, linalgToLoops,
-                  parseTensorInitType(initType));
+  MLIRBenchConfig config(seed, tppToLoops, linalgToLoops,
+                         parseTensorInitType(initType));
+  MLIRBench bench(op, config);
 
   // Basic checks
   if (options.mainFuncType != "void")


### PR DESCRIPTION
Adds `linalg-to-loops` option to the default pipeline and `tpp-run` to skip linalg conversion to TPP and go directly to loops for testing and validation purposes.