### PR TITLE
Default pipeline - common up ops after LICM

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -146,6 +146,9 @@ private:
     // of loops, if possible. This approach assumes that the function calls do
     // not have any side effects and can be safely moved outside of loop body.
     pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
+    // Run cleanup after LICM to allow CSE to eliminate common operations now
+    // that they are hoisted out of loops.
+    pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
     pm.addPass(createConvertXsmmToFuncPass());
     pm.addPass(createConvertPerfToFuncPass());

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -932,114 +932,114 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // Check all matmul calls
 // CHECK: %[[matDis34:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis34]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis34]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis35:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis35]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis35]]
 // CHECK: %[[matDis36:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis36]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis36]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis37:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis37]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis37]]
 // CHECK: %[[matDis38:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis38]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis38]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis39:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis39]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis39]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis38]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis38]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis41:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis41]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis41]]
 // CHECK: %[[matDis42:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis43:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis43]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis43]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis43]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis43]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis45:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c64_i64]], %[[c192_i64]], %[[c192_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis45]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis45]]
 // CHECK: %[[matDis46:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis47:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis49:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c96_i64]], %[[c384_i64]], %[[c384_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis49]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis49]]
 // CHECK: %[[matDis50:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis51:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis51]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis51]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis51]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis51]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis53:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c160_i64]], %[[c576_i64]], %[[c576_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis53]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis53]]
 // CHECK: %[[matDis54:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis55:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis55]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis55]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis55]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis55]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]]
 // CHECK: linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK: %[[matDis57:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c320_i64]], %[[c960_i64]], %[[c960_i64]], %[[c320_i64]], %[[c320_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis57]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis57]]
 // CHECK: %[[matDis58:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c1280_i64]], %[[c320_i64]], %[[c320_i64]], %[[c1280_i64]], %[[c1280_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis58]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis58]]
 // CHECK: linalg.pooling_nhwc_sum
 // CHECK: %[[matDis59:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis59]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis59]]
 //
 // No more matmul dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_matmul_

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -909,7 +909,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK-DAG: %[[c56_i64:.+]] = arith.constant 56 : i64
 // CHECK-DAG: %[[c24_i64:.+]] = arith.constant 24 : i64
 // CHECK-DAG: %[[c144_i64:.+]] = arith.constant 144 : i64
-// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[c28_i64:.+]] = arith.constant 28 : i64
 // CHECK-DAG: %[[c192_i64:.+]] = arith.constant 192 : i64
 // CHECK-DAG: %[[c14_i64:.+]] = arith.constant 14 : i64
@@ -923,15 +922,12 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
 // CHECK-DAG: %[[c1280_i64:.+]] = arith.constant 1280 : i64
 // CHECK-DAG: %[[c1001_i64:.+]] = arith.constant 1001 : i64
 // CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[c224:.+]] = arith.constant 224 : index
 // CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[c112:.+]] = arith.constant 112 : index
 // CHECK-DAG: %[[c56:.+]] = arith.constant 56 : index
 // CHECK-DAG: %[[c28:.+]] = arith.constant 28 : index
 // CHECK-DAG: %[[c14:.+]] = arith.constant 14 : index
 // CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
-// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
 //
 // Check all matmul calls
 // CHECK: %[[matDis34:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64

--- a/test/Models/mobilenet-without-batchnorm.mlir
+++ b/test/Models/mobilenet-without-batchnorm.mlir
@@ -75,47 +75,7 @@
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> ()>
 
-//
-// CHECK-LABEL: @mobilenet(
-// CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1001xf32> {
-//
 func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
-  // CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
-  // CHECK-DAG: %[[c0_i1:.*]] = arith.constant false
-  // CHECK-DAG: %[[c112_i64:.*]] = arith.constant 112 : i64
-  // CHECK-DAG: %[[c32_i64:.*]] = arith.constant 32 : i64
-  // CHECK-DAG: %[[c3_i64:.*]] = arith.constant 3 : i64
-  // CHECK-DAG: %[[c6_i64:.*]] = arith.constant 6 : i64
-  // CHECK-DAG: %[[c16_i64:.*]] = arith.constant 16 : i64
-  // CHECK-DAG: %[[c96_i64:.*]] = arith.constant 96 : i64
-  // CHECK-DAG: %[[c56_i64:.*]] = arith.constant 56 : i64
-  // CHECK-DAG: %[[c24_i64:.*]] = arith.constant 24 : i64
-  // CHECK-DAG: %[[c144_i64:.*]] = arith.constant 144 : i64
-  // CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
-  // CHECK-DAG: %[[c28_i64:.*]] = arith.constant 28 : i64
-  // CHECK-DAG: %[[c192_i64:.*]] = arith.constant 192 : i64
-  // CHECK-DAG: %[[c14_i64:.*]] = arith.constant 14 : i64
-  // CHECK-DAG: %[[c64_i64:.*]] = arith.constant 64 : i64
-  // CHECK-DAG: %[[c384_i64:.*]] = arith.constant 384 : i64
-  // CHECK-DAG: %[[c576_i64:.*]] = arith.constant 576 : i64
-  // CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
-  // CHECK-DAG: %[[c160_i64:.*]] = arith.constant 160 : i64
-  // CHECK-DAG: %[[c960_i64:.*]] = arith.constant 960 : i64
-  // CHECK-DAG: %[[c320_i64:.*]] = arith.constant 320 : i64
-  // CHECK-DAG: %[[c1280_i64:.*]] = arith.constant 1280 : i64
-  // CHECK-DAG: %[[c1001_i64:.*]] = arith.constant 1001 : i64
-  // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[c224:.*]] = arith.constant 224 : index
-  // CHECK-DAG: %[[c112:.*]] = arith.constant 112 : index
-  // CHECK-DAG: %[[c56:.*]] = arith.constant 56 : index
-  // CHECK-DAG: %[[c28:.*]] = arith.constant 28 : index
-  // CHECK-DAG: %[[c14:.*]] = arith.constant 14 : index
-  // CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
-  // CHECK-DAG: %[[cst:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
-  //
-
   %cst = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant dense<4.900000e+01> : tensor<f32>
   %cst_2 = arith.constant dense<6.000000e+00> : tensor<f32>
@@ -222,14 +182,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x112x112x32xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
   
   // Layer 2 - Bottleneck block 1 - depthwise Conv2D, 3x3, stride 1, ReLU6
   %padded_18 = tensor.pad %32 low[0, 1, 1, 0] high[0, 1, 1, 0] {
@@ -249,22 +201,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
   } -> tensor<1x112x112x32xf32>
   //
   // TODO: Update this check later when we support depthwise Conv2D.
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x114x114x32xf32>, memref<3x3x32xf32>) outs({{.*}} : memref<1x112x112x32xf32>) 
-  //
 
   // Layer 3 - Bottleneck block 1, second Conv2D, 1x1 filter, stride 1
   %58 = tensor.empty() : tensor<1x112x112x16xf32>
   %59 = linalg.fill ins(%cst : f32) outs(%58 : tensor<1x112x112x16xf32>) -> tensor<1x112x112x16xf32>
   %60 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%57, %bottleneck_block_1_project_weights : tensor<1x112x112x32xf32>, tensor<1x1x32x16xf32>) outs(%59 : tensor<1x112x112x16xf32>) -> tensor<1x112x112x16xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 4 - Bottleneck block 2, first Conv2D, 1x1 filter, stride 1, ReLU6
   %81 = tensor.empty() : tensor<1x112x112x96xf32>
@@ -277,14 +218,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x112x112x96xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_19 = tensor.pad %105 low[0, 0, 0, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -303,22 +236,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x56x56x96xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins({{.*}} : memref<1x113x113x96xf32>, memref<3x3x96xf32>) outs({{.*}} : memref<1x56x56x96xf32>)
-  //
 
   // Layer 6 - Bottleneck block 2, second Conv2D, 1x1 filter, stride 1
   %131 = tensor.empty() : tensor<1x56x56x24xf32>
   %132 = linalg.fill ins(%cst : f32) outs(%131 : tensor<1x56x56x24xf32>) -> tensor<1x56x56x24xf32>
   %133 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%130, %bottleneck_block_2_project_weights : tensor<1x56x56x96xf32>, tensor<1x1x96x24xf32>) outs(%132 : tensor<1x56x56x24xf32>) -> tensor<1x56x56x24xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 7 - Bottleneck block 3, first Conv2D, 1x1 filter, stride 1, ReLU6
   %154 = tensor.empty() : tensor<1x56x56x144xf32>
@@ -331,14 +253,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x56x56x144xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
   
   %padded_21 = tensor.pad %178 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -357,22 +271,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x56x56x144xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x58x58x144xf32>, memref<3x3x144xf32>) outs({{.*}} : memref<1x56x56x144xf32>)
