### PR TITLE
Fix brgemm rewrite to VNNI

### DIFF
--- a/lib/TPP/RewriteToBatchReduceGemm.cpp
+++ b/lib/TPP/RewriteToBatchReduceGemm.cpp
@@ -180,8 +180,8 @@ getSlicedOperands(OpBuilder &builder, Location loc, ValueRange localIvs,
   SmallVector<Value> slicedOperands;
   for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
     FailureOr<Value> slicedOperand;
-    AffineMap map = linalgOp.getMatchingIndexingMap(operand);
-    if (isVNNILoop && map.getNumResults() == 5) {
+    // In VNNI layout the second operand has size '4'.
+    if (isVNNILoop && operand->getOperandNumber() == 1) {
       slicedOperand = linalgx::utils::getSliceOperand(
           builder, operand, linalgOp, localIvs, valuesToUse, 4);
     } else {


### PR DESCRIPTION
We still need to clarify this but my understanding was that Brgemm VNNI was 3 - 4 - 2. Meaning the first operand was a slice of size 3, the second a slice of size 4 and so on. Unclear why the affine map checks was looking for a number of results equal to 5. This fixes MLP example.