### PR TITLE
Default pipeline - add packing

### DIFF
--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -45,7 +45,7 @@
     "mlir_48x64x96": {
       "type": "MLIR",
       "benchmark": "matmul_48x64x96.mlir",
-      "flags": []
+      "flags": [ "-run-args='-def-pack-matmul=0'" ]
     },
     "ref_64x48x96": {
       "type": "C++",
@@ -55,7 +55,7 @@
     "mlir_64x48x96": {
       "type": "MLIR",
       "benchmark": "matmul_64x48x96.mlir",
-      "flags": []
+      "flags": [ "-run-args='-def-pack-matmul=0'" ]
     },
     "ref_64x64x64": {
       "type": "C++",
@@ -65,7 +65,7 @@
     "mlir_64x64x64": {
       "type": "MLIR",
       "benchmark": "matmul_64x64x64.mlir",
-      "flags": []
+      "flags": [ "-run-args='-def-pack-matmul=0'" ]
     }
   }}
 ]

--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -10,6 +10,16 @@
       "type": "MLIR",
       "benchmark": "mlp-fp32-1layer-512.mlir",
       "flags": []
+    },
+    "matmul_64x64x64_ref": {
+      "type": "C++",
+      "benchmark": "bench_matmul",
+      "flags": [ "--input=64x64x64" ]
+    },
+    "matmul_64x64x64_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul_64x64x64.mlir",
+      "flags": []
     }
   }},
   {
@@ -17,22 +27,22 @@
     "fp32_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-fp32-3layers-1024.mlir",
-      "flags": ["--disable-lsan"]
+      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
     },
     "bf16_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-3layers-1024.mlir",
-      "flags": ["--disable-lsan"]
+      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
     },
     "bf16_10x3584_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-10layers-3584.mlir",
-      "flags": ["--disable-lsan"]
+      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
     },
     "vnni_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-vnni-3layers-1536.mlir",
-      "flags": ["--disable-lsan"]
+      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
     }
   }},
   {
@@ -67,18 +77,5 @@
       "benchmark": "matmul_64x64x64.mlir",
       "flags": [ "-run-args='-def-pack-matmul=0'" ]
     }
-  }},
-  {
-    "def-pipe": {
-      "mlp": {
-        "type": "MLIR",
-        "benchmark": "mlp.mlir",
-        "flags": []
-      },
-      "matmul_64x64x64": {
-        "type": "MLIR",
-        "benchmark": "matmul_64x64x64.mlir",
-        "flags": []
-      }
   }}
 ]

--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -27,12 +27,12 @@
     "fp32_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-fp32-3layers-1024.mlir",
-      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
+      "flags": [ "--disable-lsan" ]
     },
     "bf16_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-3layers-1024.mlir",
-      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
+      "flags": [ "--disable-lsan" ]
     },
     "bf16_10x3584_mlir": {
       "type": "MLIR",
@@ -42,7 +42,7 @@
     "vnni_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-vnni-3layers-1536.mlir",
-      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
+      "flags": [ "--disable-lsan" ]
     }
   }},
   {

--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -67,5 +67,18 @@
       "benchmark": "matmul_64x64x64.mlir",
       "flags": [ "-run-args='-def-pack-matmul=0'" ]
     }
+  }},
+  {
+    "def-pipe": {
+      "mlp": {
+        "type": "MLIR",
+        "benchmark": "mlp.mlir",
+        "flags": []
+      },
+      "matmul_64x64x64": {
+        "type": "MLIR",
+        "benchmark": "matmul_64x64x64.mlir",
+        "flags": []
+      }
   }}
 ]

--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -27,17 +27,17 @@
     "fp32_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-fp32-3layers-1024.mlir",
-      "flags": [ "--disable-lsan" ]
+      "flags": []
     },
     "bf16_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-3layers-1024.mlir",
-      "flags": [ "--disable-lsan" ]
+      "flags": []
     },
     "bf16_10x3584_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-10layers-3584.mlir",