-  //
 
   // Layer 9 - Bottleneck block 3, second Conv2D, 1x1 filter, stride 1
   %204 = tensor.empty() : tensor<1x56x56x24xf32>
   %205 = linalg.fill ins(%cst : f32) outs(%204 : tensor<1x56x56x24xf32>) -> tensor<1x56x56x24xf32>
   %206 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%203, %bottleneck_block_3_project_weights : tensor<1x56x56x144xf32>, tensor<1x1x144x24xf32>) outs(%205 : tensor<1x56x56x24xf32>) -> tensor<1x56x56x24xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]],  %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %227 = tensor.empty() : tensor<1x56x56x24xf32>
@@ -381,17 +284,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x56x56x24xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c56_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c24_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c56]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 10 - Bottleneck block 4, first Conv2D, 1x1 filter, stride 1, ReLU6
   %229 = tensor.empty() : tensor<1x56x56x144xf32>
@@ -404,14 +296,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x56x56x144xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_23 = tensor.pad %253 low[0, 0, 0, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -430,22 +314,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x28x28x144xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins({{.*}} : memref<1x57x57x144xf32>, memref<3x3x144xf32>) outs({{.*}} : memref<1x28x28x144xf32>)
-  //
 
   // Layer 12 - Bottleneck block 4, second Conv2D, 1x1 filter, stride 1
   %279 = tensor.empty() : tensor<1x28x28x32xf32>
   %280 = linalg.fill ins(%cst : f32) outs(%279 : tensor<1x28x28x32xf32>) -> tensor<1x28x28x32xf32>
   %281 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%278, %bottleneck_block_4_project_weights : tensor<1x28x28x144xf32>, tensor<1x1x144x32xf32>) outs(%280 : tensor<1x28x28x32xf32>) -> tensor<1x28x28x32xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 13 - Bottleneck block 5, first Conv2D, 1x1 filter, stride 1, ReLU%[[c0_i1]], 6
   %302 = tensor.empty() : tensor<1x28x28x192xf32>
@@ -458,14 +331,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x28x28x192xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c28_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_25 = tensor.pad %326 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -484,22 +349,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x28x28x192xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x30x30x192xf32>, memref<3x3x192xf32>) outs({{.*}} : memref<1x28x28x192xf32>)
-  //
 
   // Layer 15 - Bottleneck block 5, second Conv2D, 1x1 filter, stride 1
   %352 = tensor.empty() : tensor<1x28x28x32xf32>
   %353 = linalg.fill ins(%cst : f32) outs(%352 : tensor<1x28x28x32xf32>) -> tensor<1x28x28x32xf32>
   %354 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%351, %bottleneck_block_5_project_weights : tensor<1x28x28x192xf32>, tensor<1x1x192x32xf32>) outs(%353 : tensor<1x28x28x32xf32>) -> tensor<1x28x28x32xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c28_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %375 = tensor.empty() : tensor<1x28x28x32xf32>
@@ -508,17 +362,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x28x28x32xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c28]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 16 - Bottleneck block 6, first Conv2D, 1x1 filter, stride 1, ReLU6
   %377 = tensor.empty() : tensor<1x28x28x192xf32>
@@ -531,14 +374,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x28x28x192xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c28_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
   
   %padded_27 = tensor.pad %401 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -557,22 +392,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x28x28x192xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x30x30x192xf32>, memref<3x3x192xf32>) outs({{.*}} : memref<1x28x28x192xf32>)
-  //
 
   // Layer 18 - Bottleneck block 6, second Conv2D, 1x1 filter, stride 1
   %427 = tensor.empty() : tensor<1x28x28x32xf32>
   %428 = linalg.fill ins(%cst : f32) outs(%427 : tensor<1x28x28x32xf32>) -> tensor<1x28x28x32xf32>
   %429 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%426, %bottleneck_block_6_project_weights : tensor<1x28x28x192xf32>, tensor<1x1x192x32xf32>) outs(%428 : tensor<1x28x28x32xf32>) -> tensor<1x28x28x32xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c28_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %450 = tensor.empty() : tensor<1x28x28x32xf32>
@@ -581,17 +405,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x28x28x32xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c28_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c32_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c28]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 19 - Bottleneck block 7, first Conv2D, 1x1 filter, stride 1, ReLU6
   %452 = tensor.empty() : tensor<1x28x28x192xf32>
@@ -604,14 +417,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x28x28x192xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c28_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
   
   %padded_29 = tensor.pad %476 low[0, 0, 0, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -630,22 +435,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x192xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins({{.*}} : memref<1x29x29x192xf32>, memref<3x3x192xf32>) outs({{.*}} : memref<1x14x14x192xf32>)
-  //
 
   // Layer 21 - Bottleneck block 7, second Conv2D, 1x1 filter, stride 1
   %502 = tensor.empty() : tensor<1x14x14x64xf32>
   %503 = linalg.fill ins(%cst : f32) outs(%502 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
   %504 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%501, %bottleneck_block_7_project_weights : tensor<1x14x14x192xf32>, tensor<1x1x192x64xf32>) outs(%503 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c64_i64]], %[[c192_i64]], %[[c192_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 22 - Bottleneck block 8, first Conv2D, 1x1 filter, stride 1, ReLU6
   %525 = tensor.empty() : tensor<1x14x14x384xf32>
@@ -658,14 +452,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_31 = tensor.pad %549 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -684,22 +470,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x16x16x384xf32>, memref<3x3x384xf32>) outs({{.*}} : memref<1x14x14x384xf32>)
-  //
 
   // Layer 24 - Bottleneck block 8, second Conv2D, 1x1 filter, stride 1
   %575 = tensor.empty() : tensor<1x14x14x64xf32>
   %576 = linalg.fill ins(%cst : f32) outs(%575 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
   %577 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%574, %bottleneck_block_8_project_weights : tensor<1x14x14x384xf32>, tensor<1x1x384x64xf32>) outs(%576 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %598 = tensor.empty() : tensor<1x14x14x64xf32>
@@ -708,17 +483,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c14]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 25 - Bottleneck block 9, first Conv2D, 1x1 filter, stride 1, ReLU6
   %600 = tensor.empty() : tensor<1x14x14x384xf32>
@@ -731,14 +495,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_33 = tensor.pad %624 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -757,22 +513,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x16x16x384xf32>, memref<3x3x384xf32>) outs({{.*}} : memref<1x14x14x384xf32>)
-  //
 
   // Layer 27 - Bottleneck block 9, second Conv2D, 1x1 filter, stride 1
   %650 = tensor.empty() : tensor<1x14x14x64xf32>
   %651 = linalg.fill ins(%cst : f32) outs(%650 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
   %652 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%649, %bottleneck_block_9_project_weights : tensor<1x14x14x384xf32>, tensor<1x1x384x64xf32>) outs(%651 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %673 = tensor.empty() : tensor<1x14x14x64xf32>
@@ -781,17 +526,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c14]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 28 - Bottleneck block 10, first Conv2D, 1x1 filter, stride 1, ReLU6
   %675 = tensor.empty() : tensor<1x14x14x384xf32>
@@ -804,14 +538,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_35 = tensor.pad %699 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -830,22 +556,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x16x16x384xf32>, memref<3x3x384xf32>) outs({{.*}} : memref<1x14x14x384xf32>)
-  //
 
   // Layer 30 - Bottleneck block 10, second Conv2D, 1x1 filter, stride 1
   %725 = tensor.empty() : tensor<1x14x14x64xf32>
   %726 = linalg.fill ins(%cst : f32) outs(%725 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
   %727 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%724, %bottleneck_block_10_project_weights : tensor<1x14x14x384xf32>, tensor<1x1x384x64xf32>) outs(%726 : tensor<1x14x14x64xf32>) -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %748 = tensor.empty() : tensor<1x14x14x64xf32>
@@ -854,17 +569,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x14x14x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c14]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 31 - Bottleneck block 11, first Conv2D, 1x1 filter, stride 1, ReLU6
   %750 = tensor.empty() : tensor<1x14x14x384xf32>
