### PR TITLE
Benchmarks - pass arg flags to tpp-run

### DIFF
--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -71,6 +71,8 @@ class BenchmarkController(object):
             self.unit = "gflops"
         if (not self.args.opt_args and 'opt-args' in fileArgs):
             self.args.opt_args = fileArgs['opt-args']
+        if (not self.args.run_args and 'run-args' in fileArgs):
+            self.args.run_args = fileArgs['run-args']
 
         # Make sure we get all we need
         self.logger.info("Validating arguments")
@@ -114,6 +116,7 @@ class BenchmarkController(object):
                                              '--entry-point-result=void',
                                              '--print=0',
                   ]
+        runCmd.extend(shlex.split(self.args.run_args))
         runResult = executor.run(runCmd, irContents)
         if runResult.stderr:
             self.logger.error(f"Error executing tpp-run: {runResult.stderr}")
@@ -171,6 +174,8 @@ if __name__ == '__main__':
                         help='Name of the entry point (checks RUN line)')
     parser.add_argument('-opt-args', type=str,
                         help='tpp-opt arguments (checks RUN line)')
+    parser.add_argument('-run-args', type=str,
+                        help='tpp-run arguments')
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help='The verbosity of logging output')
     parser.add_argument('-q', '--quiet', action='count', default=0,


### PR DESCRIPTION
Allows to pass optional tpp-run flags through benchmarks controller. This functionally lets benchmarks use high level tpp-run flags which influence IR generated by the runner.