### PR TITLE
OpTrait for checking unit strides in tpp.add

### DIFF
--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -37,6 +37,10 @@ def TppVNNIOperand : AnyTypeOf<[TppVNNIMemrefInput, AnyFloat]>;
 // following Numpy-style broadcast.
 def BroadcastableShape : NativeOpTrait<"tpp::BroadcastableShape">;
 
+// Tpp operation trait - make sure the stride in the fastest-varying
+// dimension is one.
+def UnitStrideInnerLoop : NativeOpTrait<"tpp::UnitStrideInnerLoop">;
+
 // Class for tpp binary operations.
 class Tpp_BinaryOp<string mnemonic, list<Trait> traits = []> :
   Tpp_Op<mnemonic, !listconcat(traits, [])> {
@@ -65,13 +69,14 @@ class Tpp_UnaryOp<string mnemonic, list<Trait> traits = []> :
 // AddOp
 //===----------------------------------------------------------------------===//
 
-def Tpp_AddOp : Tpp_BinaryOp<"add", [BroadcastableShape]> {
+def Tpp_AddOp : Tpp_BinaryOp<"add", [BroadcastableShape, 
+                                     UnitStrideInnerLoop]> {
   let summary = "Element-wise addition.";
   let description = [{
     The `tpp.add` operation performs element-wise addition on two-dimensional
     memrefs, writing the result on the output memref. No checks or assumption are
     made on the input/output arguments so the same memref can be passed both as
-    input and output. 
+    input and output. It supports broadcast semantic based on Numpy rules. 
 
     Example:
 

--- a/include/TPP/Dialect/Tpp/TppTraits.h
+++ b/include/TPP/Dialect/Tpp/TppTraits.h
@@ -7,13 +7,22 @@ namespace mlir {
 namespace OpTrait {
 namespace tpp {
 
-LogicalResult verifyTraitImpl(Operation *op);
+LogicalResult verifyBroadcastableShapeImpl(Operation *op);
+LogicalResult verifyUnitStrideInnerLoopImpl(Operation *op);
 
 template <typename ConcreteType>
 struct BroadcastableShape
     : public OpTrait::TraitBase<ConcreteType, BroadcastableShape> {
   static LogicalResult verifyTrait(Operation *op) {
-    return verifyTraitImpl(op);
+    return verifyBroadcastableShapeImpl(op);
+  }
+};
+
+template <typename ConcreteType>
+struct UnitStrideInnerLoop
+    : public OpTrait::TraitBase<ConcreteType, UnitStrideInnerLoop> {
+  static LogicalResult verifyTrait(Operation *op) {
+    return verifyUnitStrideInnerLoopImpl(op);
   }
 };
 

--- a/test/Dialect/Tpp/tpp-invalid.mlir
+++ b/test/Dialect/Tpp/tpp-invalid.mlir
@@ -119,3 +119,21 @@ func.func @tpp_add_check_broadcast_result(%arg0: memref<8x1xf32>, %arg1: memref<
   tpp.add ins(%arg1: memref<8x8xf32>, %arg1: memref<8x8xf32>) out(%arg0: memref<8x1xf32>)
   return 
 }
+
+// -----
+
+func.func @tpp_add_stride_inner_dim(%arg0: memref<8x8xf32, strided<[8, 2], offset: 0>>, 
+                                    %arg1: memref<8x8xf32>) {
+  // expected-error @below {{non-unit stride in the innermost varying dimension for operand 0}}
+  tpp.add ins(%arg0: memref<8x8xf32, strided<[8, 2], offset: 0>>, %arg1: memref<8x8xf32>) out(%arg1: memref<8x8xf32>)
+  return
+}
+
+// -----
+
+func.func @tpp_add_non_constant_stride(%arg0: memref<8x8xf32, strided<[?, ?], offset: 0>>,
+                                       %arg1: memref<8x8xf32>) {
+  // expected-error @below {{non-unit stride in the innermost varying dimension for operand 0}}
+  tpp.add ins(%arg0: memref<8x8xf32, strided<[?, ?], offset: 0>>, %arg1: memref<8x8xf32>) out(%arg1: memref<8x8xf32>)
+  return 
+}


### PR DESCRIPTION
Add an Native operation trait to verify innermost strides in a tpp.add operation. Require all the operand to have stride one in the fastest-varying dimension. Need to be done for all the other tpp ops.