@@ -877,14 +581,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_37 = tensor.pad %774 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -903,22 +599,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x384xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x16x16x384xf32>, memref<3x3x384xf32>) outs({{.*}} : memref<1x14x14x384xf32>)
-  //
 
   // Layer 33 - Bottleneck block 11, second Conv2D, 1x1 filter, stride 1
   %800 = tensor.empty() : tensor<1x14x14x96xf32>
   %801 = linalg.fill ins(%cst : f32) outs(%800 : tensor<1x14x14x96xf32>) -> tensor<1x14x14x96xf32>
   %802 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%799, %bottleneck_block_11_project_weights : tensor<1x14x14x384xf32>, tensor<1x1x384x96xf32>) outs(%801 : tensor<1x14x14x96xf32>) -> tensor<1x14x14x96xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c96_i64]], %[[c384_i64]], %[[c384_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 34 - Bottleneck block 12, first Conv2D, 1x1 filter, stride 1, ReLU6
   %823 = tensor.empty() : tensor<1x14x14x576xf32>
@@ -931,14 +616,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x576xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_39 = tensor.pad %847 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -957,22 +634,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x576xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x16x16x576xf32>, memref<3x3x576xf32>) outs({{.*}} : memref<1x14x14x576xf32>)
-  // 
 
   // Layer 36 - Bottleneck block 12, second Conv2D, 1x1 filter, stride 1
   %873 = tensor.empty() : tensor<1x14x14x96xf32>
   %874 = linalg.fill ins(%cst : f32) outs(%873 : tensor<1x14x14x96xf32>) -> tensor<1x14x14x96xf32>
   %875 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%872, %bottleneck_block_12_project_weights : tensor<1x14x14x576xf32>, tensor<1x1x576x96xf32>) outs(%874 : tensor<1x14x14x96xf32>) -> tensor<1x14x14x96xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %896 = tensor.empty() : tensor<1x14x14x96xf32>
@@ -981,17 +647,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x14x14x96xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c14]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 37 - Bottleneck block 13, first Conv2D, 1x1 filter, stride 1, ReLU6
   %898 = tensor.empty() : tensor<1x14x14x576xf32>
@@ -1004,14 +659,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x576xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_41 = tensor.pad %922 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -1030,22 +677,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x576xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x16x16x576xf32>, memref<3x3x576xf32>) outs({{.*}} : memref<1x14x14x576xf32>)
-  //
 
   // Layer 39 - Bottleneck block 13, second Conv2D, 1x1 filter, stride 1
   %948 = tensor.empty() : tensor<1x14x14x96xf32>
   %949 = linalg.fill ins(%cst : f32) outs(%948 : tensor<1x14x14x96xf32>) -> tensor<1x14x14x96xf32>
   %950 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%947, %bottleneck_block_13_project_weights : tensor<1x14x14x576xf32>, tensor<1x1x576x96xf32>) outs(%949 : tensor<1x14x14x96xf32>) -> tensor<1x14x14x96xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %971 = tensor.empty() : tensor<1x14x14x96xf32>
@@ -1054,17 +690,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x14x14x96xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c14_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c96_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c14]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 40 - Bottleneck block 14, first Conv2D, 1x1 filter, stride 1, ReLU6
   %973 = tensor.empty() : tensor<1x14x14x576xf32>
@@ -1077,14 +702,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x14x14x576xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c14_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_43 = tensor.pad %997 low[0, 0, 0, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -1103,22 +720,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x576xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins({{.*}} : memref<1x15x15x576xf32>, memref<3x3x576xf32>) outs({{.*}} : memref<1x7x7x576xf32>)
-  //
 
   // Layer 42 - Bottleneck block 14, second Conv2D, 1x1 filter, stride 1
   %1023 = tensor.empty() : tensor<1x7x7x160xf32>
   %1024 = linalg.fill ins(%cst : f32) outs(%1023 : tensor<1x7x7x160xf32>) -> tensor<1x7x7x160xf32>
   %1025 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%1022, %bottleneck_block_14_project_weights : tensor<1x7x7x576xf32>, tensor<1x1x576x160xf32>) outs(%1024 : tensor<1x7x7x160xf32>) -> tensor<1x7x7x160xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c160_i64]], %[[c576_i64]], %[[c576_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 43 - Bottleneck block 15, first Conv2D, 1x1 filter, stride 1, ReLU6
   %1046 = tensor.empty() : tensor<1x7x7x960xf32>
@@ -1131,14 +737,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x960xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_45 = tensor.pad %1070 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -1157,22 +755,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x960xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x9x9x960xf32>, memref<3x3x960xf32>) outs({{.*}} : memref<1x7x7x960xf32>)
-  // 
 
   // Layer 45 - Bottleneck block 15, second Conv2D, 1x1 filter, stride 1
   %1096 = tensor.empty() : tensor<1x7x7x160xf32>
   %1097 = linalg.fill ins(%cst : f32) outs(%1096 : tensor<1x7x7x160xf32>) -> tensor<1x7x7x160xf32>
   %1098 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%1095, %bottleneck_block_15_project_weights : tensor<1x7x7x960xf32>, tensor<1x1x960x160xf32>) outs(%1097 : tensor<1x7x7x160xf32>) -> tensor<1x7x7x160xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %1119 = tensor.empty() : tensor<1x7x7x160xf32>
@@ -1181,17 +768,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x7x7x160xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c7]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 46 - Bottleneck block 16, first Conv2D, 1x1 filter, stride 1, ReLU6
   %1121 = tensor.empty() : tensor<1x7x7x960xf32>
@@ -1204,14 +780,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x960xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_47 = tensor.pad %1145 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -1230,22 +798,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x960xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x9x9x960xf32>, memref<3x3x960xf32>) outs({{.*}} : memref<1x7x7x960xf32>)
-  //
 
   // Layer 48 - Bottleneck block 16, second Conv2D, 1x1 filter, stride 1
   %1171 = tensor.empty() : tensor<1x7x7x160xf32>
   %1172 = linalg.fill ins(%cst : f32) outs(%1171 : tensor<1x7x7x160xf32>) -> tensor<1x7x7x160xf32>
   %1173 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%1170, %bottleneck_block_16_project_weights : tensor<1x7x7x960xf32>, tensor<1x1x960x160xf32>) outs(%1172 : tensor<1x7x7x160xf32>) -> tensor<1x7x7x160xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // skip connection
   %1194 = tensor.empty() : tensor<1x7x7x160xf32>
