### PR TITLE
Multiple MLIR dump stages in tpp-run

### DIFF
--- a/test/Integration/tpp-run-splat-memref.mlir
+++ b/test/Integration/tpp-run-splat-memref.mlir
@@ -1,8 +1,8 @@
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early 2>&1 | \
 // RUN: FileCheck %s --check-prefix=SPLAT
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 2>&1 | \
 // RUN: FileCheck %s --check-prefix=RANDOM
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random 2>&1 | \
 // RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
 
 memref.global "private" constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00> {alignment = 128 : i64}

--- a/test/Integration/tpp-run-splat-memref.mlir
+++ b/test/Integration/tpp-run-splat-memref.mlir
@@ -1,8 +1,8 @@
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early | \
 // RUN: FileCheck %s --check-prefix=SPLAT
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 | \
 // RUN: FileCheck %s --check-prefix=RANDOM
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random | \
 // RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
 
 memref.global "private" constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00> {alignment = 128 : i64}

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -1,20 +1,20 @@
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early 2>&1 | \
 // RUN: FileCheck %s --check-prefix=SPLAT
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 2>&1 | \
 // RUN: FileCheck %s --check-prefix=RANDOM
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random 2>&1 | \
 // RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
 
 // Options for -init-type
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=const | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=const 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-CONST
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=simple | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=simple 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-SIMPLE
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=cont | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=cont 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-CONT
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=random | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=random 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-RANDOM
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=normal | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=normal 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-NORMAL
 
 func.func @entry(%input: tensor<4x2xf32>) {

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -1,20 +1,20 @@
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early | \
 // RUN: FileCheck %s --check-prefix=SPLAT
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 | \
 // RUN: FileCheck %s --check-prefix=RANDOM
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random | \
 // RUN: FileCheck %s --check-prefix=RANDOM-SPLAT
 
 // Options for -init-type
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=const 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=const | \
 // RUN: FileCheck %s --check-prefix=OPT-CONST
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=simple 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=simple | \
 // RUN: FileCheck %s --check-prefix=OPT-SIMPLE
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=cont 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=cont | \
 // RUN: FileCheck %s --check-prefix=OPT-CONT
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=random 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=random | \
 // RUN: FileCheck %s --check-prefix=OPT-RANDOM
-// RUN: tpp-run %s -e entry -entry-point-result=void -dump-mlir -seed 123 -splat-to-random -init-type=normal 2>&1 | \
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=normal | \
 // RUN: FileCheck %s --check-prefix=OPT-NORMAL
 
 func.func @entry(%input: tensor<4x2xf32>) {

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -1,0 +1,100 @@
+// Print mlir
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early | FileCheck %s --check-prefix=EARLY
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late  | FileCheck %s --check-prefix=LATE
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=llvm  | FileCheck %s --check-prefix=LLVM
+
+// Loops options (should be the same for both cases in this small example)
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late -tpp-to-loops | FileCheck %s --check-prefix=LOOPS
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late -linalg-to-loops | FileCheck %s --check-prefix=LOOPS
+
+// Benchmark options
+// RUN: tpp-run %s -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=BENCH_PRINT
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 10  | FileCheck %s --check-prefix=BENCH_STATS
+
+// CPU options can't be tested as even the LLVM IR is identical
+// Splat and init options in tpp-run-splat-* tests
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @entry(%A: tensor<4x8xf32>,
+                 %C: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // Weight is defined locally as a dense
+  %B = arith.constant dense<1.0> : tensor<8x4xf32>
+  %D = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                       iterator_types = ["parallel", "parallel", "reduction"]}
+          ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) {
+              ^bb0(%a: f32, %b: f32, %c: f32):
+                %0 = arith.mulf %a, %b : f32
+                %1 = arith.addf %c, %0 : f32
+                linalg.yield %1 : f32
+       } -> tensor<4x4xf32>
+  return %D : tensor<4x4xf32>
+}
+
+// EARLY-LABEL: @_entry
+// EARLY: arith.constant dense<1.000000e+00> : tensor<8x4xf32>
+// EARLY: linalg.generic
+// EARLY:   arith.mulf
+// EARLY:   arith.addf
+// EARLY-LABEL: @entry
+// EARLY: arith.constant dense<1.000000e+00> : tensor<4x8xf32>
+// EARLY: arith.constant dense<1.000000e+00> : tensor<4x4xf32>
+// EARLY: call @_entry({{.*}}) : (tensor<4x8xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+
+
+// LATE-DAG: memref.global "private" constant @__constant_4x4xf32 : memref<4x4xf32> = dense<1.000000e+00> {alignment = 64 : i64}
+// LATE-DAG: memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<1.000000e+00> {alignment = 64 : i64}
+// LATE-DAG: memref.global "private" constant @__constant_8x4xf32 : memref<8x4xf32> = dense<1.000000e+00> {alignment = 64 : i64}
+// LATE-LABEL: @_entry
+// LATE:   memref.get_global @__constant_8x4xf32 : memref<8x4xf32>
+// LATE:   call @xsmm_matmul_dispatch
+// LATE:   memref.cast
+// LATE:   memref.cast
+// LATE:   memref.cast
+// LATE:   call @xsmm_matmul_invoke
+// LATE-DAG: @xsmm_matmul_invoke
+// LATE-DAG: @xsmm_matmul_dispatch
+// LATE-LABEL: @entry
+// LATE:   memref.get_global @__constant_4x8xf32 : memref<4x8xf32>
+// LATE:   memref.get_global @__constant_4x4xf32 : memref<4x4xf32>
+// LATE:   call @_entry({{.*}}) : (memref<4x8xf32>, memref<4x4xf32>) -> ()
+
+
+// LLVM-DAG: llvm.mlir.global private constant @__constant_4x4xf32(dense<1.000000e+00> : tensor<4x4xf32>) {addr_space = 0 : i32, alignment = 64 : i64} : !llvm.array<4 x array<4 x f32>>
+// LLVM-DAG: llvm.mlir.global private constant @__constant_4x8xf32(dense<1.000000e+00> : tensor<4x8xf32>) {addr_space = 0 : i32, alignment = 64 : i64} : !llvm.array<4 x array<8 x f32>>
+// LLVM-DAG: llvm.mlir.global private constant @__constant_8x4xf32(dense<1.000000e+00> : tensor<8x4xf32>) {addr_space = 0 : i32, alignment = 64 : i64} : !llvm.array<8 x array<4 x f32>>
+// LLVM-LABEL: @_entry
+// LLVM:   llvm.call @xsmm_matmul_dispatch
+// LLVM:   llvm.call @xsmm_matmul_invoke
+// LLVM-LABEL: @entry
+// LLVM:   llvm.call @_entry
+
+
+// LOOPS-DAG:  memref.global "private" constant @__constant_4x4xf32 : memref<4x4xf32> = dense<1.000000e+00> {alignment = 64 : i64}
+// LOOPS-DAG:  memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<1.000000e+00> {alignment = 64 : i64}
+// LOOPS-DAG:  memref.global "private" constant @__constant_8x4xf32 : memref<8x4xf32> = dense<1.000000e+00> {alignment = 64 : i64}
+// LOOPS-LABEL: @_entry
+// LOOPS:   memref.get_global @__constant_8x4xf32 : memref<8x4xf32>
+// LOOPS:   cf.cond_br %{{.*}}, [[BODY:.*]], [[LATCH:.*]]
+// LOOPS: [[BODY]]:
+// LOOPS:   memref.load
+// LOOPS:   memref.load
+// LOOPS:   memref.load
+// LOOPS:   arith.mulf
+// LOOPS:   arith.addf
+// LOOPS:   memref.store
+// LOOPS:   arith.addi
+// LOOPS: [[LATCH]]:
+// LOOPS-LABEL: @entry
+// LOOPS:   call @_entry({{.*}}) : (memref<4x8xf32>, memref<4x4xf32>) -> ()
+
+
+// BENCH_PRINT: ( 9, 9, 9, 9 )
+// BENCH_PRINT: ( 9, 9, 9, 9 )
+// BENCH_PRINT: ( 9, 9, 9, 9 )
+// BENCH_PRINT: ( 9, 9, 9, 9 )
+
+
+// BENCH_STATS: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -1,15 +1,15 @@
 // Print mlir
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early | FileCheck %s --check-prefix=EARLY
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late  | FileCheck %s --check-prefix=LATE
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=llvm  | FileCheck %s --check-prefix=LLVM
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early 2>&1 | FileCheck %s --check-prefix=EARLY
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late  2>&1 | FileCheck %s --check-prefix=LATE
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=llvm  2>&1 | FileCheck %s --check-prefix=LLVM
 
 // Loops options (should be the same for both cases in this small example)
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late -tpp-to-loops | FileCheck %s --check-prefix=LOOPS
-// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late -linalg-to-loops | FileCheck %s --check-prefix=LOOPS
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late -tpp-to-loops 2>&1 | FileCheck %s --check-prefix=LOOPS
+// RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=late -linalg-to-loops 2>&1 | FileCheck %s --check-prefix=LOOPS
 
 // Benchmark options