-      "flags": [ "--disable-lsan", "-run-args='-def-pack-matmul=0'" ]
+      "flags": [ "-run-args='-def-pack-matmul=0'" ]
     },
     "vnni_3x1024_mlir": {
       "type": "MLIR",

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -101,7 +101,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createCleanupPass();
 std::unique_ptr<OperationPass<ModuleOp>> createTransformPass();
 std::unique_ptr<OperationPass<ModuleOp>> createLocalDialectsLoweringPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPostprocessingPass();
-std::unique_ptr<OperationPass<func::FuncOp>> createTppMappingPass();
+std::unique_ptr<OperationPass<ModuleOp>> createTppMappingPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createTppConversionPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createTppLoweringPass(bool loops = false);

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -78,8 +78,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createTransformDropSchedulePass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPackVNNIPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createPackMatmulPass(ArrayRef<int64_t> blockingFactors = {});
-std::unique_ptr<OperationPass<func::FuncOp>> createPackConv2DNchwFchwPass();
-std::unique_ptr<OperationPass<func::FuncOp>> createPackConv2DNhwcHwcfPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createPackConv2DNchwFchwPass(ArrayRef<int64_t> blockingFactors = {});
+std::unique_ptr<OperationPass<func::FuncOp>>
+createPackConv2DNhwcHwcfPass(ArrayRef<int64_t> blockingFactors = {});
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteToBatchReduceGemmPass();
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -76,7 +76,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createConvertPerfToLoopsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createConvertPerfToFuncPass();
 std::unique_ptr<OperationPass<ModuleOp>> createTransformDropSchedulePass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPackVNNIPass();
-std::unique_ptr<OperationPass<func::FuncOp>> createPackMatmulPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createPackMatmulPass(ArrayRef<int64_t> blockingFactors = {});
 std::unique_ptr<OperationPass<func::FuncOp>> createPackConv2DNchwFchwPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPackConv2DNhwcHwcfPass();
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -321,7 +321,7 @@ def Postprocessing : Pass<"postprocess", "func::FuncOp"> {
   let constructor = "mlir::tpp::createPostprocessingPass()";
 }
 
-def TppMapping : Pass<"tpp-mapping", "func::FuncOp"> {
+def TppMapping : Pass<"tpp-mapping", "ModuleOp"> {
   let summary = "Map operations to be TPP compatible";
   let description = [{
     Apply collection of TPP rewriting passes to map eligble operations

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -226,7 +226,6 @@ def RewriteConvToMatmulOrBrgemm : Pass<"rewrite-conv-to-matmul-or-brgemm",
 
 def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
   let summary = "Collection of default TPP passes";
-  let constructor = "mlir::tpp::createDefaultTppPass()";
   let description = [{
     A collection of passes that lower everything TPP-related
     to standard low-level dialects.
@@ -239,6 +238,7 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
            "bool", /*default=*/"0",
            "Skip all TPP transformations. Lower linalg directly to loops.">,
   ];
+  let constructor = "mlir::tpp::createDefaultTppPass()";
 }
 
 def GeneralizeTensorPackAndUnPack : Pass<"generalize-tensor-pack-unpack",
@@ -344,12 +344,12 @@ def TppLowering : Pass<"tpp-lowering", "func::FuncOp"> {
     Lower all TPP operations into combination of operations from
     standard and local dialects.
   }];
-  let constructor = "mlir::tpp::createTppLoweringPass()";
   let options= [
     Option<"tppToLoops", "tpp-to-loops",
            "bool", /*default=*/"0",
            "By default TPP ops are lowered to XSMM. Lower TPP to loops instead.">,
   ];
+  let constructor = "mlir::tpp::createTppLoweringPass()";
 }
 
 def ConvertForAllToParallelOp : Pass<"convert-forall-to-parallel", 

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -265,6 +265,9 @@ private:
 
     // Generalize tensor.pack and tensor.unpack.
     pm.addPass(createGeneralizeTensorPackAndUnPackPass());
+
+    // Final clenaup after all the mapping.
+    pm.addPass(createCleanupPass());
   }
 };
 
@@ -410,11 +413,11 @@ private:
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
       pm.addPass(createBufferizePass());
-    // Convert generics to BRGEMM.
-    // The mapping is done after bufferization as the buffer semantics
-    // allow direct use of scf.parallel loops. This prevents different
-    // lowering outputs between input linalg on tensors and memrefs.
-    pm.addNestedPass<func::FuncOp>(createRewriteToBatchReduceGemmPass());
+      // Convert generics to BRGEMM.
+      // The mapping is done after bufferization as the buffer semantics
+      // allow direct use of scf.parallel loops. This prevents different
+      // lowering outputs between input linalg on tensors and memrefs.
+      pm.addNestedPass<func::FuncOp>(createRewriteToBatchReduceGemmPass());
 
       // Lower operations to TPP.
       pm.addNestedPass<func::FuncOp>(createTppConversionPass());

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -235,6 +235,7 @@ private:
 
     pm.addPass(createTileConsumerAndFuseProducersPass());
     // Preprocess convolutions.
+    pm.addPass(createPackConv2DNchwFchwPass({32, 32}));
     pm.addPass(createRewriteConvToMatmulOrBrgemmPass());
 
     // Pack matmuls.

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -24,10 +24,16 @@
 #include "TPP/Dialect/VNNI/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/VNNI/VNNIDialect.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
 using namespace mlir::tpp;
+
+// Extra command line options to control the default TPP utility passes.
+llvm::cl::opt<bool> packMatmul("def-pack-matmul",
+                               llvm::cl::desc("Default pipeline - pack matmul"),
+                               llvm::cl::init(true));
 
 #define GEN_PASS_CLASSES
 #include "TPP/Passes.h.inc"
@@ -241,7 +247,8 @@ private:
     pm.addPass(createRewriteConvToMatmulOrBrgemmPass());
 
     // Convert ops to packed layouts.
-    pm.addPass(createPackMatmulPass({32, 32, 32}));
+    if (packMatmul)
+      pm.addPass(createPackMatmulPass({32, 32, 32}));
     pm.addPass(createPackVNNIPass());
 
     // Postprocess packing.

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -235,6 +235,7 @@ private:
 
     pm.addPass(createTileConsumerAndFuseProducersPass());
     // Preprocess convolutions.
+    pm.addPass(createPackConv2DNhwcHwcfPass({32, 32}));
     pm.addPass(createPackConv2DNchwFchwPass({32, 32}));
     pm.addPass(createRewriteConvToMatmulOrBrgemmPass());
 

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -234,6 +234,8 @@ private:
     pm.clear();
 
     // Preprocess convolutions.
+    pm.addPass(createConvInitSimplifyPass());
+    pm.addPass(createCleanupPass());
     pm.addPass(createPackConv2DNhwcHwcfPass({32, 32}));
     pm.addPass(createPackConv2DNchwFchwPass({32, 32}));
     pm.addPass(createRewriteConvToMatmulOrBrgemmPass());

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -202,7 +202,7 @@ private:
 // Apply collection of high-level passes that map operations to
 // TPP-compatible forms.
 struct TppMappingPass : public TppMappingBase<TppMappingPass>,
-                        UtilityPassBase<func::FuncOp> {
+                        UtilityPassBase<ModuleOp> {
   void getDependentDialects(DialectRegistry &registry) const override {
     // clang-format off
     registry
@@ -397,7 +397,7 @@ private:
     } else {
       // Lower IR through TPP operations.
       // Transform operations to be TPP compatible.
-      pm.addNestedPass<func::FuncOp>(createTppMappingPass());
+      pm.addPass(createTppMappingPass());
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
       pm.addPass(createBufferizePass());
@@ -444,7 +444,7 @@ mlir::tpp::createPostprocessingPass() {
   return std::make_unique<PostprocessingPass>();
 }
 
-std::unique_ptr<OperationPass<func::FuncOp>> mlir::tpp::createTppMappingPass() {
+std::unique_ptr<OperationPass<ModuleOp>> mlir::tpp::createTppMappingPass() {
   return std::make_unique<TppMappingPass>();
 }
 

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -237,6 +237,9 @@ private:
     // Preprocess convolutions.
     pm.addPass(createRewriteConvToMatmulOrBrgemmPass());
 
+    // Pack matmuls.
+    pm.addPass(createPackMatmulPass({32, 32, 32}));
+
     // Map ops to VNNI layout.
     pm.addPass(createPackVNNIPass());
 

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -237,6 +237,9 @@ private:
     // Preprocess convolutions.
     pm.addPass(createRewriteConvToMatmulOrBrgemmPass());
 
+    // Map ops to VNNI layout.
+    pm.addPass(createPackVNNIPass());
+
     // Generalize tensor.pack and tensor.unpack.
     pm.addPass(createGeneralizeTensorPackAndUnPackPass());
   }

--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -485,7 +485,11 @@ mlir::linalgx::packVNNIMatmulOp(RewriterBase &rewriter,
         /*doc=*/"", /*libraryCall=*/"");
 
   } else {
-    assert(matmulOp.getInputs()[1].getType().cast<ShapedType>().getRank() == 3);
+    // TODO: validate operands earlier
+    if (matmulOp.getInputs()[1].getType().cast<ShapedType>().getRank() != 3)
+      return rewriter.notifyMatchFailure(matmulOp,
+                                         "invalid second operand shape");
+
     dims = 5;
     bindDims(ctx, r1, r3, p3, p4, r2);
     mapA = AffineMap::get(dims, /*symbols=*/0, {r1, p3, r2}, ctx);

--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -794,13 +794,13 @@ mlir::tpp::createPackMatmulPass(ArrayRef<int64_t> blockingFactors) {
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::tpp::createPackConv2DNchwFchwPass() {
-  return std::make_unique<PackConv2DNchwFchw>();
+mlir::tpp::createPackConv2DNchwFchwPass(ArrayRef<int64_t> blockingFactors) {
+  return std::make_unique<PackConv2DNchwFchw>(blockingFactors);
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::tpp::createPackConv2DNhwcHwcfPass() {
-  return std::make_unique<PackConv2DNhwcHwcf>();
+mlir::tpp::createPackConv2DNhwcHwcfPass(ArrayRef<int64_t> blockingFactors) {
+  return std::make_unique<PackConv2DNhwcHwcf>(blockingFactors);
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>> mlir::tpp::createPackVNNIPass() {

--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -788,8 +788,9 @@ void mlir::tpp::populateSinkPackPatterns(RewritePatternSet &patterns) {
   patterns.add<BubbleUpThroughFillOp>(patterns.getContext());
 }
 
-std::unique_ptr<OperationPass<func::FuncOp>> mlir::tpp::createPackMatmulPass() {
-  return std::make_unique<PackMatmul>();
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createPackMatmulPass(ArrayRef<int64_t> blockingFactors) {
+  return std::make_unique<PackMatmul>(blockingFactors);
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/test/Benchmarks/mlp-bf16-10layers-3584.mlir
+++ b/test/Benchmarks/mlp-bf16-10layers-3584.mlir
@@ -1,4 +1,3 @@
-// RUN: tpp-opt %s -element-wise-fusion -tile-consumer-and-fuse-producers="tile-sizes=1,1 max-depth=2" |
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 

--- a/test/Benchmarks/mlp-bf16-10layers-3584.mlir
+++ b/test/Benchmarks/mlp-bf16-10layers-3584.mlir
@@ -1,9 +1,6 @@
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 
-// This benchmark isn't expected to "pass", just run as benchmark for now
-// XFAIL: *
-//
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 10
 // 2*256x3584x3584 (6576668672) + 256x3584 (917504) + 256x3584 (917504) x 10 = 13,158,842,368
 // BENCH_TOTAL_FLOPS: 13158842368

--- a/test/Benchmarks/mlp-bf16-3layers-1024.mlir
+++ b/test/Benchmarks/mlp-bf16-3layers-1024.mlir
@@ -1,4 +1,3 @@
-// RUN: tpp-opt %s -element-wise-fusion -tile-consumer-and-fuse-producers="tile-sizes=1,1 max-depth=2" |
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 

--- a/test/Benchmarks/mlp-bf16-3layers-1024.mlir
+++ b/test/Benchmarks/mlp-bf16-3layers-1024.mlir
@@ -1,9 +1,6 @@
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 
-// This benchmark isn't expected to "pass", just run as benchmark for now
-// XFAIL: *
-//
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3
 // 2*256x1024x1024 (536870912) + 256x1024 (262144) + 256x1024 262144) x 3 = 1,072,168,960
 // BENCH_TOTAL_FLOPS: 1072168960

--- a/test/Benchmarks/mlp-fp32-3layers-1024.mlir
+++ b/test/Benchmarks/mlp-fp32-3layers-1024.mlir
@@ -1,9 +1,6 @@
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 
-// This benchmark isn't expected to "pass", just run as benchmark for now
-// XFAIL: *
-//
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3
 // 2*256x1024x1024 (536870912) + 256x1024 (262144) + 256x1024 262144) x 3 = 1,072,168,960
 // BENCH_TOTAL_FLOPS: 1072168960

--- a/test/Benchmarks/mlp-fp32-3layers-1024.mlir
+++ b/test/Benchmarks/mlp-fp32-3layers-1024.mlir
@@ -1,4 +1,3 @@
-// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,1 max-depth=2" |
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 

--- a/test/Benchmarks/mlp-vnni-3layers-1536.mlir
+++ b/test/Benchmarks/mlp-vnni-3layers-1536.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -element-wise-fusion -tile-consumer-and-fuse-producers="tile-sizes=1,1 max-depth=2" |
+// RUN: tpp-opt %s -element-wise-fusion |
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -950,81 +950,57 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK:   linalg.generic
-// CHECK: %[[xsmmDis22:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis30:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis22]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
-// CHECK: %[[xsmmDis23:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis31:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis23]]
-// CHECK: %[[xsmmDis24:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis31]]
+// CHECK: %[[xsmmDis32:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis24]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
-// CHECK: %[[xsmmDis25:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis33:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis25]]
-// CHECK: %[[xsmmDis26:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis33]]
+// CHECK: %[[xsmmDis34:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis26]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis34]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
-// CHECK: %[[xsmmDis27:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis35:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis27]]
-// CHECK: %[[xsmmDis28:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis35]]
+// CHECK: %[[xsmmDis36:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis28]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis36]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis26]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis34]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
-// CHECK: %[[xsmmDis29:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis37:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis29]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis37]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
 // CHECK:     linalg.transpose
+// CHECK: %[[xsmmDis38:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:   linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: %[[xsmmDis30:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
-// CHECK: scf.parallel
-// CHECK:   linalg.generic
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.parallel
-// CHECK:   linalg.generic
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:   linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
-// CHECK: %[[xsmmDis31:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis31]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
@@ -1035,11 +1011,27 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK: %[[xsmmDis39:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis31]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis39]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis39]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c29]] step %[[c1]] {
@@ -1049,21 +1041,13 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK:       linalg.transpose
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
+// CHECK: %[[xsmmDis40:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: %[[xsmmDis32:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
@@ -1074,18 +1058,16 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
 // CHECK:       linalg.transpose
-// CHECK: %[[xsmmDis33:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis41:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis33]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis41]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
@@ -1096,12 +1078,12 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
-// CHECK: %[[xsmmDis34:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
+// CHECK: %[[xsmmDis42:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis42]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
@@ -1112,11 +1094,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis42]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
@@ -1127,19 +1109,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
@@ -1150,18 +1124,16 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
 // CHECK:       linalg.transpose
-// CHECK: %[[xsmmDis35:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis43:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis35]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis43]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
@@ -1172,11 +1144,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis42]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis40]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c15]] step %[[c1]] {
@@ -1186,21 +1158,13 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK:       linalg.transpose
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
+// CHECK: %[[xsmmDis44:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: %[[xsmmDis36:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c9]] step %[[c1]] {
@@ -1211,18 +1175,16 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
 // CHECK:       linalg.transpose
-// CHECK: %[[xsmmDis37:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis45:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis37]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis45]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c9]] step %[[c1]] {
@@ -1233,12 +1195,12 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
-// CHECK: %[[xsmmDis38:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
+// CHECK: %[[xsmmDis46:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis46]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c9]] step %[[c1]] {
@@ -1249,22 +1211,20 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c10]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c10]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c40]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c40]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis44]]
 // CHECK: scf.parallel
 // CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
 // CHECK:       linalg.transpose
 // CHECK: linalg.pooling_nhwc_sum