@@ -1254,17 +811,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x7x7x160xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c7_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c160_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.parallel (%[[arg2:.*]]) = (%[[c0]]) to (%[[c7]]) step (%[[c1]]) {
-  // CHECK:   %[[subview:.*]] = memref.subview
-  // CHECK:   %[[subview1:.*]] = memref.subview
-  // CHECK:   %[[subview2:.*]] = memref.subview
-  // CHECK:   %[[cast:.*]] = memref.cast %[[subview]]
-  // CHECK:   %[[cast1:.*]] = memref.cast %[[subview1]]
-  // CHECK:   %[[cast2:.*]] = memref.cast %[[subview2]]
-  // CHECK:   func.call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 49 - Bottleneck block 17, first Conv2D, 1x1 filter, stride 1, ReLU6
   %1196 = tensor.empty() : tensor<1x7x7x960xf32>
@@ -1277,14 +823,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x960xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %padded_49 = tensor.pad %1220 low[0, 1, 1, 0] high[0, 1, 1, 0] {
   ^bb0(%arg1: index, %arg2: index, %arg3: index, %arg4: index):
@@ -1303,22 +841,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x960xf32>
-  //
-  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins({{.*}} : memref<1x9x9x960xf32>, memref<3x3x960xf32>) outs({{.*}} : memref<1x7x7x960xf32>)
-  //
 
   // Layer 51 - Bottleneck block 17, second Conv2D, 1x1 filter, stride 1
   %1246 = tensor.empty() : tensor<1x7x7x320xf32>
   %1247 = linalg.fill ins(%cst : f32) outs(%1246 : tensor<1x7x7x320xf32>) -> tensor<1x7x7x320xf32>
   %1248 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%1245, %bottleneck_block_17_project_weights : tensor<1x7x7x960xf32>, tensor<1x1x960x320xf32>) outs(%1247 : tensor<1x7x7x320xf32>) -> tensor<1x7x7x320xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c320_i64]], %[[c960_i64]], %[[c960_i64]], %[[c320_i64]], %[[c320_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 52 - Conv2D, 1x1 filter, stride 1, ReLU6
   %1269 = tensor.empty() : tensor<1x7x7x1280xf32>
@@ -1331,14 +858,6 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1308 = arith.minf %1307, %in_53 : f32
     linalg.yield %1308 : f32
   } -> tensor<1x7x7x1280xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c7_i64]], %[[c1280_i64]], %[[c320_i64]], %[[c320_i64]], %[[c1280_i64]], %[[c1280_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 53 - Average pooling
   %1294 = tensor.empty() : tensor<7x7xf32>
@@ -1356,22 +875,11 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.divf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x1x1x1280xf32>
-  //
-  // linalg.pooling_nhwc_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%alloc_134, %alloc_135 : memref<1x7x7x1280xf32>, memref<7x7xf32>) outs(%alloc_136 : memref<1x1x1x1280xf32>)
-  // CHECK: linalg.pooling_nhwc_sum {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
-  //
   
   // Layer 54 - Conv2D, 1x1 filter, stride 1
   %1302 = tensor.empty() : tensor<1x1x1x1001xf32>
   %1303 = linalg.fill ins(%cst : f32) outs(%1302 : tensor<1x1x1x1001xf32>) -> tensor<1x1x1x1001xf32>
   %1304 = linalg.conv_2d_nhwc_hwcf {dilations  = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%1301, %layer_54_logits_conv_weights : tensor<1x1x1x1280xf32>, tensor<1x1x1280x1001xf32>) outs(%1303 : tensor<1x1x1x1001xf32>) -> tensor<1x1x1x1001xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[c0_i1]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: %[[cast:.*]] = memref.cast
-  // CHECK: %[[cast1:.*]] = memref.cast
-  // CHECK: %[[cast2:.*]] = memref.cast
-  // CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
   
   %expanded = tensor.expand_shape %layer_54_logits_conv_biases [[0, 1, 2, 3]] : tensor<1001xf32> into tensor<1x1x1x1001xf32>
   %1305 = tensor.empty() : tensor<1x1x1x1001xf32>
@@ -1380,11 +888,164 @@ func.func @mobilenet(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1001xf32> {
     %1307 = arith.addf %in, %in_52 : f32
     linalg.yield %1307 : f32
   } -> tensor<1x1x1x1001xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_binary_dispatch(%[[c1_i64]], %[[c1_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1001_i64]], %[[c1_i64]], %[[c0_i64]]) : ({{.+}}) -> i64
-  // CHECK: call @xsmm_binary_invoke(%[[c1_i64]], %[[ret]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %collapsed_51 = tensor.collapse_shape %1306 [[0], [1, 2, 3]] : tensor<1x1x1x1001xf32> into tensor<1x1001xf32>
   return %collapsed_51 : tensor<1x1001xf32>
 }
+
+//
+// CHECK-LABEL: @mobilenet(
+// CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1001xf32> {
+//
+// Constant definitions
+// CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c112_i64:.+]] = arith.constant 112 : i64
+// CHECK-DAG: %[[c32_i64:.+]] = arith.constant 32 : i64
+// CHECK-DAG: %[[c3_i64:.+]] = arith.constant 3 : i64
+// CHECK-DAG: %[[c6_i64:.+]] = arith.constant 6 : i64
+// CHECK-DAG: %[[c16_i64:.+]] = arith.constant 16 : i64
+// CHECK-DAG: %[[c96_i64:.+]] = arith.constant 96 : i64
+// CHECK-DAG: %[[c56_i64:.+]] = arith.constant 56 : i64
+// CHECK-DAG: %[[c24_i64:.+]] = arith.constant 24 : i64
+// CHECK-DAG: %[[c144_i64:.+]] = arith.constant 144 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c28_i64:.+]] = arith.constant 28 : i64
+// CHECK-DAG: %[[c192_i64:.+]] = arith.constant 192 : i64
+// CHECK-DAG: %[[c14_i64:.+]] = arith.constant 14 : i64
+// CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
+// CHECK-DAG: %[[c384_i64:.+]] = arith.constant 384 : i64
+// CHECK-DAG: %[[c576_i64:.+]] = arith.constant 576 : i64
+// CHECK-DAG: %[[c7_i64:.+]] = arith.constant 7 : i64
+// CHECK-DAG: %[[c160_i64:.+]] = arith.constant 160 : i64
+// CHECK-DAG: %[[c960_i64:.+]] = arith.constant 960 : i64
+// CHECK-DAG: %[[c320_i64:.+]] = arith.constant 320 : i64
+// CHECK-DAG: %[[c1280_i64:.+]] = arith.constant 1280 : i64
+// CHECK-DAG: %[[c1001_i64:.+]] = arith.constant 1001 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c224:.+]] = arith.constant 224 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c112:.+]] = arith.constant 112 : index
+// CHECK-DAG: %[[c56:.+]] = arith.constant 56 : index
+// CHECK-DAG: %[[c28:.+]] = arith.constant 28 : index
+// CHECK-DAG: %[[c14:.+]] = arith.constant 14 : index
+// CHECK-DAG: %[[c7:.+]] = arith.constant 7 : index
+// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[c3:.+]] = arith.constant 3 : index
+//
+// Check all matmul calls
+// CHECK: %[[matDis34:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c32_i64]], %[[c3_i64]], %[[c6_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis34]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis35:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c16_i64]], %[[c32_i64]], %[[c32_i64]], %[[c16_i64]], %[[c16_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis35]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis36:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c96_i64]], %[[c16_i64]], %[[c16_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis36]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis37:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c96_i64]], %[[c96_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis37]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis38:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis38]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis39:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c24_i64]], %[[c144_i64]], %[[c144_i64]], %[[c24_i64]], %[[c24_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis39]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis38]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis41:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c144_i64]], %[[c144_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis41]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis42:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis43:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c32_i64]], %[[c192_i64]], %[[c192_i64]], %[[c32_i64]], %[[c32_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis43]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis43]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis42]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis45:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c64_i64]], %[[c192_i64]], %[[c192_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis45]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis46:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis47:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c64_i64]], %[[c384_i64]], %[[c384_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis47]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis46]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis49:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c96_i64]], %[[c384_i64]], %[[c384_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis49]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis50:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis51:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c96_i64]], %[[c576_i64]], %[[c576_i64]], %[[c96_i64]], %[[c96_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis51]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis51]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis50]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis53:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c160_i64]], %[[c576_i64]], %[[c576_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis53]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis54:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis55:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c160_i64]], %[[c960_i64]], %[[c960_i64]], %[[c160_i64]], %[[c160_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis55]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis55]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis54]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK: %[[matDis57:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c320_i64]], %[[c960_i64]], %[[c960_i64]], %[[c320_i64]], %[[c320_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis57]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis58:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c1280_i64]], %[[c320_i64]], %[[c320_i64]], %[[c1280_i64]], %[[c1280_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis58]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.pooling_nhwc_sum
+// CHECK: %[[matDis59:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1001_i64]], %[[c1280_i64]], %[[c1280_i64]], %[[c1001_i64]], %[[c1001_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis59]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+//
+// No more matmul dispatches or invokes should be present
+// CHECK-NOT: call @xsmm_matmul_
+//
+// CHECK: return

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -33,17 +33,6 @@
 !multi_head_attention_output_tensor_t  = tensor<32x8x128xf32> // batch_size, embedding_size, seq_length
 !tensor_print_t = tensor<1x8xf32>
 
-
-// CHECK: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 
-// CHECK-DAG: func.func private @xsmm_unary_invoke(i64, i64, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK-DAG: func.func private @xsmm_matmul_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
-// CHECK-DAG: func.func private @xsmm_matmul_dispatch(i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-//
-// CHECK-LABEL: @multi_head_attention(
-// CHECK-SAME: %[[arg:.*]]: memref<32x8x128xf32>, %[[arg1:.*]]: memref<1x8xf32>) {
-//
 func.func @multi_head_attention(
         %input : !multi_head_attention_input_tensor_t, %output : !tensor_print_t) -> !tensor_print_t {
     %cst = arith.constant 0xFF800000 : f32
@@ -61,16 +50,6 @@ func.func @multi_head_attention(
     %cst_11 = arith.constant dense<4.471500e-02> : tensor<f32>
     %cst_12 = arith.constant dense<1.000000e+00> : tensor<f32>
     %cst_13 = arith.constant dense<9.99999996E-13> : tensor<f32>
-    //
-    // CHECK: %[[C1:.+]] = arith.constant 1 : i64
-    // CHECK-DAG: %[[FALSE:.+]] = arith.constant false
-    // CHECK-DAG: %[[C256:.+]] = arith.constant 256 : i64
-    // CHECK-DAG: %[[C128:.+]] = arith.constant 128 : i64
-    // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i64
-    // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : i64
-    // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
-    // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : i64
-    // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64 
 
     %transformer_layer_0_self_attention_attention_output_bias = arith.constant dense<1.1> : tensor<128xf32>
     %transformer_layer_0_self_attention_attention_output_kernel = arith.constant dense<1.2> : tensor<2x64x128xf32>
@@ -92,10 +71,6 @@ func.func @multi_head_attention(
     %81 = tensor.empty() : tensor<256x128xf32>
     %82 = linalg.fill ins(%cst_1 : f32) outs(%81 : tensor<256x128xf32>) -> tensor<256x128xf32> 
     %83 = linalg.matmul ins(%collapsed_20, %collapsed_21 : tensor<256x128xf32>, tensor<128x128xf32>) outs(%82 : tensor<256x128xf32>) -> tensor<256x128xf32>
-    // 
-    // CHECK: %[[DISPATCH1:.+]] = call @xsmm_matmul_dispatch(%[[C1]], %[[FALSE]], %[[C256]], %[[C128]], %[[C128]], %[[C128]], %[[C128]], %[[C128]]) : ({{.+}}) -> i64
-    // CHECK: call @xsmm_matmul_invoke(%{{.+}}, %[[DISPATCH1]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     %expanded_22 = tensor.expand_shape %83 [[0, 1], [2, 3]] : tensor<256x128xf32> into tensor<32x8x2x64xf32>
     %84 = tensor.empty() : tensor<32x8x2x64xf32> 
     %85 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%transformer_layer_0_self_attention_key_bias : tensor<2x64xf32>) outs(%84 : tensor<32x8x2x64xf32>) {
@@ -103,48 +78,29 @@ func.func @multi_head_attention(
       linalg.yield %in : f32
     } -> tensor<32x8x2x64xf32>
     %86 = tensor.empty() : tensor<32x8x2x64xf32>
-    //
-    // CHECK: %[[DISPATCH2:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C2]], %[[C64]], %[[C64]], %[[C64]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH2]], %{{.+}}, %{{.+}})
-    //
      %87 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%expanded_22, %85 : tensor<32x8x2x64xf32>, tensor<32x8x2x64xf32>) outs(%86 : tensor<32x8x2x64xf32>) {
     ^bb0(%in: f32, %in_74: f32, %out: f32):
       %490 = arith.addf %in, %in_74 : f32
       linalg.yield %490 : f32
     } -> tensor<32x8x2x64xf32>
-    //
-    // CHECK: %[[DISPATCH3:.+]] = call @xsmm_binary_dispatch(%[[C1]], %[[C2]], %[[C64]], %[[C64]], %[[C64]], %[[C64]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_binary_invoke(%{{.+}}, %[[DISPATCH3]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
 
     // Encoder 1 - Linear layer (MatMul + Bias) for Query tensor
     %collapsed_23 = tensor.collapse_shape %transformer_layer_0_self_attention_query_kernel [[0], [1, 2]] : tensor<128x2x64xf32> into tensor<128x128xf32>
     %88 = tensor.empty() : tensor<256x128xf32>
     %89 = linalg.fill ins(%cst_1 : f32) outs(%88 : tensor<256x128xf32>) -> tensor<256x128xf32>
     %90 = linalg.matmul ins(%collapsed_20, %collapsed_23 : tensor<256x128xf32>, tensor<128x128xf32>) outs(%89 : tensor<256x128xf32>) -> tensor<256x128xf32>
-    //
-    // CHECK: call @xsmm_matmul_invoke(%{{.+}}, %[[DISPATCH1]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     %expanded_24 = tensor.expand_shape %90 [[0, 1], [2, 3]] : tensor<256x128xf32> into tensor<32x8x2x64xf32>
     %91 = tensor.empty() : tensor<32x8x2x64xf32> 
     %92 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%transformer_layer_0_self_attention_query_bias : tensor<2x64xf32>) outs(%91 : tensor<32x8x2x64xf32>) {
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x8x2x64xf32>
-    //
-    // CHECK: %[[DISPATCH4:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C2]], %[[C64]], %[[C64]], %[[C64]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH4]], %{{.+}}, %{{.+}})
-    //
     %93 = tensor.empty() : tensor<32x8x2x64xf32> 
     %94 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%expanded_24, %92 : tensor<32x8x2x64xf32>, tensor<32x8x2x64xf32>) outs(%93 : tensor<32x8x2x64xf32>) {
     ^bb0(%in: f32, %in_74: f32, %out: f32):
       %490 = arith.addf %in, %in_74 : f32
       linalg.yield %490 : f32
     } -> tensor<32x8x2x64xf32>
-    //
-    // CHECK: %[[DISPATCH5:.+]] = call @xsmm_binary_dispatch(%[[C1]], %[[C2]], %[[C64]], %[[C64]], %[[C64]], %[[C64]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_binary_invoke(%{{.+}}, %[[DISPATCH5]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     
     // Encoder 1 - Multi-head attention layer - 2 heads (logical)
     // That is why [batch_size, embedding_size, seq_length] output of linear layers gets split into [batch_size, embedding_size, number_of_heads, seq_length/number_of_heads]
@@ -182,19 +138,11 @@ func.func @multi_head_attention(
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x2x8x8xf32> 
-    //
-    // CHECK: %[[DISPATCH6:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C8]], %[[C8]], %[[C8]], %[[C8]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH6]], %{{.+}}, %{{.+}})
-    //
     %108 = tensor.empty() : tensor<32x2x8x8xf32> 
     %109 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%input_mask : tensor<32x1x8x8xf32>) outs(%108 : tensor<32x2x8x8xf32>) {
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x2x8x8xf32>
-    //
-    // CHECK: %[[DISPATCH7:.+]] = call @xsmm_unary_dispatch(%c1_i64, %c8_i64, %c8_i64, %c8_i64, %c8_i64, %c1_i64, %c0_i64) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH7]], %{{.+}}, %{{.+}})
-    //
     // Encoder 1 - Multi-head attention - Add of Mask to MatMul(linear(Key), linear(Query))
     %110 = tensor.empty() : tensor<32x2x8x8xf32>
     %111 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%107, %109 : tensor<32x2x8x8xf32>, tensor<32x2x8x8xf32>) outs(%110 : tensor<32x2x8x8xf32>) {
@@ -202,10 +150,6 @@ func.func @multi_head_attention(
       %490 = arith.addf %in, %in_74 : f32
       linalg.yield %490 : f32
     } -> tensor<32x2x8x8xf32> 
-    //
-    // CHECK: %[[DISPATCH8:.+]] = call @xsmm_binary_dispatch(%[[C1]], %[[C8]], %[[C8]], %[[C8]], %[[C8]], %[[C8]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_binary_invoke(%{{.+}}, %[[DISPATCH8]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
 
     // Encoder 1 - not sure what this block is.. looks like some form of activation
     %112 = tensor.empty() : tensor<32x2x8xf32>
@@ -221,10 +165,6 @@ func.func @multi_head_attention(
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x2x8x8xf32> 
-    //
-    // CHECK: %[[DISPATCH9:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C8]], %[[C8]], %[[C8]], %[[C8]], %[[C1]], %[[C4]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH9]], %{{.+}}, %{{.+}})
-    //
     %117 = tensor.empty() : tensor<32x2x8x8xf32>
     %118 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%111, %116 : tensor<32x2x8x8xf32>, tensor<32x2x8x8xf32>) outs(%117 : tensor<32x2x8x8xf32>) {
     ^bb0(%in: f32, %in_74: f32, %out: f32):
@@ -253,10 +193,6 @@ func.func @multi_head_attention(
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x2x8x8xf32> 
-    //
-    // CHECK: %[[DISPATCH10:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C8]], %[[C8]], %[[C8]], %[[C8]], %[[C1]], %[[C4]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH10]], %{{.+}}, %{{.+}})
-    //
     %126 = tensor.empty() : tensor<32x2x8x8xf32>
     %127 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%120, %125 : tensor<32x2x8x8xf32>, tensor<32x2x8x8xf32>) outs(%126 : tensor<32x2x8x8xf32>) {
     ^bb0(%in: f32, %in_74: f32, %out: f32):
@@ -269,29 +205,18 @@ func.func @multi_head_attention(
     %128 = tensor.empty() : tensor<256x128xf32>
     %129 = linalg.fill ins(%cst_1 : f32) outs(%128 : tensor<256x128xf32>) -> tensor<256x128xf32> 
     %130 = linalg.matmul ins(%collapsed_20, %collapsed_30 : tensor<256x128xf32>, tensor<128x128xf32>) outs(%129 : tensor<256x128xf32>) -> tensor<256x128xf32>
-    //
-    // CHECK: call @xsmm_matmul_invoke(%{{.+}}, %[[DISPATCH1]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     %expanded_31 = tensor.expand_shape %130 [[0, 1], [2, 3]] : tensor<256x128xf32> into tensor<32x8x2x64xf32>
     %131 = tensor.empty() : tensor<32x8x2x64xf32>
     %132 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%transformer_layer_0_self_attention_value_bias : tensor<2x64xf32>) outs(%131 : tensor<32x8x2x64xf32>) {
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x8x2x64xf32>
-    //
-    // CHECK: %[[DISPATCH11:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C2]], %[[C64]], %[[C64]], %[[C64]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH11]], %{{.+}}, %{{.+}})
-    //
     %133 = tensor.empty() : tensor<32x8x2x64xf32> 
     %134 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%expanded_31, %132 : tensor<32x8x2x64xf32>, tensor<32x8x2x64xf32>) outs(%133 : tensor<32x8x2x64xf32>) {
     ^bb0(%in: f32, %in_74: f32, %out: f32):
       %490 = arith.addf %in, %in_74 : f32
       linalg.yield %490 : f32
     } -> tensor<32x8x2x64xf32>
-    // 
-    // CHECK: %[[DISPATCH12:.+]] = call @xsmm_binary_dispatch(%[[C1]], %[[C2]], %[[C64]], %[[C64]], %[[C64]], %[[C64]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_binary_invoke(%{{.+}}, %[[DISPATCH12]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     // Encoder 1 - Multi-head attention - MatMul(softmax, linear(Value))
     %135 = tensor.empty() : tensor<32x2x8x64xf32>
     %136 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%134 : tensor<32x8x2x64xf32>) outs(%135 : tensor<32x2x8x64xf32>) {
@@ -303,7 +228,6 @@ func.func @multi_head_attention(
     %137 = tensor.empty() : tensor<64x8x64xf32>
     %138 = linalg.fill ins(%cst_1 : f32) outs(%137 : tensor<64x8x64xf32>) -> tensor<64x8x64xf32>
     // TODO: Make this work
-    // CHECK: linalg.batch_matmul
     %139 = linalg.batch_matmul ins(%collapsed_32, %collapsed_33 : tensor<64x8x8xf32>, tensor<64x8x64xf32>) outs(%138 : tensor<64x8x64xf32>) -> tensor<64x8x64xf32>
     %expanded_34 = tensor.expand_shape %139 [[0, 1], [2], [3]] : tensor<64x8x64xf32> into tensor<32x2x8x64xf32>
     %140 = tensor.empty() : tensor<32x8x2x64xf32>
@@ -318,29 +242,18 @@ func.func @multi_head_attention(
     %142 = tensor.empty() : tensor<256x128xf32>
     %143 = linalg.fill ins(%cst_1 : f32) outs(%142 : tensor<256x128xf32>) -> tensor<256x128xf32>
     %144 = linalg.matmul ins(%collapsed_35, %collapsed_36 : tensor<256x128xf32>, tensor<128x128xf32>) outs(%143 : tensor<256x128xf32>) -> tensor<256x128xf32>
-    //
-    // CHECK: call @xsmm_matmul_invoke(%{{.+}}, %[[DISPATCH1]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     %expanded_37 = tensor.expand_shape %144 [[0, 1], [2]] : tensor<256x128xf32> into tensor<32x8x128xf32>
     %145 = tensor.empty() : tensor<32x8x128xf32> 
     %146 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%transformer_layer_0_self_attention_attention_output_bias : tensor<128xf32>) outs(%145 : tensor<32x8x128xf32>) {
     ^bb0(%in: f32, %out: f32):
       linalg.yield %in : f32
     } -> tensor<32x8x128xf32>
-    //
-    // CHECK: %[[DISPATCH13:.+]] = call @xsmm_unary_dispatch(%[[C1]], %[[C8]], %[[C128]], %[[C128]], %[[C128]], %[[C1]], %[[C4]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_unary_invoke(%{{.+}}, %[[DISPATCH13]], %{{.+}}, %{{.+}})
-    //
     %147 = tensor.empty() : tensor<32x8x128xf32> 
     %148 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%expanded_37, %146 : tensor<32x8x128xf32>, tensor<32x8x128xf32>) outs(%147 : tensor<32x8x128xf32>) {
     ^bb0(%in: f32, %in_74: f32, %out: f32):
       %490 = arith.addf %in, %in_74 : f32
       linalg.yield %490 : f32
     } -> tensor<32x8x128xf32>
-    //
-    // CHECK: %[[DISPATCH14:.+]] = call @xsmm_binary_dispatch(%[[C1]], %[[C8]], %[[C128]], %[[C128]], %[[C128]], %[[C128]], %[[C1]], %[[C0]]) : ({{.+}}) -> i64
-    // CHECK: func.call @xsmm_binary_invoke(%{{.+}}, %[[DISPATCH14]], %{{.+}}, %{{.+}}, %{{.+}})
-    //
     // Extract a 2D slice for printing
     %149 = tensor.extract_slice %148[0, 0, 0][1, 1, 8][1, 1, 1] : tensor<32x8x128xf32> to !tensor_print_t
     // Copy the slice to the argument output tensor
@@ -349,6 +262,49 @@ func.func @multi_head_attention(
 
     return %ret : !tensor_print_t
 }
+
+// CHECK-DAG: func.func private @xsmm_binary_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
+// CHECK-DAG: func.func private @xsmm_binary_dispatch(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 
+// CHECK-DAG: func.func private @xsmm_unary_invoke(i64, i64, memref<*xf32>, memref<*xf32>)
+// CHECK-DAG: func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK-DAG: func.func private @xsmm_matmul_invoke(i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>)
+// CHECK-DAG: func.func private @xsmm_matmul_dispatch(i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+//
+// CHECK-LABEL: @multi_head_attention(
+// CHECK-SAME: %[[arg:.*]]: memref<32x8x128xf32>, %[[arg1:.*]]: memref<1x8xf32>) {
+//
+// Constant definitions
+// CHECK-DAG: %[[c1_i64:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[false:.+]] = arith.constant false
+// CHECK-DAG: %[[c256_i64:.+]] = arith.constant 256 : i64
+// CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
+// CHECK-DAG: %[[c2_i64:.+]] = arith.constant 2 : i64
+// CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c8_i64:.+]] = arith.constant 8 : i64
+// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[c8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[c2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[cst_0:.+]] = arith.constant -0.000000e+00 : f32
+// CHECK-DAG: %[[cst_1:.+]] = arith.constant 0xFF800000 : f32
+//
+// Check all matmul calls
+// CHECK: %[[matDis10:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c256_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+// CHECK: linalg.batch_matmul
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+// CHECK: linalg.batch_matmul
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+//
+// No more matmul dispatches or invokes should be present
+// CHECK-NOT: call @xsmm_matmul_
+//
+// CHECK: return
 
 // Output
 // EXEC:      ( 35651.7, 35651.7, 35651.7, 35651.7,

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -278,16 +278,6 @@ func.func @multi_head_attention(
 // CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c256_i64:.+]] = arith.constant 256 : i64
 // CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
-// CHECK-DAG: %[[c2_i64:.+]] = arith.constant 2 : i64
-// CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
-// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
-// CHECK-DAG: %[[c8_i64:.+]] = arith.constant 8 : i64
-// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
-// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
-// CHECK-DAG: %[[c1:.+]] = arith.constant 1 : index
-// CHECK-DAG: %[[c8:.+]] = arith.constant 8 : index
-// CHECK-DAG: %[[c2:.+]] = arith.constant 2 : index
 // CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG: %[[cst_0:.+]] = arith.constant -0.000000e+00 : f32
 // CHECK-DAG: %[[cst_1:.+]] = arith.constant 0xFF800000 : f32

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -278,21 +278,46 @@ func.func @multi_head_attention(
 // CHECK-DAG: %[[false:.+]] = arith.constant false
 // CHECK-DAG: %[[c256_i64:.+]] = arith.constant 256 : i64
 // CHECK-DAG: %[[c128_i64:.+]] = arith.constant 128 : i64
+// CHECK-DAG: %[[c2_i64:.+]] = arith.constant 2 : i64
+// CHECK-DAG: %[[c64_i64:.+]] = arith.constant 64 : i64
+// CHECK-DAG: %[[c0_i64:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[c8_i64:.+]] = arith.constant 8 : i64
+// CHECK-DAG: %[[c4_i64:.+]] = arith.constant 4 : i64
 // CHECK-DAG: %[[cst:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG: %[[cst_0:.+]] = arith.constant -0.000000e+00 : f32
 // CHECK-DAG: %[[cst_1:.+]] = arith.constant 0xFF800000 : f32
 //
-// Check all matmul calls
-// CHECK: %[[matDis10:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c256_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+// Check all XSMM calls
+// CHECK: %[[xsmmDis10:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c256_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: %[[xsmmDis11:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK: %[[xsmmDis12:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c2_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
 // CHECK: linalg.batch_matmul
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+// CHECK: %[[xsmmDis13:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis13]]
+// CHECK: %[[xsmmDis14:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis14]]
+// CHECK: %[[xsmmDis15:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c8_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis15]]
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis11]]
+// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis12]]
 // CHECK: linalg.batch_matmul
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis10]],{{.*}})
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[xsmmDis10]]
+// CHECK: %[[xsmmDis16:.+]] = call @xsmm_unary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c4_i64]]) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_unary_invoke(%[[c1_i64]], %[[xsmmDis16]]
+// CHECK: %[[xsmmDis17:.+]] = call @xsmm_binary_dispatch(%[[c1_i64]], %[[c8_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c1_i64]], %[[c0_i64]]) : (i64, i64, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK:     func.call @xsmm_binary_invoke(%[[c1_i64]], %[[xsmmDis17]]
 //
-// No more matmul dispatches or invokes should be present
-// CHECK-NOT: call @xsmm_matmul_
+// No more XSMM dispatches or invokes should be present
+// CHECK-NOT: call @xsmm_
 //
 // CHECK: return
 

--- a/test/Models/resnet50v1.mlir
+++ b/test/Models/resnet50v1.mlir
@@ -95,10 +95,6 @@
 #map4 = affine_map<(d0, d1) -> (d0, d1)>
 #map5 = affine_map<(d0, d1) -> (d0)>
 
-//
-// CHECK-LABEL: @resnet50v1(
-// CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1000xf32> {
-//
 func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
   %cst = arith.constant 0xFF800000 : f32
   %cst_0 = arith.constant 0.000000e+00 : f32
@@ -118,35 +114,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
   %cst_14 = arith.constant dense<0.000000e+00> : tensor<1x56x56x256xf32>
   %cst_15 = arith.constant dense<0.000000e+00> : tensor<1x56x56x64xf32>
   %cst_16 = arith.constant dense<0.000000e+00> : tensor<1x112x112x64xf32>
-
-  // CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
-  // CHECK-DAG: %[[false:.*]] = arith.constant false
-  // CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
-  // CHECK-DAG: %[[c3_i64:.*]] = arith.constant 3 : i64
-  // CHECK-DAG: %[[c4_i64:.*]] = arith.constant 4 : i64
-  // CHECK-DAG: %[[c6_i64:.*]] = arith.constant 6 : i64
-  // CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
-  // CHECK-DAG: %[[c14_i64:.*]] = arith.constant 14 : i64
-  // CHECK-DAG: %[[c28_i64:.*]] = arith.constant 28 : i64
-  // CHECK-DAG: %[[c56_i64:.*]] = arith.constant 56 : i64
-  // CHECK-DAG: %[[c64_i64:.*]] = arith.constant 64 : i64
-  // CHECK-DAG: %[[c112_i64:.*]] = arith.constant 112 : i64
-  // CHECK-DAG: %[[c128_i64:.*]] = arith.constant 128 : i64
-  // CHECK-DAG: %[[c256_i64:.*]] = arith.constant 256 : i64
-  // CHECK-DAG: %[[c512_i64:.*]] = arith.constant 512 : i64
-  // CHECK-DAG: %[[c1000_i64:.*]] = arith.constant 1000 : i64
-  // CHECK-DAG: %[[c1024_i64:.*]] = arith.constant 1024 : i64
-  // CHECK-DAG: %[[c2048_i64:.*]] = arith.constant 2048 : i64
-  // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
-  // CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
-  // CHECK-DAG: %[[c14:.*]] = arith.constant 14 : index
-  // CHECK-DAG: %[[c28:.*]] = arith.constant 28 : index
-  // CHECK-DAG: %[[c56:.*]] = arith.constant 56 : index
-  // CHECK-DAG: %[[c112:.*]] = arith.constant 112 : index
-  // CHECK-DAG: %[[cst:.*]] = arith.constant 0.000000e+00 : f32
-  // CHECK-DAG: %[[cst_0:.*]] = arith.constant 0xFF800000 : f32
   
   %layer-2.kernel = arith.constant dense<1.000000e+00> : tensor<7x7x3x64xf32>
   %layer-2.bias = arith.constant dense<5.000000e-01> : tensor<64xf32>
@@ -277,14 +244,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x112x112x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c64_i64]], %[[c3_i64]], %[[c6_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c112]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
   
   // ReLU
   %27 = tensor.empty() : tensor<1x112x112x64xf32>
@@ -304,9 +263,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
   %30 = tensor.empty() : tensor<1x56x56x64xf32>
   %31 = linalg.fill ins(%cst : f32) outs(%30 : tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
   %32 = linalg.pooling_nhwc_max {dilations = dense<1> : vector<2xi64>, strides =  dense<2> : vector<2xi64>} ins(%padded_17, %29 : tensor<1x114x114x64xf32>, tensor<3x3xf32>) outs(%31 : tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: linalg.pooling_nhwc_max {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
-  //
   
   // Layer 3 - Conv block 1 - Conv2D, 1x1 filter, stride 1, BiasAdd
   %33 = tensor.empty() : tensor<1x56x56x256xf32>
@@ -323,14 +279,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 4 - Conv block 1 - Conv2D, 1x1 filter, stride 1, BiasAdd, ReLU
   %60 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -347,14 +295,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %87 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -384,14 +324,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %116 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -416,14 +348,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Conv block 1 - Add
   %145 = tensor.empty() : tensor<1x56x56x256xf32>
@@ -456,14 +380,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %176 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -493,14 +409,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %205 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -525,14 +433,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 1 - Add
   %234 = tensor.empty() : tensor<1x56x56x256xf32>
@@ -565,14 +465,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]],  %[[c56_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]] 
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %265 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -602,14 +494,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x64xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %294 = tensor.empty() : tensor<1x56x56x64xf32>
@@ -634,14 +518,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x56x56x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c56]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 2 - Add
   %323 = tensor.empty() : tensor<1x56x56x256xf32>
@@ -674,14 +550,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c256_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 14 - Conv block 2 - Conv2D, 1x1 filter, stride 2, BiasAdd, ReLU.
   %354 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -698,14 +566,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c256_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %381 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -734,14 +594,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %410 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -766,14 +618,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Conv block 2 - Add
   %439 = tensor.empty() : tensor<1x28x28x512xf32>
@@ -806,14 +650,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %470 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -842,14 +678,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %499 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -874,14 +702,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %530 = tensor.empty() : tensor<1x28x28x512xf32>
@@ -906,14 +726,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %559 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -942,14 +754,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %588 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -974,14 +778,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]],  %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 4 - Add
   %617 = tensor.empty() : tensor<1x28x28x512xf32>