-// RUN: tpp-run %s -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=BENCH_PRINT
-// RUN: tpp-run %s -e entry -entry-point-result=void -n 10  | FileCheck %s --check-prefix=BENCH_STATS
+// RUN: tpp-run %s -e entry -entry-point-result=void -print 2>&1 | FileCheck %s --check-prefix=BENCH_PRINT
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 10  2>&1 | FileCheck %s --check-prefix=BENCH_STATS
 
 // CPU options can't be tested as even the LLVM IR is identical
 // Splat and init options in tpp-run-splat-* tests

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -159,8 +159,17 @@ public:
   /// Prints the result of a kernel call
   LogicalResult printResult(Operation *kernelCall);
 
+  /// Enum to control what to dump when
+  enum class PrintStage {
+    None,
+    Early, // After main generation, before optimization
+    Late,  // After optimizaiton, before LLVM dialect
+    LLVM,  // Final MLIR, in LLVM dialect
+    Invalid,
+  };
+
   /// Terminates the function, issuing a return, lower to LLVM
-  LogicalResult finalize(bool dump);
+  LogicalResult finalize(PrintStage dump);
 
   /// Reports error on the current module's location
   LogicalResult emitError(llvm::Twine);


### PR DESCRIPTION
Allow to dump MLIR from different stages of the compilation process while running it:
 * Early: After main code generation, before optimization
 *  Late: After optimization, before LLVM dialect conversion
 *  LLVM: After LLVM dialect conversion, before LLVM IR lowering

Dumping the LLVM IR is a separate flag and should remain so. For debug purposes we may want to dump both.

Fixes #365