-// CHECK: %[[xsmmDis39:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis39]]
-// CHECK: %[[xsmmDis40:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis40]]
+// CHECK: linalg.generic
+// CHECK: linalg.generic
+// CHECK: %[[xsmmDis47:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis47]]
+// CHECK: %[[xsmmDis48:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis48]]
 //
 // No more XSMM dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -893,10 +893,10 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
   return %collapsed_51 : tensor<1x1001xf32>
 }
 
-// CHECK-DAG: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 
-// CHECK-DAG: func.func private @xsmm_matmul_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_matmul_dispatch(i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK-DAG: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_matmul_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_matmul_dispatch(i64, i1, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
 //
 // CHECK-LABEL: @mobilenet(
 // CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1001xf32> {
@@ -915,156 +915,356 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK-DAG: %[[c144_i64:.+]] = arith.constant 144 : i64
 // CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c28_i64:.+]] = arith.constant 28 : i64
-// CHECK-DAG: %[[c192_i64:.+]] = arith.constant 192 : i64
 // CHECK-DAG: %[[c14_i64:.+]] = arith.constant 14 : i64
 // CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
-// CHECK-DAG: %[[c384_i64:.+]] = arith.constant 384 : i64
-// CHECK-DAG: %[[c576_i64:.+]] = arith.constant 576 : i64
 // CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
 // CHECK-DAG: %[[c160_i64:.+]] = arith.constant 160 : i64
-// CHECK-DAG: %[[c960_i64:.+]] = arith.constant 960 : i64
-// CHECK-DAG: %[[c320_i64:.+]] = arith.constant 320 : i64
-// CHECK-DAG: %[[c1280_i64:.+]] = arith.constant 1280 : i64
 // CHECK-DAG: %[[c1001_i64:.+]] = arith.constant 1001 : i64
+// CHECK-DAG: %[[c1280_i64:.+]] = arith.constant 1280 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[c224:.+]] = arith.constant 224 : index
 // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[c112:.+]] = arith.constant 112 : index
 // CHECK-DAG: %[[c56:.+]] = arith.constant 56 : index
 // CHECK-DAG: %[[c28:.+]] = arith.constant 28 : index
+// CHECK-DAG: %[[c6:.+]] = arith.constant 6 : index
 // CHECK-DAG: %[[c14:.+]] = arith.constant 14 : index
-// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c12:.+]] = arith.constant 12 : index
+// CHECK-DAG: %[[c2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[c18:.+]] = arith.constant 18 : index
 // CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
+// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[c30:.+]] = arith.constant 30 : index
+// CHECK-DAG: %[[c5:.+]] = arith.constant 5 : index
+// CHECK-DAG: %[[c40:.+]] = arith.constant 40 : index
+// CHECK-DAG: %[[c10:.+]] = arith.constant 10 : index
+// CHECK-DAG: %[[c29:.+]] = arith.constant 29 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c15:.+]] = arith.constant 15 : index
+// CHECK-DAG: %[[c9:.+]] = arith.constant 9 : index
 //
 // Check all XSMM calls
-// CHECK: %[[xsmmDis34:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK:   linalg.generic
+// CHECK: %[[xsmmDis22:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis22]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis35:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: %[[xsmmDis23:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis35]]
-// CHECK: %[[xsmmDis36:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis23]]
+// CHECK: %[[xsmmDis24:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis24]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis37:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: %[[xsmmDis25:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis37]]
-// CHECK: %[[xsmmDis38:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis25]]
+// CHECK: %[[xsmmDis26:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis26]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis39:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: %[[xsmmDis27:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis39]]
-// CHECK: %[[xsmmDis40:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis40]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis27]]
+// CHECK: %[[xsmmDis28:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis28]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis26]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis41:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: %[[xsmmDis29:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis41]]
-// CHECK: %[[xsmmDis42:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis29]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis42]]
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:   linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis30:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis43:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:   linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis43]]
-// CHECK: %[[xsmmDis44:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis44]]
+// CHECK:     linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis42]]
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK: %[[xsmmDis31:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis31]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis43]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis44]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis42]]
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis31]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis30]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c29]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis45:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c64_i64]], %[[c192_i64]], %[[c192_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c6]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis32:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis45]]
-// CHECK: %[[xsmmDis46:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis46]]
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis47:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis47]]
-// CHECK: %[[xsmmDis48:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis48]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis46]]
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis33:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis33]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis47]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis48]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis46]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: %[[xsmmDis34:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis47]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis48]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis46]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis49:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c96_i64]], %[[c384_i64]], %[[c384_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c12]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis49]]
-// CHECK: %[[xsmmDis50:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis50]]
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis51:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis51]]
-// CHECK: %[[xsmmDis52:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis52]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis50]]
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis35:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis35]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis51]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis52]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis50]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c3]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis34]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis32]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c15]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis53:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c160_i64]], %[[c576_i64]], %[[c576_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c18]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis36:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis53]]
-// CHECK: %[[xsmmDis54:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis54]]
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c9]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis55:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis55]]
-// CHECK: %[[xsmmDis56:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis56]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis54]]
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis37:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis37]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c9]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis55]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis56]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis54]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c5]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK: %[[xsmmDis38:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis38]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c9]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
-// CHECK: %[[xsmmDis57:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c320_i64]], %[[c960_i64]], %[[c960_i64]], %[[c320_i64]], %[[c320_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c30]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c10]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c10]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c40]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c40]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis36]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis57]]
-// CHECK: %[[xsmmDis58:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c1280_i64]], %[[c320_i64]], %[[c320_i64]], %[[c1280_i64]], %[[c1280_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis58]]
+// CHECK:       linalg.transpose
 // CHECK: linalg.pooling_nhwc_sum
-// CHECK: %[[xsmmDis59:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis59]]
-// CHECK: %[[xsmmDis60:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis60]]
+// CHECK: %[[xsmmDis39:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis39]]
+// CHECK: %[[xsmmDis40:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis40]]
 //
 // No more XSMM dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -292,74 +292,73 @@ func.func @multi_head_attention(
 // Check all XSMM calls
 // CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: %[[xsmmDis10:.+]] = call @xsmm_brgemm_dispatch(%[[c1_i64]], %[[false]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis11:.+]] = call @xsmm_brgemm_dispatch(%[[c1_i64]], %[[false]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis11]]
 // CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
 // CHECK:     linalg.transpose
-// CHECK: %[[xsmmDis11:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis12:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
-// CHECK: %[[xsmmDis12:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: %[[xsmmDis13:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis13]]
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis11]]
 // CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
 // CHECK:     linalg.transpose
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis12]]
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis13]]
 // CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK:   linalg.generic
 // CHECK: scf.parallel
+// CHECK:   linalg.generic
 // CHECK: scf.parallel
-// CHECK: linalg.batch_matmul
-// CHECK: %[[xsmmDis13:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   linalg.generic
+// CHECK: %[[xsmmDis14:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
-// CHECK: %[[xsmmDis14:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis14]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis14]]
+// CHECK: %[[xsmmDis15:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis14]]
-// CHECK: %[[xsmmDis15:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
-// CHECK: scf.parallel
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
-// CHECK: scf.parallel
-// CHECK: linalg.batch_matmul
-// CHECK: scf.parallel
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
-// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: %[[xsmmDis16:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis15]]
+// CHECK: linalg.generic
+// CHECK: %[[xsmmDis16:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis16]]
-// CHECK: %[[xsmmDis17:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   linalg.generic
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis17]]
+// CHECK:   linalg.generic
+// CHECK: linalg.generic
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis16]]
+// CHECK:   linalg.generic
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis13]]
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.parallel
+// CHECK:   linalg.generic
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: %[[xsmmDis17:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis17]]
+// CHECK: %[[xsmmDis18:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis18]]
 //
 // No more XSMM dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -263,12 +263,12 @@ func.func @multi_head_attention(
     return %ret : !tensor_print_t
 }
 
-// CHECK-DAG: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 
-// CHECK-DAG: func.func private @xsmm_unary_invoke(i64, i64, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK-DAG: func.func private @xsmm_matmul_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_matmul_dispatch(i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK-DAG: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_unary_invoke(i64, i64, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_brgemm_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>, i64) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_brgemm_dispatch(i64, i1, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
 //
 // CHECK-LABEL: @multi_head_attention(
 // CHECK-SAME: %[[arg:.*]]: memref<32x8x128xf32>, %[[arg1:.*]]: memref<1x8xf32>) {