@@ -1014,14 +810,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %648 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -1050,14 +838,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x128xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %677 = tensor.empty() : tensor<1x28x28x128xf32>
@@ -1082,14 +862,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x28x28x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c28]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 5 - Add
   %706 = tensor.empty() : tensor<1x28x28x512xf32>
@@ -1122,14 +894,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 27 - Conv block 3 - Conv2D, 1x1 filter, stride 2, BiasAdd, ReLU
   %737 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1146,14 +910,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %764 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1182,14 +938,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %793 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1214,14 +962,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Conv block 3 - Add
   %822 = tensor.empty() : tensor<1x14x14x1024xf32>
@@ -1254,14 +994,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %853 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1290,14 +1022,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %882 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1322,14 +1046,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 6 - Add
   %911 = tensor.empty() : tensor<1x14x14x1024xf32>
@@ -1362,14 +1078,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %942 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1398,14 +1106,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %971 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1430,14 +1130,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 7 - Add
   %1000 = tensor.empty() : tensor<1x14x14x1024xf32>
@@ -1470,14 +1162,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1031 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1506,14 +1190,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1060 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1538,14 +1214,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 8 - Add
   %1089 = tensor.empty() : tensor<1x14x14x1024xf32>
@@ -1578,14 +1246,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1120 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1614,14 +1274,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1149 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1646,14 +1298,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 9 - Add
   %1178 = tensor.empty() : tensor<1x14x14x1024xf32>
