### PR TITLE
Enable better bufferization for tile and fuse

### DIFF
--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -683,18 +683,18 @@ struct TileConsumerAndFuseProducers
 
     auto &ctx = getContext();
     {
-      // Patterns for scf.for
+      // Patterns for scf.for.
       RewritePatternSet patterns(&ctx);
       patterns.add<ReplaceIterArgs>(&ctx);
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
     }
 
     {
-      // Patterns for scf.forall
+      // Patterns for scf.forall.
       RewritePatternSet patterns(&ctx);
       if (this->useForAll)
         patterns.add<ConvertToForAll>(&ctx);
-      // fold unit-extent dims for linalg on tensors.
+      // Fold unit-extent dims for linalg on tensors.
       linalg::populateFoldUnitExtentDimsViaSlicesPatterns(patterns);
       tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -32,6 +32,38 @@ using namespace mlir;
 
 namespace {
 
+struct ReplaceIterArgs : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+
+  void replaceIterArgs(PatternRewriter &rewriter, scf::ForOp outerFor,
+                       scf::ForOp innerFor) const {
+    assert(outerFor.getNumIterOperands() == innerFor.getNumIterOperands() &&
+           "expect same number of iter args");
+    Block *block = &(*innerFor.getRegion().begin());
+    for (auto it :
+         llvm::zip(outerFor.getIterOperands(), innerFor.getRegionIterArgs())) {
+      Value source = std::get<0>(it);
+      Value target = std::get<1>(it);
+      rewriter.replaceUsesWithIf(source, target, [&](OpOperand &use) {
+        return use.getOwner()->getBlock() == block;
+      });
+    }
+  }
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    auto metadata = forOp->getAttrOfType<StringAttr>("fusion");
+    if (!metadata || metadata.getValue() != "root")
+      return failure();
+    if (forOp.getNumRegionIterArgs() != 1)
+      return failure();
+    SmallVector<scf::ForOp> nestedLoops;
+    getPerfectlyNestedLoops(nestedLoops, forOp);
+    replaceIterArgs(rewriter, forOp, nestedLoops[nestedLoops.size() - 1]);
+    return success();
+  }
+};
+
 // Convert scf.for to scf.forall after fusion.
 struct ConvertToForAll : public OpRewritePattern<scf::ForOp> {
   using OpRewritePattern<scf::ForOp>::OpRewritePattern;
@@ -648,6 +680,12 @@ struct TileConsumerAndFuseProducers
         }
       }
     }
+
+    // Pattern to replace iter args of the outer most loop with region args of
+    // the inner most one.
+    RewritePatternSet patterns1(&getContext());
+    patterns1.add<ReplaceIterArgs>(&getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns1));
 
     RewritePatternSet patterns(&getContext());
     if (this->useForAll)

--- a/test/Passes/DefaultPipeline/mlp-to-stack.mlir
+++ b/test/Passes/DefaultPipeline/mlp-to-stack.mlir
@@ -36,8 +36,6 @@ func.func @mlp(%arg0: tensor<8x48x32x32xbf16>,
 // CHECK-LABEL: func.func @mlp(
 // CHECK:     call @xsmm_brgemm_dispatch
 // CHECK:     scf.parallel
-// CHECK-NOT:   memref.alloc()
-// CHECK:       memref.alloca() {alignment
 // CHECK:       call @xsmm_brgemm_invoke
 // CHECK-NOT:   memref.alloc()
 // CHECK:       memref.alloca() {alignment

--- a/test/Passes/dps-in-tile-and-fuse.mlir
+++ b/test/Passes/dps-in-tile-and-fuse.mlir
@@ -1,0 +1,80 @@
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers -cse | FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+
+// This test check that destination-passing-style is respected by fusion.
+// %arg3 should not be used in the scf.forall region.
+
+func.func @dps_test(%arg0: tensor<8x48x32x32xbf16>, 
+               %arg1: tensor<48x48x16x32x2xbf16>, 
+               %arg2: tensor<1536xbf16>, 
+               %arg3: tensor<8x48x32x32xbf16>) -> tensor<8x48x32x32xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x48x32x32xbf16>, tensor<48x48x16x32x2xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> tensor<8x48x32x32xbf16>
+  %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<1536xbf16> into tensor<48x32xbf16>
+  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %expanded : tensor<8x48x32x32xbf16>, tensor<48x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %add = arith.addf %in, %in_0 : bf16
+      linalg.yield %add : bf16
+  } -> tensor<8x48x32x32xbf16>
+  %3 = linalg.generic {__internal_linalg_transform__ = "fusion", indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<8x48x32x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %max = arith.maxf %in, %cst : bf16
+      linalg.yield %max : bf16
+  } -> tensor<8x48x32x32xbf16> 
+  return %3 : tensor<8x48x32x32xbf16>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4 floordiv 2, d3, d1)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1) -> (d1)>
+
+// CHECK-LABEL: func.func @dps_test
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<8x48x32x32xbf16>, 
+// CHECK-SAME:  %[[ARG1:.+]]: tensor<48x48x16x32x2xbf16>, 
+// CHECK-SAME:  %[[ARG2:.+]]: tensor<1536xbf16>, 
+// CHECK-SAME:  %[[ARG3:.+]]: tensor<8x48x32x32xbf16>
+// CHECK: %[[C48:.+]] = arith.constant 48 : index
+// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK: scf.forall (%[[I:.+]], %[[J:.+]]) in (%[[C8]], %[[C48]]) 
+// CHECK-SAME:  shared_outs(%[[ARG6:.+]] = %[[ARG3]])
+// CHECK: %[[SLICE_ARG0:.+]] = tensor.extract_slice 
+// CHECK-SAME:  %[[ARG0]][%[[I]], 0, 0, 0] [1, 48, 32, 32] [1, 1, 1, 1] 
+// CHECK-SAME:  : tensor<8x48x32x32xbf16> to tensor<48x32x32xbf16>
+// CHECK: %[[SLICE_ARG1:.+]] = tensor.extract_slice 
+// CHECK-SAME:  %[[ARG1:.+]][%[[J]], 0, 0, 0, 0] [1, 48, 16, 32, 2] [1, 1, 1, 1, 1] 
+// CHECK-SAME:  : tensor<48x48x16x32x2xbf16> to tensor<48x16x32x2xbf16>
+// CHECK: %[[SLICE_INIT:.+]] = tensor.extract_slice 
+// CHECK-SAME:  %[[ARG6]][%[[I]], %[[J]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] 
+// CHECK-SAME:  : tensor<8x48x32x32xbf16> to tensor<32x32xbf16>
+// CHECK: %[[MUL:.+]] = linalg.generic 
+// CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:  iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SLICE_ARG0]], %[[SLICE_ARG1]]
+// CHECK-SAME: outs(%[[SLICE_INIT]]
+// CHECK: %[[SLICE_EXPAND:.+]] = tensor.extract_slice 
+// CHECK-SAME:  %{{.+}}[%[[J]], 0] [1, 32] [1, 1] 
+// CHECK-SAME:  : tensor<48x32xbf16> to tensor<32xbf16>
+// CHECK: %[[ADD:.+]] = linalg.generic
+// CHECK-SAME:  indexing_maps = [#[[MAP3]], #[[MAP4]], #[[MAP3]]]
+// CHECK-SAME:  iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:  ins(%[[MUL]], %[[SLICE_EXPAND]]
+// CHECK-SAME:  outs(%[[SLICE_INIT]]
+// CHECK: %[[RELU:.+]] = linalg.generic
+// CHECK-SAME:  indexing_maps = [#[[MAP3]], #[[MAP3]]]
+// CHECK-SAME:  iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:  ins(%[[ADD]]
+// CHECK-SAME:  outs(%[[SLICE_INIT]]