@@ -276,45 +276,90 @@ func.func @multi_head_attention(
 // Constant definitions
 // CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
 // CHECK-DAG: %[[false:.+]] = arith.constant false
-// CHECK-DAG: %[[c256_i64:.+]] = arith.constant 256 : i64
-// CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
 // CHECK-DAG: %[[c2_i64:.+]] = arith.constant 2 : i64
 // CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
 // CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c8_i64:.+]] = arith.constant 8 : i64
 // CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG: %[[cst_0:.+]] = arith.constant -0.000000e+00 : f32
-// CHECK-DAG: %[[cst_1:.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[c4:.+]] = arith.constant 4 : index
+// CHECK-DAG: %[[c256:.+]] = arith.constant 256 : index
 //
 // Check all XSMM calls
-// CHECK: %[[xsmmDis10:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c256_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: %[[xsmmDis10:.+]] = call @xsmm_brgemm_dispatch(%[[c1_i64]], %[[false]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
+// CHECK:     linalg.transpose
 // CHECK: %[[xsmmDis11:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
 // CHECK: %[[xsmmDis12:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: scf.parallel
+// CHECK: scf.parallel
+// CHECK: scf.parallel
 // CHECK: linalg.batch_matmul
 // CHECK: %[[xsmmDis13:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
 // CHECK: %[[xsmmDis14:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis14]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis14]]
 // CHECK: %[[xsmmDis15:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
+// CHECK: scf.parallel
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: scf.parallel
 // CHECK: linalg.batch_matmul
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: scf.parallel
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_brgemm_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: scf.for %[[arg2:.+]] = %[[c0]] to %[[c256]] step %[[c1]] {
+// CHECK:     linalg.transpose
 // CHECK: %[[xsmmDis16:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis16]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis16]]
 // CHECK: %[[xsmmDis17:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis17]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis17]]
 //
 // No more XSMM dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_

--- a/test/Models/resnet50-bottleneck-block.mlir
+++ b/test/Models/resnet50-bottleneck-block.mlir
@@ -110,7 +110,6 @@ func.func @first_conv2d_1x1_biasadd_relu(
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis2]]
 // CHECK:       linalg.transpose
 // CHECK:       linalg.transpose
-// CHECK-NOT:       linalg.transpose
 // CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
@@ -118,7 +117,6 @@ func.func @first_conv2d_1x1_biasadd_relu(
 // CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
 // CHECK:       linalg.transpose
-// CHECK-NOT:       linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //
@@ -201,7 +199,6 @@ func.func @conv2d_3x3_biasadd_relu(
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis2]]
 // CHECK:       linalg.transpose
 // CHECK:       linalg.transpose
-// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
@@ -209,7 +206,6 @@ func.func @conv2d_3x3_biasadd_relu(
 // CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
 // CHECK:       linalg.transpose
-// CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //
@@ -294,7 +290,6 @@ func.func @second_conv2d_1x1_biasadd_relu(
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis2]]
 // CHECK:       linalg.transpose
 // CHECK:       linalg.transpose
-// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
@@ -302,7 +297,6 @@ func.func @second_conv2d_1x1_biasadd_relu(
 // CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
 // CHECK:       linalg.transpose
-// CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //

--- a/test/Models/resnet50-bottleneck-block.mlir
+++ b/test/Models/resnet50-bottleneck-block.mlir
@@ -97,6 +97,7 @@ func.func @first_conv2d_1x1_biasadd_relu(
 // CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
 // CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
 // CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c5_i64:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
 // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
@@ -104,24 +105,22 @@ func.func @first_conv2d_1x1_biasadd_relu(
 // CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[c512:.+]] = arith.constant 512 : index
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK: linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK: %[[xsmmDis2:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
-// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis2]]
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
-// CHECK: %[[xsmmDis5:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis5]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK: %[[xsmmDis5:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis5]]
+// CHECK: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //
@@ -200,22 +199,22 @@ func.func @conv2d_3x3_biasadd_relu(
 // CHECK-DAG: %[[c512:.+]] = arith.constant 512 : index
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK: %[[xsmmDis2:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:         linalg.transpose
-// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
-// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis2]]
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
-// CHECK: %[[xsmmDis5:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis5]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK: %[[xsmmDis5:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis5]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
 // CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //
@@ -296,22 +295,22 @@ func.func @second_conv2d_1x1_biasadd_relu(
 // CHECK-DAG: %[[c2048:.+]] = arith.constant 2048 : index
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK: %[[xsmmDis2:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
-// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis2]]
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
-// CHECK: %[[xsmmDis5:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis5]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK: %[[xsmmDis5:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis5]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
 // CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //

--- a/test/Models/resnet50-bottleneck-block.mlir
+++ b/test/Models/resnet50-bottleneck-block.mlir
@@ -92,35 +92,33 @@ func.func @first_conv2d_1x1_biasadd_relu(
 // CHECK-LABEL: @first_conv2d_1x1_biasadd_relu(
 // CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
 // CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
-// CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
-// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c512_i64:.+]] = arith.constant 512 : i64
 // CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
-// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
 // CHECK-DAG: %[[c5_i64:.+]] = arith.constant 5 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
-// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
 // CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[c512:.+]] = arith.constant 512 : index
-// CHECK: linalg.transpose
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis2:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis2:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis2]]
+// CHECK:       linalg.transpose
+// CHECK:       linalg.transpose
+// CHECK-NOT:       linalg.transpose
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis2]]
-// CHECK: %[[xsmmDis3:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis3]]
-// CHECK: %[[xsmmDis4:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis4]]
-// CHECK: %[[xsmmDis5:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis5]]
-// CHECK: linalg.transpose
-// CHECK-NOT: linalg.transpose
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK:       linalg.transpose
+// CHECK-NOT:       linalg.transpose
 // CHECK-NOT: call @xsmm_
 // CHECK: return
 //
@@ -184,35 +182,32 @@ func.func @conv2d_3x3_biasadd_relu(
 // CHECK-LABEL: @conv2d_3x3_biasadd_relu(
 // CHECK-SAME: %[[arg:.*]]: memref<1x9x9x512xf32>) -> memref<1x7x7x512xf32> {
 // CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
-// CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
-// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c512_i64:.+]] = arith.constant 512 : i64
 // CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c5_i64:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
-// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
 // CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
-// CHECK-DAG: %[[c9:.+]] = arith.constant 9 : index
 // CHECK-DAG: %[[c512:.+]] = arith.constant 512 : index
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK-DAG: %[[c9:.+]] = arith.constant 9 : index
+// CHECK: %[[xsmmDis2:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis2]]
+// CHECK:       linalg.transpose
 // CHECK:       linalg.transpose
 // CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis2:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis2]]
-// CHECK: %[[xsmmDis3:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis3]]
-// CHECK: %[[xsmmDis4:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis4]]
-// CHECK: %[[xsmmDis5:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis5]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
 // CHECK:       linalg.transpose
 // CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_
@@ -281,34 +276,31 @@ func.func @second_conv2d_1x1_biasadd_relu(
 // CHECK-LABEL: @second_conv2d_1x1_biasadd_relu(
 // CHECK-SAME: %[[arg:.*]]: memref<1x7x7x512xf32>) -> memref<1x7x7x2048xf32> {
 // CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
-// CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
-// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c2048_i64:.+]] = arith.constant 2048 : i64
 // CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c5_i64:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
-// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
 // CHECK-DAG: %[[c2048:.+]] = arith.constant 2048 : index
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK: %[[xsmmDis2:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis2]]
+// CHECK:       linalg.transpose
 // CHECK:       linalg.transpose
 // CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis2:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis2]]
-// CHECK: %[[xsmmDis3:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis3]]
-// CHECK: %[[xsmmDis4:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis4]]
-// CHECK: %[[xsmmDis5:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.parallel
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis5]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
 // CHECK:       linalg.transpose
 // CHECK-NOT: linalg.transpose
 // CHECK-NOT: call @xsmm_

--- a/test/Models/resnet50-bottleneck-block.mlir
+++ b/test/Models/resnet50-bottleneck-block.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes -expand-strided-metadata | \
-// RUN: FileCheck %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck %s
 
 // RUN: tpp-run %s -n 10 \
 // RUN:         -print -e resnet50_bottleneck_block -entry-point-result=void | \
@@ -33,26 +32,8 @@
 #map_print = affine_map<(d0, d1) -> (d0, d1)>
 !tensor_print_t = tensor<1x8xf32>
 
-//
-// CHECK-LABEL: @first_conv2d_1x1_biasadd_relu(
-// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
-//
 func.func @first_conv2d_1x1_biasadd_relu(
         %input : !first_conv1x1_input_tensor_t) -> !first_conv1x1_output_tensor_t {
-    //
-    // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
-    // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
-    // CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
-    // CHECK-DAG: %[[false:.*]] = arith.constant false
-    // CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
-    // CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
-    // CHECK-DAG: %[[c4_i64:.*]] = arith.constant 4 : i64
-    // CHECK-DAG: %[[c5_i64:.*]] = arith.constant 5 : i64
-    // CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
-    // CHECK-DAG: %[[c512_i64:.*]] = arith.constant 512 : i64
-    // CHECK-DAG: %[[c2048_i64:.*]] = arith.constant 2048 : i64
-    //
-
     %cst_0 = arith.constant 0.000000e+00 : f32
     %cst_9 = arith.constant dense<0.000000e+00> : !first_conv1x1_output_tensor_t
 
@@ -67,15 +48,6 @@ func.func @first_conv2d_1x1_biasadd_relu(
                 ins(%input, %filter : !first_conv1x1_input_tensor_t, !first_conv1x1_filter_tensor_t) 
                 outs(%1 : !first_conv1x1_output_tensor_t) -> !first_conv1x1_output_tensor_t
     
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.for
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
     // BiasAdd
     %3 = tensor.empty() : !first_conv1x1_output_tensor_t
     %4 = linalg.generic {
@@ -88,14 +60,6 @@ func.func @first_conv2d_1x1_biasadd_relu(
             linalg.yield %in : f32
     } -> !first_conv1x1_output_tensor_t
 
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]]) : (i64, i64, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
     %5 = tensor.empty() : !first_conv1x1_output_tensor_t
     %6 = linalg.generic {
             indexing_maps = [#map1, #map1, #map1], 
@@ -107,15 +71,6 @@ func.func @first_conv2d_1x1_biasadd_relu(
             %1591 = arith.addf %in, %in_34 : f32
             linalg.yield %1591 : f32
     } -> !first_conv1x1_output_tensor_t
-
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
 
     // ReLU
     %7 = tensor.empty() : !first_conv1x1_output_tensor_t
@@ -130,39 +85,49 @@ func.func @first_conv2d_1x1_biasadd_relu(
                 linalg.yield %1591 : f32
     } -> !first_conv1x1_output_tensor_t
 
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
-    //
-    // CHECK: return %[[alloc_12:.*]] : memref<1x7x7x512xf32>
-    //
     return %8 : !first_conv1x1_output_tensor_t
 }
 
 //
-// CHECK-LABEL: @conv2d_3x3_biasadd_relu(
-// CHECK-SAME: %[[arg:.*]]: memref<1x9x9x512xf32>) -> memref<1x7x7x512xf32> {
+// CHECK-LABEL: @first_conv2d_1x1_biasadd_relu(
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
+// CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[c512:.+]] = arith.constant 512 : index
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK: %[[xsmmDis5:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis5]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK-NOT: call @xsmm_
+// CHECK: return
 //
+
 func.func @conv2d_3x3_biasadd_relu(
         %input : !conv3x3_input_tensor_t) -> !conv3x3_output_tensor_t {
-    //
-    // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
-    // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
-    // CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
-    // CHECK-DAG: %[[false:.*]] = arith.constant false
-    // CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
-    // CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
-    // CHECK-DAG: %[[c4_i64:.*]] = arith.constant 4 : i64
-    // CHECK-DAG: %[[c5_i64:.*]] = arith.constant 5 : i64
-    // CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
-    // CHECK-DAG: %[[c512_i64:.*]] = arith.constant 512 : i64
-    //
-
     %cst_0 = arith.constant 0.000000e+00 : f32
     %cst_9 = arith.constant dense<0.000000e+00> : !conv3x3_output_tensor_t
 
@@ -176,15 +141,6 @@ func.func @conv2d_3x3_biasadd_relu(
     %2 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} 
                 ins(%input, %filter : !conv3x3_input_tensor_t, !conv3x3_filter_tensor_t) 
                 outs(%1 : !conv3x3_output_tensor_t) -> !conv3x3_output_tensor_t
-
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.for
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
     
     // BiasAdd
     %3 = tensor.empty() : !conv3x3_output_tensor_t
@@ -198,14 +154,6 @@ func.func @conv2d_3x3_biasadd_relu(
             linalg.yield %in : f32
     } -> !conv3x3_output_tensor_t
 
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]]) : (i64, i64, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
     %5 = tensor.empty() : !conv3x3_output_tensor_t
     %6 = linalg.generic {
             indexing_maps = [#map1, #map1, #map1], 
@@ -217,15 +165,6 @@ func.func @conv2d_3x3_biasadd_relu(
             %1591 = arith.addf %in, %in_34 : f32
             linalg.yield %1591 : f32
     } -> !conv3x3_output_tensor_t
-
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
 
     // ReLU
     %7 = tensor.empty() : !conv3x3_output_tensor_t
@@ -240,39 +179,50 @@ func.func @conv2d_3x3_biasadd_relu(
                 linalg.yield %1591 : f32
     } -> !conv3x3_output_tensor_t
 
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
-    //
-    // CHECK: return %[[alloc:.*]] : memref<1x7x7x512xf32>
-    //
     return %8 : !conv3x3_output_tensor_t
 }
+//
+// CHECK-LABEL: @conv2d_3x3_biasadd_relu(
+// CHECK-SAME: %[[arg:.*]]: memref<1x9x9x512xf32>) -> memref<1x7x7x512xf32> {
+// CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
+// CHECK-DAG: %[[c9:.+]] = arith.constant 9 : index
+// CHECK-DAG: %[[c512:.+]] = arith.constant 512 : index
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK: %[[xsmmDis5:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis5]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK-NOT: call @xsmm_
+// CHECK: return
+//
 
-//
-// CHECK-LABEL: @second_conv2d_1x1_biasadd_relu(
-// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x512xf32>) -> memref<1x7x7x2048xf32> {
-//
+
 func.func @second_conv2d_1x1_biasadd_relu(
         %input : !second_conv1x1_input_tensor_t) -> !second_conv1x1_output_tensor_t {
-    //
-    // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
-    // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
-    // CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
-    // CHECK-DAG: %[[false:.*]] = arith.constant false
-    // CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
-    // CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
-    // CHECK-DAG: %[[c4_i64:.*]] = arith.constant 4 : i64
-    // CHECK-DAG: %[[c5_i64:.*]] = arith.constant 5 : i64
-    // CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
-    // CHECK-DAG: %[[c512_i64:.*]] = arith.constant 512 : i64
-    // CHECK-DAG: %[[c2048_i64:.*]] = arith.constant 2048 : i64
-    //
 
     %cst_0 = arith.constant 0.000000e+00 : f32
     %cst_9 = arith.constant dense<0.000000e+00> : !second_conv1x1_output_tensor_t
@@ -287,14 +237,6 @@ func.func @second_conv2d_1x1_biasadd_relu(
     %2 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} 
                 ins(%input, %filter : !second_conv1x1_input_tensor_t, !second_conv1x1_filter_tensor_t) 
                 outs(%1 : !second_conv1x1_output_tensor_t) -> !second_conv1x1_output_tensor_t
-
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: %[[cast:.*]] = memref.cast
-    // CHECK: %[[cast1:.*]] = memref.cast
-    // CHECK: %[[cast2:.*]] = memref.cast
-    // CHECK: func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
     
     // BiasAdd
     %3 = tensor.empty() : !second_conv1x1_output_tensor_t
@@ -308,14 +250,6 @@ func.func @second_conv2d_1x1_biasadd_relu(
             linalg.yield %in : f32
     } -> !second_conv1x1_output_tensor_t
 
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]]) : (i64, i64, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
     %5 = tensor.empty() : !second_conv1x1_output_tensor_t
     %6 = linalg.generic {
             indexing_maps = [#map1, #map1, #map1], 
@@ -327,15 +261,6 @@ func.func @second_conv2d_1x1_biasadd_relu(
             %1591 = arith.addf %in, %in_34 : f32
             linalg.yield %1591 : f32
     } -> !second_conv1x1_output_tensor_t
-
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
 
     // ReLU
     %7 = tensor.empty() : !second_conv1x1_output_tensor_t
@@ -350,24 +275,47 @@ func.func @second_conv2d_1x1_biasadd_relu(
                 linalg.yield %1591 : f32
     } -> !second_conv1x1_output_tensor_t
     
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
-    //
-    // CHECK: return %[[alloc:.*]] : memref<1x7x7x2048xf32>
-    //
     return %8 : !second_conv1x1_output_tensor_t
 }
 
 //
-// CHECK-LABEL: @padding_for_3x3
-// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x512xf32>) -> memref<1x9x9x512xf32> {
+// CHECK-LABEL: @second_conv2d_1x1_biasadd_relu(
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x512xf32>) -> memref<1x7x7x2048xf32> {
+// CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c2048:.+]] = arith.constant 2048 : index
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: %[[xsmmDis3:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis3]]
+// CHECK: %[[xsmmDis4:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis4]]
+// CHECK: %[[xsmmDis5:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis5]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.parallel
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK-NOT: call @xsmm_
+// CHECK: return
 //
+
 func.func @padding_for_3x3(%input : !first_conv1x1_output_tensor_t) -> !conv3x3_input_tensor_t {
     %cst_0 = arith.constant 0.000000e+00 : f32
     %0 = tensor.pad %input low[0, 1, 1, 0] high[0, 1, 1, 0] {
@@ -375,18 +323,17 @@ func.func @padding_for_3x3(%input : !first_conv1x1_output_tensor_t) -> !conv3x3_
             tensor.yield %cst_0 : f32
     } : !first_conv1x1_output_tensor_t to !conv3x3_input_tensor_t
 
-    //
-    // CHECK: %[[alloc:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x9x9x512xf32>
-    // CHECK: %[[reinterpret_cast:.*]] = memref.reinterpret_cast %alloc to offset: [5120], sizes: [1, 7, 7, 512], strides: [41472, 4608, 512, 1]
-    //
-
     return %0 : !conv3x3_input_tensor_t
 }
 
 //
-// CHECK-LABEL: @skip_connection
-// CHECK-SAME: %[[arg0:.*]]: memref<1x7x7x2048xf32>, %[[arg1:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x2048xf32> {
+// CHECK-LABEL: @padding_for_3x3
+// CHECK-SAME: %[[arg:.*]]: memref<1x7x7x512xf32>) -> memref<1x9x9x512xf32> {
+// CHECK: %[[alloc:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x9x9x512xf32>
+// CHECK: %[[subview:.*]] = memref.subview %[[alloc]]
+// CHECK: memref.copy %[[arg]], %[[subview]]
 //
+
 func.func @skip_connection(%skip : !first_conv1x1_input_tensor_t, %input : !second_conv1x1_output_tensor_t) -> !second_conv1x1_output_tensor_t {
     %0 = tensor.empty() : !second_conv1x1_output_tensor_t
     %1 = linalg.generic {
@@ -400,36 +347,44 @@ func.func @skip_connection(%skip : !first_conv1x1_input_tensor_t, %input : !seco
                 linalg.yield %sum : f32
     } -> !second_conv1x1_output_tensor_t
 
-    //
-    // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-    // CHECK: scf.parallel
-    // CHECK:   %[[cast:.*]] = memref.cast
-    // CHECK:   %[[cast1:.*]] = memref.cast
-    // CHECK:   %[[cast2:.*]] = memref.cast
-    // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-    //
-
     return %1 : !second_conv1x1_output_tensor_t
 }
 
 //
-// CHECK-LABEL: @extract_results_for_printing
-// CHECK-SAME: %[[arg0:.*]]: memref<1x7x7x2048xf32>) -> memref<1x8xf32> {
+// CHECK-LABEL: @skip_connection
+// CHECK-SAME: %[[arg0:.*]]: memref<1x7x7x2048xf32>, %[[arg1:.*]]: memref<1x7x7x2048xf32>) -> memref<1x7x7x2048xf32> {
+// CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
+// CHECK-DAG: %[[c2048_i64:.+]] = arith.constant 2048 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK: %[[xsmmDis0:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis0]]
+// CHECK-NOT: call @xsmm_
+// CHECK: return
 //
+
 func.func @extract_results_for_printing(%input : !second_conv1x1_output_tensor_t) -> !tensor_print_t {
     %ret = tensor.extract_slice %input[0, 0, 0, 0][1, 1, 1, 8][1, 1, 1, 1] : !second_conv1x1_output_tensor_t to !tensor_print_t
-
-    //
-    // CHECK: {{.*}} = memref.extract_strided_metadata %[[arg0]] : memref<1x7x7x2048xf32> -> memref<f32>, index,
-    // CHECK: %[[cast:.*]] = memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [1, 8], strides: [100352, 1] : memref<f32> to memref<1x8xf32, strided<[100352, 1]>>
-    // CHECK: %[[alloc:.*]] = memref.alloc() : memref<1x8xf32>
-    // CHECK: memref.copy %[[cast]], %[[alloc]] : memref<1x8xf32, strided<[100352, 1]>> to memref<1x8xf32>
-    //
 
     return %ret : !tensor_print_t
 }
 
 //
+// CHECK-LABEL: @extract_results_for_printing
+// CHECK-SAME: %[[arg0:.*]]: memref<1x7x7x2048xf32>) -> memref<1x8xf32> {
+// CHECK: %[[subview:.*]] = memref.subview %[[arg0]]
+// CHECK: %[[alloc:.*]] = memref.alloc() : memref<1x8xf32>
+// CHECK: memref.copy %[[subview]], %[[alloc]] : memref<1x8xf32, strided<[100352, 1]>> to memref<1x8xf32>
+//
+
+
+//
+// CHECK-DAG: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
+// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
 // CHECK-DAG: func.func private @xsmm_unary_invoke(i64, i64, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}
 // CHECK-DAG: func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64 attributes {llvm.emit_c_interface}
 // CHECK-DAG: func.func private @xsmm_matmul_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) attributes {llvm.emit_c_interface}

--- a/test/Models/resnet50v1.mlir
+++ b/test/Models/resnet50v1.mlir
@@ -1750,346 +1750,531 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 //
 // Constant definitions
 // CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
-// CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c112_i64:.+]] = arith.constant 112 : i64
 // CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
+// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c3_i64:.+]] = arith.constant 3 : i64
 // CHECK-DAG: %[[c6_i64:.+]] = arith.constant 6 : i64
-// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
-// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c5_i64:.+]] = arith.constant 5 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c56_i64:.+]] = arith.constant 56 : i64
+// CHECK-DAG: %[[c256_i64:.+]] = arith.constant 256 : i64
 // CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
 // CHECK-DAG: %[[c28_i64:.+]] = arith.constant 28 : i64
+// CHECK-DAG: %[[c512_i64:.+]] = arith.constant 512 : i64
+// CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
 // CHECK-DAG: %[[c14_i64:.+]] = arith.constant 14 : i64
+// CHECK-DAG: %[[c1024_i64:.+]] = arith.constant 1024 : i64
 // CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
-// CHECK-DAG: %[[c1000_i64:.+]] = arith.constant 1000 : i64
 // CHECK-DAG: %[[c2048_i64:.+]] = arith.constant 2048 : i64
+// CHECK-DAG: %[[c1000_i64:.+]] = arith.constant 1000 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[c112:.+]] = arith.constant 112 : index
 // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
-// CHECK-DAG: %[[c8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[c56:.+]] = arith.constant 56 : index
 // CHECK-DAG: %[[c2:.+]] = arith.constant 2 : index
-// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c8:.+]] = arith.constant 8 : index
 // CHECK-DAG: %[[c4:.+]] = arith.constant 4 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c14:.+]] = arith.constant 14 : index
 // CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
-// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG: %[[cst_0:.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
 //
 // Check all XSMM calls
+// CHECK: %[[xsmmDis109:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis109]]
 // CHECK: %[[xsmmDis110:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c64_i64]], %[[c3_i64]], %[[c6_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis110]]
-// CHECK: %[[xsmmDis111:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis111:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis111]]
-// CHECK: %[[xsmmDis112:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis112]]
-// CHECK: %[[xsmmDis113:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis113]]
-// CHECK: linalg.pooling_nhwc_max
-// CHECK: linalg.transpose
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis114:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: %[[xsmmDis112:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis112]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK: %[[xsmmDis115:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK: %[[xsmmDis116:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis113:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis114:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: %[[xsmmDis115:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis112]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis116:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: %[[xsmmDis117:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.parallel
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis117:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis112]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: %[[xsmmDis118:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis112]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: %[[xsmmDis119:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK: %[[xsmmDis118:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK: %[[xsmmDis119:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis120:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis120:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
+// CHECK: %[[xsmmDis121:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
+// CHECK: %[[xsmmDis122:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis123:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis121:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: %[[xsmmDis124:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: %[[xsmmDis125:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
-// CHECK: %[[xsmmDis122:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK: %[[xsmmDis123:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis124:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis126:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis127:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK: %[[xsmmDis128:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis130:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis130]]
+// CHECK: %[[xsmmDis131:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis131]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK-NOT: linalg.transpose
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis125:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: %[[xsmmDis132:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis132]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis132]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis132]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis132]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis125]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis132]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK: %[[xsmmDis133:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis133]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
-// CHECK: %[[xsmmDis126:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK: %[[xsmmDis127:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis128:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis134:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis134]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis135:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis135]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis134]]
+// CHECK: %[[xsmmDis136:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis135]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis137:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis133]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK-NOT: linalg.transpose
+// CHECK:       linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: linalg.transpose
-// CHECK-NOT: linalg.transpose
-// CHECK: %[[xsmmDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
-// CHECK: %[[xsmmDis130:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis130]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis138:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
+// CHECK: %[[xsmmDis139:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis135]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis135]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis133]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: %[[xsmmDis140:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis140]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis135]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis135]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis133]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis137]]
+// CHECK: scf.parallel
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis140]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis136]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: linalg.generic
+// CHECK: linalg.generic
+// CHECK: %[[xsmmDis141:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
+// CHECK: %[[xsmmDis142:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis142]]
 //
 // No more XSMM dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_

--- a/test/Models/resnet50v1.mlir
+++ b/test/Models/resnet50v1.mlir
@@ -1759,354 +1759,418 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c5_i64:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[c56_i64:.+]] = arith.constant 56 : i64
-// CHECK-DAG: %[[c256_i64:.+]] = arith.constant 256 : i64
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
 // CHECK-DAG: %[[c28_i64:.+]] = arith.constant 28 : i64
-// CHECK-DAG: %[[c512_i64:.+]] = arith.constant 512 : i64
-// CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
 // CHECK-DAG: %[[c14_i64:.+]] = arith.constant 14 : i64
-// CHECK-DAG: %[[c1024_i64:.+]] = arith.constant 1024 : i64
 // CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
-// CHECK-DAG: %[[c2048_i64:.+]] = arith.constant 2048 : i64
 // CHECK-DAG: %[[c1000_i64:.+]] = arith.constant 1000 : i64
+// CHECK-DAG: %[[c2048_i64:.+]] = arith.constant 2048 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[c112:.+]] = arith.constant 112 : index
 // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
-// CHECK-DAG: %[[c56:.+]] = arith.constant 56 : index
-// CHECK-DAG: %[[c28:.+]] = arith.constant 28 : index
-// CHECK-DAG: %[[c14:.+]] = arith.constant 14 : index
+// CHECK-DAG: %[[c8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[c2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16 : index
+// CHECK-DAG: %[[c4:.+]] = arith.constant 4 : index
+// CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
 // CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG: %[[cst_0:.+]] = arith.constant 0xFF800000 : f32
-// CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
 //
-// Check all matmul calls
-// CHECK: %[[xsmmDis109:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c64_i64]], %[[c3_i64]], %[[c6_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// Check all XSMM calls
+// CHECK: %[[xsmmDis110:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c64_i64]], %[[c3_i64]], %[[c6_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis109]]
-// CHECK: %[[xsmmDis110:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis110]]
-// CHECK: %[[xsmmDis111:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis111]]
-// CHECK: %[[xsmmDis112:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis112]]
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis110]]
+// CHECK: %[[xsmmDis111:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis111]]
+// CHECK: %[[xsmmDis112:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis112]]
+// CHECK: %[[xsmmDis113:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis113]]
 // CHECK: linalg.pooling_nhwc_max
-// CHECK: %[[xsmmDis113:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
-// CHECK: %[[xsmmDis114:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK: %[[xsmmDis115:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK: %[[xsmmDis116:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: %[[xsmmDis117:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK: %[[xsmmDis118:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK: %[[xsmmDis119:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK: %[[xsmmDis120:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK: %[[xsmmDis121:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis117]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis118]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis113]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis114]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis115]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis120]]
-// CHECK: %[[xsmmDis122:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c256_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis122]]
-// CHECK: %[[xsmmDis123:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: %[[xsmmDis124:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK: %[[xsmmDis125:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c256_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
-// CHECK: %[[xsmmDis126:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK: %[[xsmmDis127:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: %[[xsmmDis128:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: %[[xsmmDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: %[[xsmmDis130:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis130]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK: %[[xsmmDis131:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis131]]
-// CHECK: %[[xsmmDis132:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis132]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis130]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis131]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis132]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis130]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis131]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis132]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis128]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis130]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis124]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis131]]
-// CHECK: %[[xsmmDis133:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis133]]
-// CHECK: %[[xsmmDis134:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK: %[[xsmmDis135:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK: %[[xsmmDis136:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis136]]
-// CHECK: %[[xsmmDis137:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK: %[[xsmmDis138:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK: %[[xsmmDis139:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: %[[xsmmDis140:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis140]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: %[[xsmmDis141:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK: %[[xsmmDis142:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis142]]
-// CHECK: %[[xsmmDis143:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis143]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis140]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis142]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis143]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis140]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis142]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis143]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis140]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis142]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis143]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis140]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis142]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis143]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis140]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis137]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis138]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis139]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis141]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis134]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis135]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis142]]
-// CHECK: %[[xsmmDis144:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis114:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK: %[[xsmmDis115:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK: %[[xsmmDis116:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis117:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis117]]
+// CHECK: %[[xsmmDis118:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK: %[[xsmmDis119:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis117]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: %[[xsmmDis120:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis121:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK: %[[xsmmDis122:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK: %[[xsmmDis123:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: %[[xsmmDis124:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis125:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
+// CHECK: %[[xsmmDis126:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK: %[[xsmmDis127:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: %[[xsmmDis128:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:         linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
+// CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:     linalg.transpose
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
+// CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
+// CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis144]]
-// CHECK: %[[xsmmDis145:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis145]]
-// CHECK: %[[xsmmDis146:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK: %[[xsmmDis147:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis147]]
-// CHECK: %[[xsmmDis148:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis148]]
-// CHECK: %[[xsmmDis149:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis149]]
-// CHECK: %[[xsmmDis150:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis150]]
-// CHECK: %[[xsmmDis151:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis151]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis148]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis149]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis150]]
-// CHECK: %[[xsmmDis152:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis152]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis145]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK: %[[xsmmDis153:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis153]]
-// CHECK: %[[xsmmDis154:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis154]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis148]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis149]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis150]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis151]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis148]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis149]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis150]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis152]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis145]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis153]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis154]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis148]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis149]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis150]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:         func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis151]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis148]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis149]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis150]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:     func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis152]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis145]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis146]]
-// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis153]]
-// CHECK: %[[xsmmDis155:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis155]]
-// CHECK: %[[xsmmDis156:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis156]]
+// CHECK:       linalg.transpose
+// CHECK: %[[xsmmDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
+// CHECK: %[[xsmmDis130:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis130]]
 //
 // No more XSMM dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_

--- a/test/Models/resnet50v1.mlir
+++ b/test/Models/resnet50v1.mlir
@@ -1789,12 +1789,8 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK: %[[xsmmDis113:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c112_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c5_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis113]]
 // CHECK: linalg.pooling_nhwc_max
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis114:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
@@ -1802,73 +1798,55 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK: %[[xsmmDis116:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c2]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis114]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis115]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis116]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis117:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis117]]
@@ -1876,92 +1854,71 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK: %[[xsmmDis119:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis117]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis120:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c4]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis120]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis118]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis119]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis121:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
@@ -1969,131 +1926,105 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK: %[[xsmmDis123:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis121]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis124:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c8]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c32]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis124]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis122]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis123]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis125:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c64_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
@@ -2101,72 +2032,60 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK: %[[xsmmDis127:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis125]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis128:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:       linalg.transpose
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
-// CHECK:         linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c16]] step %[[c1]] {
 // CHECK:           func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
-// CHECK:     linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c64]] step %[[c1]] {
 // CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis128]]
 // CHECK:   func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis126]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
 // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis127]]
-// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:       linalg.transpose
+// CHECK: linalg.transpose
+// CHECK-NOT: linalg.transpose
 // CHECK: %[[xsmmDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis129]]
 // CHECK: %[[xsmmDis130:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1000_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -33,3 +33,21 @@ func.func @generalize_pack_unpack(%arg0: tensor<12x2x56x56x32xf32>, %arg1: tenso
 // CHECK:     tensor.extract_slice
 // CHECK:     linalg.transpose
 // CHECK:     tensor.insert_slice
+
+// -----
+
+func.func @pack_vnni(%arg0: tensor<32x4x4xbf16>, %arg1: tensor<32x4x4xbf16>, %arg2: tensor<4x4xbf16>) -> tensor<4x4xbf16>{
+  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1:tensor<32x4x4xbf16>, tensor<32x4x4xbf16>) outs(%arg2:tensor<4x4xbf16>) -> tensor<4x4xbf16>
+  return %0: tensor<4x4xbf16>
+}
+
+// CHECK-LABEL: func.func @pack_vnni(
+// CHECK-NOT: linalg.batch_reduce_matmul
+// CHECK-NOT: tensor.pack
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:     scf.for
+// CHECK:       tensor.extract_slice
+// CHECK:       linalg.transpose
+// CHECK:       tensor.insert_slice
+// CHECK: vnni.brgemm

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -tpp-mapping -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -tpp-mapping -cleanup -split-input-file | FileCheck %s
 
 // We don't expect to block as the blocking factor do not create full tiles.
 func.func @conv_to_matmul(%img: tensor<1x5x5x3xf32>, %filter: tensor<3x3x3x8xf32>, %out: tensor<1x3x3x8xf32>) -> tensor<1x3x3x8xf32> {
@@ -8,15 +8,16 @@ func.func @conv_to_matmul(%img: tensor<1x5x5x3xf32>, %filter: tensor<3x3x3x8xf32
 
 // CHECK-LABEL: func.func @conv_to_matmul(
 // CHECK-NOT: linalg.conv_2d_nhwc_hwcf
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
 // CHECK: scf.for
 // CHECK:   scf.for
 // CHECK:     scf.for
-// CHECK:       scf.for
-// CHECK:         tensor.extract_slice
-// CHECK:         tensor.extract_slice
-// CHECK:         tensor.extract_slice
-// CHECK:         linalg.matmul
-// CHECK:         tensor.insert_slice
+// CHECK:         tensor.extract_slice{{[^:]+}}: tensor<1x5x5x3xf32> to tensor<3x3xf32>
+// CHECK:         tensor.extract_slice{{[^:]+}}: tensor<3x3x3x8xf32> to tensor<3x8xf32>
+// CHECK:         tensor.extract_slice{{[^:]+}}: tensor<1x3x3x8xf32> to tensor<3x8xf32>
+// CHECK:         linalg.matmul{{.*}} -> tensor<3x8xf32>
+// CHECK:         tensor.insert_slice{{[^:]+}}: tensor<3x8xf32> into tensor<1x3x3x8xf32>
 // CHECK:       }
 
 // -----
@@ -34,21 +35,21 @@ func.func @conv_2d_nhwc_hwcf(%arg0: tensor<1x113x113x64xf32>, %arg1: tensor<3x3x
 // Generalized pack of the first input
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<1x113x113x64xf32> to tensor<32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32xf32> into tensor<1x2x113x113x32xf32>
 // Generalized pack of the second input
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<3x3x64x256xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<8x2x3x3x32x32xf32>
 // Generalized pack of the output
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<1x111x111x256xf32> to tensor<32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32xf32> into tensor<1x8x111x111x32xf32>
 // Conv as matmul
 // CHECK: scf.for
 // CHECK:   linalg.matmul
@@ -66,21 +67,21 @@ func.func @conv_2d_nchw_fchw(%i: tensor<14x512x28x28xf32>, %f: tensor<1024x512x1
 // Generalized pack of the first input
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<14x512x28x28xf32> to tensor<32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32xf32> into tensor<14x16x28x28x32xf32>
 // Generalized pack of the second input
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<1024x512x1x1xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<32x16x1x1x32x32xf32>
 // Generalized pack of the output
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<14x1024x28x28xf32> to tensor<32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32xf32> into tensor<14x32x28x28x32xf32>
 // Conv as matmul
 // CHECK: scf.for
 // CHECK:   linalg.matmul
@@ -100,15 +101,15 @@ func.func @generalize_pack_unpack(%arg0: tensor<12x2x56x56x32xf32>, %arg1: tenso
 // CHECK-NOT: tensor.pack
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<512x1024xbf16> to tensor<2xbf16>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<2xbf16> into tensor<256x1024x2xbf16>
 // CHECK-NOT: tensor.unpack
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<12x2x56x56x32xf32> to tensor<32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<1x1x1x1xf32> into tensor<12x56x56x64xf32>
 
 // -----
 
@@ -123,9 +124,9 @@ func.func @pack_vnni(%arg0: tensor<32x4x4xbf16>, %arg1: tensor<32x4x4xbf16>, %ar
 // CHECK: scf.for
 // CHECK:   scf.for
 // CHECK:     scf.for
-// CHECK:       tensor.extract_slice
+// CHECK:       tensor.extract_slice{{[^:]+}}: tensor<32x4x4xbf16> to tensor<2xbf16>
 // CHECK:       linalg.transpose
-// CHECK:       tensor.insert_slice
+// CHECK:       tensor.insert_slice{{[^:]+}}: tensor<2xbf16> into tensor<32x2x4x2xbf16>
 // CHECK: vnni.brgemm
 
 // -----
@@ -144,22 +145,25 @@ func.func @pack_matmul(
 // Generalized pack of the first input
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<128x128xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<4x4x32x32xf32>
 // Generalized pack of the second input
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<128x128xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<4x4x32x32xf32>
 // Generalized pack of the output
 // CHECK: scf.for
 // CHECK:   scf.for
-// CHECK:     tensor.extract_slice
+// CHECK:     tensor.extract_slice{{[^:]+}}: tensor<128x128xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
-// CHECK:     tensor.insert_slice
+// CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<4x4x32x32xf32>
 // Packed matmul
 // CHECK: linalg.generic
+// CHECK-SAME: {{.*}}iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+// CHECK-SAME: ins({{.*}}: tensor<4x4x32x32xf32>, tensor<4x4x32x32xf32>)
+// CHECK-SAME: outs({{.*}}: tensor<4x4x32x32xf32>)
 // CHECK:   arith.mulf
 // CHECK:   arith.addf

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -167,3 +167,17 @@ func.func @pack_matmul(
 // CHECK-SAME: outs({{.*}}: tensor<4x4x32x32xf32>)
 // CHECK:   arith.mulf
 // CHECK:   arith.addf
+
+// -----
+
+func.func @fold_const_pack() ->  tensor<8x2x1x1x32x32xi64> {
+  %cst = arith.constant dense<1> : tensor<1x1x64x256xi64>
+  %0 = tensor.empty() : tensor<8x2x1x1x32x32xi64>
+  %pack = tensor.pack %cst outer_dims_perm = [3, 2, 0, 1] inner_dims_pos = [2, 3] inner_tiles = [32, 32] into %0 : tensor<1x1x64x256xi64> -> tensor<8x2x1x1x32x32xi64>
+  return  %pack : tensor<8x2x1x1x32x32xi64>
+}
+
+// CHECK-LABEL: func.func @fold_const_pack(
+// CHECK-NOT: tensor.pack
+// CHECK: %[[CST:.+]] = arith.constant dense<1> : tensor<8x2x1x1x32x32xi64>
+// CHECK-NEXT: return %[[CST]] : tensor<8x2x1x1x32x32xi64>

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -307,11 +307,12 @@ func.func @tile_and_fuse(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>,
 // CHECK:     tensor.extract_slice{{[^:]+}}: tensor<64x64xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
 // CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<2x2x32x32xf32>
-// Merged matmul and relu
-// CHECK: scf.forall
-// CHECK: linalg.generic{{.*}}ins(%{{.+}}, %{{.+}} : tensor<2x32x32xf32>, tensor<2x32x32xf32>)
-// CHECK-SAME:{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
-// CHECK:   arith.mulf
-// CHECK:   arith.addf
-// CHECK: linalg.generic{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
-// CHECK:   arith.maxf
+// TODO: reenable once tile and fuse defaults are back
+// Fused matmul and relu
+// C_HECK: scf.forall
+// C_HECK: linalg.generic{{.*}}ins(%{{.+}}, %{{.+}} : tensor<2x32x32xf32>, tensor<2x32x32xf32>)
+// C_HECK-SAME:{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
+// C_HECK:   arith.mulf
+// C_HECK:   arith.addf
+// C_HECK: linalg.generic{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
+// C_HECK:   arith.maxf

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -307,12 +307,11 @@ func.func @tile_and_fuse(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>,
 // CHECK:     tensor.extract_slice{{[^:]+}}: tensor<64x64xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
 // CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<2x2x32x32xf32>
-// TODO: reenable once tile and fuse defaults are back
 // Fused matmul and relu
-// C_HECK: scf.forall
-// C_HECK: linalg.generic{{.*}}ins(%{{.+}}, %{{.+}} : tensor<2x32x32xf32>, tensor<2x32x32xf32>)
-// C_HECK-SAME:{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
-// C_HECK:   arith.mulf
-// C_HECK:   arith.addf
-// C_HECK: linalg.generic{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
-// C_HECK:   arith.maxf
+// CHECK: scf.forall
+// CHECK: linalg.generic{{.*}}ins(%{{.+}}, %{{.+}} : tensor<2x32x32xf32>, tensor<2x32x32xf32>)
+// CHECK-SAME:{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
+// CHECK:   arith.mulf
+// CHECK:   arith.addf
+// CHECK: linalg.generic{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
+// CHECK:   arith.maxf

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -307,10 +307,11 @@ func.func @tile_and_fuse(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>,
 // CHECK:     tensor.extract_slice{{[^:]+}}: tensor<64x64xf32> to tensor<32x32xf32>
 // CHECK:     linalg.transpose
 // CHECK:     tensor.insert_slice{{[^:]+}}: tensor<32x32xf32> into tensor<2x2x32x32xf32>
-// TODO: the two linalg ops should be fussed when the default tiling sizes are chosen correctly
-//       then some scf loops should be present
-// CHECK-NOT: scf.for
-// CHECK-NOT: scf.parallel
-// CHECK: linalg.generic{{.*}}ins(%{{.+}}, %{{.+}} : tensor<2x2x32x32xf32>, tensor<2x2x32x32xf32>)
-// CHECK-SAME:{{.*}}outs(%{{.+}} : tensor<2x2x32x32xf32>)
-// CHECK: linalg.generic{{.*}}outs(%{{.+}} : tensor<2x2x32x32xf32>)
+// Merged matmul and relu
+// CHECK: scf.forall
+// CHECK: linalg.generic{{.*}}ins(%{{.+}}, %{{.+}} : tensor<2x32x32xf32>, tensor<2x32x32xf32>)
+// CHECK-SAME:{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
+// CHECK:   arith.mulf
+// CHECK:   arith.addf
+// CHECK: linalg.generic{{.*}}outs(%{{.+}} : tensor<32x32xf32>)
+// CHECK:   arith.maxf

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -1,17 +1,57 @@
 // RUN: tpp-opt %s -tpp-mapping -split-input-file | FileCheck %s
 
-func.func @conv_2d_nhwc_hwcf(%img: tensor<1x5x5x3xf32>, %filter: tensor<3x3x3x8xf32>, %out: tensor<1x3x3x8xf32>) -> tensor<1x3x3x8xf32> {
+// We don't expect to block as the blocking factor do not create full tiles.
+func.func @conv_to_matmul(%img: tensor<1x5x5x3xf32>, %filter: tensor<3x3x3x8xf32>, %out: tensor<1x3x3x8xf32>) -> tensor<1x3x3x8xf32> {
   %0 = linalg.conv_2d_nhwc_hwcf ins(%img, %filter: tensor<1x5x5x3xf32>, tensor<3x3x3x8xf32>) outs(%out: tensor<1x3x3x8xf32>) -> tensor<1x3x3x8xf32>
   return %0: tensor<1x3x3x8xf32>
 }
 
+// CHECK-LABEL: func.func @conv_to_matmul(
+// CHECK-NOT: linalg.conv_2d_nhwc_hwcf
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:     scf.for
+// CHECK:       scf.for
+// CHECK:         tensor.extract_slice
+// CHECK:         tensor.extract_slice
+// CHECK:         tensor.extract_slice
+// CHECK:         linalg.matmul
+// CHECK:         tensor.insert_slice
+// CHECK:       }
+
+// -----
+
+func.func @conv_2d_nhwc_hwcf(%arg0: tensor<1x113x113x64xf32>, %arg1: tensor<3x3x64x256xf32>, %arg2: tensor<1x111x111x256xf32>) -> tensor<1x111x111x256xf32> {
+  %1 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>,
+                                 strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1 : tensor<1x113x113x64xf32>, tensor<3x3x64x256xf32>)
+    outs(%arg2: tensor<1x111x111x256xf32>) -> tensor<1x111x111x256xf32>
+  return %1 : tensor<1x111x111x256xf32>
+}
+
 // CHECK-LABEL: func.func @conv_2d_nhwc_hwcf(
 // CHECK-NOT: linalg.conv_2d_nhwc_hwcf
-// CHECK: tensor.extract_slice
-// CHECK: tensor.extract_slice
-// CHECK: tensor.extract_slice
-// CHECK: linalg.matmul
-// CHECK: tensor.insert_slice
+// Generalized pack of the first input
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:     tensor.extract_slice
+// CHECK:     linalg.transpose
+// CHECK:     tensor.insert_slice
+// Generalized pack of the second input
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:     tensor.extract_slice
+// CHECK:     linalg.transpose
+// CHECK:     tensor.insert_slice
+// Generalized pack of the output
+// CHECK: scf.for
+// CHECK:   scf.for
+// CHECK:     tensor.extract_slice
+// CHECK:     linalg.transpose
+// CHECK:     tensor.insert_slice
+// Conv as matmul
+// CHECK: scf.for
+// CHECK:   linalg.matmul
 
 // -----
 
@@ -42,7 +82,8 @@ func.func @conv_2d_nchw_fchw(%i: tensor<14x512x28x28xf32>, %f: tensor<1024x512x1
 // CHECK:     linalg.transpose
 // CHECK:     tensor.insert_slice
 // Conv as matmul
-// CHECK: linalg.matmul
+// CHECK: scf.for
+// CHECK:   linalg.matmul
 
 // -----
 

--- a/test/Passes/DefaultPipeline/tpp-mapping.mlir
+++ b/test/Passes/DefaultPipeline/tpp-mapping.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -tpp-mapping -cleanup -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -tpp-mapping -split-input-file | FileCheck %s
 
 // We don't expect to block as the blocking factor do not create full tiles.
 func.func @conv_to_matmul(%img: tensor<1x5x5x3xf32>, %filter: tensor<3x3x3x8xf32>, %out: tensor<1x3x3x8xf32>) -> tensor<1x3x3x8xf32> {


### PR DESCRIPTION
Adds various existing packing passes to the default pipeline.
These passes are run with either their own default blocking factors or values hardcoded for the default pipeline.
Additionally, other support passes are added to improve packing performance such as pack propagation or folding.

The default matmul packing is disabled in some benchmarks in which the pass highly reduces performance.

Fixes #361 
Work towards #369 