@@ -1686,14 +1330,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1209 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1722,14 +1358,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x256xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1238 = tensor.empty() : tensor<1x14x14x256xf32>
@@ -1754,14 +1382,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x14x14x1024xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c14]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 10 - Add
   %1267 = tensor.empty() : tensor<1x14x14x1024xf32>
@@ -1794,14 +1414,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x2048xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Layer 46 - Conv block 4 - Conv2D, 1x1 filter, stride 2, BiasAdd, ReLU.
   %1298 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -1818,14 +1430,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1325 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -1854,14 +1458,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1354 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -1886,14 +1482,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x2048xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Conv block 4 - Add
   %1383 = tensor.empty() : tensor<1x7x7x2048xf32>
@@ -1926,14 +1514,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1414 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -1962,14 +1542,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1443 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -1994,14 +1566,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x2048xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 11 - Add
   %1472 = tensor.empty() : tensor<1x7x7x2048xf32>
@@ -2034,14 +1598,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1503 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -2070,14 +1626,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x512xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // ReLU
   %1532 = tensor.empty() : tensor<1x7x7x512xf32>
@@ -2102,14 +1650,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
     %1591 = arith.addf %in, %in_34 : f32
     linalg.yield %1591 : f32
   } -> tensor<1x7x7x2048xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: scf.for %[[arg2:.*]] = %[[c0]] to %[[c7]] step %[[c1]]