--- a/test/Passes/dps-in-tile-and-fuse.mlir
+++ b/test/Passes/dps-in-tile-and-fuse.mlir
@@ -1,4 +1,6 @@
 // RUN: tpp-opt %s -tile-consumer-and-fuse-producers -cse | FileCheck %s
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers -cse -bufferize | FileCheck %s -check-prefix=ALLOC
+// ALLOC-COUNT-1: memref.alloc
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>

--- a/test/Passes/pass-mlp-fusion.mlir
+++ b/test/Passes/pass-mlp-fusion.mlir
@@ -9,28 +9,22 @@
 func.func @main(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
   %arg2: tensor<512xf32>,  %output: tensor<128x512xf32>) -> tensor<128x512xf32> {
   // CHECK: tpp.identity ins(%{{.*}} : memref<32xf32, strided<[1], offset: ?>>) 
-  // CHECK-SAME:  out(%{{.*}} : memref<32x32xf32>)
->>>>>>> a9c7cdd9 (Enable better bufferization for tile and fuse)
+  // CHECK-SAME:         outs(%{{.*}} : memref<32x32xf32>)
   %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<512xf32>) outs(%output : tensor<128x512xf32>) {
     ^bb0(%arg9: f32, %arg10: f32):
       linalg.yield %arg9 : f32
   } -> tensor<128x512xf32>
   // CHECK: tpp.matmul ins(%{{.*}} : memref<32x256xf32, strided<[256, 1], offset: ?>>, %{{.*}} : memref<256x32xf32, strided<[512, 1], offset: ?>>) 
-  // CHECK-SAME: out(%{{.*}} : memref<32x32xf32>)
->>>>>>> a9c7cdd9 (Enable better bufferization for tile and fuse)
+  // CHECK-SAME:       outs(%{{.*}} : memref<32x32xf32>)
   %2 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>) outs(%1 : tensor<128x512xf32>) attrs =  {iterator_ranges = [128, 512, 256]} {
     ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
       %16 = arith.mulf %arg9, %arg10 : f32
       %17 = arith.addf %arg11, %16 : f32
       linalg.yield %17 : f32
   } -> tensor<128x512xf32>
-  // CHECK: tpp.relu ins(%{{.*}} : memref<32x32xf32, strided<[512, 1], offset: ?>>) 
+  // CHECK: tpp.relu ins(%{{.*}} : memref<32x32xf32>) 
   // CHECK-SAME:     outs(%{{.*}} : memref<32x32xf32, strided<[512, 1], offset: ?>>)
   %c0 = arith.constant 0.0 : f32
-  // We don't map the relu anymore - as allOperandsHaveSameShapeAndStrides fails here.
-  // ins = memref<32x32xf32>)
-  // outs = memref<32x32xf32, strided<[512, 1], offset: ?>>
-  // see: 407
   %3 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<128x512xf32>) outs(%output : tensor<128x512xf32>) {
     ^bb0(%arg9: f32, %arg10: f32):
       %16 = arith.maxf %arg9, %c0 : f32


### PR DESCRIPTION
Replace iterators of the outermost loop with region arguments of the innermost one. The changes avoid later `bufferization` passes to insert allocation within the body of the innermost loop.

Fix: #384