### PR TITLE
Fix run-args split

### DIFF
--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -116,7 +116,8 @@ class BenchmarkController(object):
                                              '--entry-point-result=void',
                                              '--print=0',
                   ]
-        runCmd.extend(shlex.split(self.args.run_args))
+        if self.args.run_args:
+            runCmd.extend(shlex.split(self.args.run_args))
         runResult = executor.run(runCmd, irContents)
         if runResult.stderr:
             self.logger.error(f"Error executing tpp-run: {runResult.stderr}")


### PR DESCRIPTION
Adds a guard if check before splitting benchmark run-args flag as passing None to the split function is deprecated.