-  // CHECK:   %[[cast:.*]] = memref.cast
-  // CHECK:   %[[cast1:.*]] = memref.cast
-  // CHECK:   %[[cast2:.*]] = memref.cast
-  // CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   // Identity block 12 - Add
   %1561 = tensor.empty() : tensor<1x7x7x2048xf32>
@@ -2145,13 +1685,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
   %1570 = tensor.empty() : tensor<1x1000xf32>
   %1571 = linalg.fill ins(%cst_0 : f32) outs(%1570 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
   %1572 = linalg.matmul ins(%1569, %layer-176.kernel : tensor<1x2048xf32>, tensor<2048x1000xf32>) outs(%1571 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
-  //
-  // CHECK: %[[ret:.*]] = {{.*}}call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-  // CHECK: %[[cast:.*]] = memref.cast
-  // CHECK: %[[cast1:.*]] = memref.cast
-  // CHECK: %[[cast2:.*]] = memref.cast
-  // CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[ret]], %[[cast]], %[[cast1]], %[[cast2]]) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
-  //
 
   %expanded = tensor.expand_shape %layer-176.bias [[0, 1]] : tensor<1000xf32> into tensor<1x1000xf32>
   %1573 = tensor.empty() : tensor<1x1000xf32>
@@ -2205,4 +1738,170 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
   return %1590 : tensor<1x1000xf32>
 }
 
-
+// CHECK-LABEL: @resnet50v1(
+// CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1000xf32> {
+//
+// Constant definitions
+// CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[false:.*]] = arith.constant false
+// CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
+// CHECK-DAG: %[[c3_i64:.*]] = arith.constant 3 : i64
+// CHECK-DAG: %[[c4_i64:.*]] = arith.constant 4 : i64
+// CHECK-DAG: %[[c6_i64:.*]] = arith.constant 6 : i64
+// CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
+// CHECK-DAG: %[[c14_i64:.*]] = arith.constant 14 : i64
+// CHECK-DAG: %[[c28_i64:.*]] = arith.constant 28 : i64
+// CHECK-DAG: %[[c56_i64:.*]] = arith.constant 56 : i64
+// CHECK-DAG: %[[c64_i64:.*]] = arith.constant 64 : i64
+// CHECK-DAG: %[[c112_i64:.*]] = arith.constant 112 : i64
+// CHECK-DAG: %[[c128_i64:.*]] = arith.constant 128 : i64
+// CHECK-DAG: %[[c256_i64:.*]] = arith.constant 256 : i64
+// CHECK-DAG: %[[c512_i64:.*]] = arith.constant 512 : i64
+// CHECK-DAG: %[[c1000_i64:.*]] = arith.constant 1000 : i64
+// CHECK-DAG: %[[c1024_i64:.*]] = arith.constant 1024 : i64
+// CHECK-DAG: %[[c2048_i64:.*]] = arith.constant 2048 : i64
+// CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
+// CHECK-DAG: %[[c14:.*]] = arith.constant 14 : index
+// CHECK-DAG: %[[c28:.*]] = arith.constant 28 : index
+// CHECK-DAG: %[[c56:.*]] = arith.constant 56 : index
+// CHECK-DAG: %[[c112:.*]] = arith.constant 112 : index
+// CHECK-DAG: %[[cst:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[cst_0:.*]] = arith.constant 0xFF800000 : f32
+//
+// Check all matmul calls
+// CHECK: %[[matDis109:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c64_i64]], %[[c3_i64]], %[[c6_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis109]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: linalg.pooling_nhwc_max
+// CHECK: %[[matDis113:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis116:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis121:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis121]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis121]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis122:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c256_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis122]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis125:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c256_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis125]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis130:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis132:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis133:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis133]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis136:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis136]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis140:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis141:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis143:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis144:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis144]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis147:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis147]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis151:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis152:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis154:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis154]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis154]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: %[[matDis155:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis155]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+//
+// No more matmul dispatches or invokes should be present
+// CHECK-NOT: call @xsmm_matmul_
+//
+// CHECK: return

--- a/test/Models/resnet50v1.mlir
+++ b/test/Models/resnet50v1.mlir
@@ -1742,11 +1742,9 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK-SAME: %[[arg:.*]]: memref<1x224x224x3xf32>) -> memref<1x1000xf32> {
 //
 // Constant definitions
-// CHECK-DAG: %[[c0_i64:.*]] = arith.constant 0 : i64
 // CHECK-DAG: %[[false:.*]] = arith.constant false
 // CHECK-DAG: %[[c1_i64:.*]] = arith.constant 1 : i64
 // CHECK-DAG: %[[c3_i64:.*]] = arith.constant 3 : i64
-// CHECK-DAG: %[[c4_i64:.*]] = arith.constant 4 : i64
 // CHECK-DAG: %[[c6_i64:.*]] = arith.constant 6 : i64
 // CHECK-DAG: %[[c7_i64:.*]] = arith.constant 7 : i64
 // CHECK-DAG: %[[c14_i64:.*]] = arith.constant 14 : i64
@@ -1762,7 +1760,6 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // CHECK-DAG: %[[c2048_i64:.*]] = arith.constant 2048 : i64
 // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
 // CHECK-DAG: %[[c7:.*]] = arith.constant 7 : index
 // CHECK-DAG: %[[c14:.*]] = arith.constant 14 : index
 // CHECK-DAG: %[[c28:.*]] = arith.constant 28 : index

--- a/test/Models/resnet50v1.mlir
+++ b/test/Models/resnet50v1.mlir
@@ -1771,132 +1771,132 @@ func.func @resnet50v1(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x1000xf32> {
 // Check all matmul calls
 // CHECK: %[[matDis109:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c112_i64]], %[[c64_i64]], %[[c3_i64]], %[[c6_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c112]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis109]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis109]]
 // CHECK: linalg.pooling_nhwc_max
 // CHECK: %[[matDis113:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]]
 // CHECK: %[[matDis116:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]]
 // CHECK: %[[matDis121:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c56_i64]], %[[c64_i64]], %[[c256_i64]], %[[c256_i64]], %[[c64_i64]], %[[c64_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis121]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis121]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis121]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis121]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis116]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c56]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis113]]
 // CHECK: %[[matDis122:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c256_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis122]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis122]]
 // CHECK: %[[matDis125:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c256_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis125]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis125]]
 // CHECK: %[[matDis129:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]]
 // CHECK: %[[matDis130:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]]
 // CHECK: %[[matDis132:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c28_i64]], %[[c128_i64]], %[[c512_i64]], %[[c512_i64]], %[[c128_i64]], %[[c128_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis132]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis129]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c28]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis130]]
 // CHECK: %[[matDis133:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis133]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis133]]
 // CHECK: %[[matDis136:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis136]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis136]]
 // CHECK: %[[matDis140:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]]
 // CHECK: %[[matDis141:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]]
 // CHECK: %[[matDis143:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c14_i64]], %[[c256_i64]], %[[c1024_i64]], %[[c1024_i64]], %[[c256_i64]], %[[c256_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis143]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis140]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c14]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis141]]
 // CHECK: %[[matDis144:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis144]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis144]]
 // CHECK: %[[matDis147:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c1024_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis147]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis147]]
 // CHECK: %[[matDis151:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]]
 // CHECK: %[[matDis152:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]]
 // CHECK: %[[matDis154:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c7_i64]], %[[c512_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c512_i64]], %[[c512_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis154]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis154]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis154]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis154]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:       func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis151]]
 // CHECK: scf.for %[[arg1:.+]] = %[[c0]] to %[[c7]] step %[[c1]] {
-// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK:   func.call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis152]]
 // CHECK: %[[matDis155:.+]] = call @xsmm_matmul_dispatch(%[[c1_i64]], %[[false]], %[[c1_i64]], %[[c1000_i64]], %[[c2048_i64]], %[[c2048_i64]], %[[c1000_i64]], %[[c1000_i64]]) : (i64, i1, i64, i64, i64, i64, i64, i64) -> i64
-// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis155]],{{.*}}) : (i64, i64, memref<*xf32>, memref<*xf32>, memref<*xf32>) -> ()
+// CHECK: call @xsmm_matmul_invoke(%[[c1_i64]], %[[matDis155]]
 //
 // No more matmul dispatches or invokes should be present
 // CHECK-NOT: call @xsmm_matmul_


### PR DESCRIPTION
Adds extra cleanup stage directly after LICM and before lowering any ops to function calls to allow CSE to eliminate common operations now that they are hoisted out of loops e.g., eliminate repeated XSMM dispatch calls with the same arguments.

Resolves #377 