### PR TITLE
Runner default pipeline options

### DIFF
--- a/test/Passes/DefaultPipeline/disable-def-pipe.mlir
+++ b/test/Passes/DefaultPipeline/disable-def-pipe.mlir
@@ -1,0 +1,11 @@
+// RUN: tpp-opt %s -disable-def-pipe -default-tpp-passes -split-input-file | FileCheck %s
+
+func.func @matmul(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %D : tensor<4x4xf32>
+}
+
+// CHECK-LABEL: func.func @matmul(
+// CHECK-NOT: {{.*}}call @xsmm_
+// CHECK: linalg.matmul

--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -162,19 +162,19 @@ LogicalResult MLIRBench::createKernelArgs() {
   builder.setInsertionPointToStart(&mainBody);
 
   for (auto &ty : kernel.getArgumentTypes()) {
-    auto arg = TypeSwitch<Type, llvm::Optional<Value>>(ty)
-                   .Case<MemRefType>([&](auto memRefTy) {
-                     // Create a memref global
-                     return createDenseMemref(builder, module, initType,
-                                              memRefTy, seed);
-                   })
-                   .Case<TensorType>([&](auto tensorTy) {
-                     // Create a dense const tensor and use it directly
-                     // as an input to the kernel
-                     return createDenseTensor(builder, initType, tensorTy,
-                                              seed);
-                   })
-                   .Default([&](auto t) { return std::nullopt; });
+    auto arg =
+        TypeSwitch<Type, llvm::Optional<Value>>(ty)
+            .Case<MemRefType>([&](auto memRefTy) {
+              // Create a memref global
+              return createDenseMemref(builder, module, initType, memRefTy,
+                                       seed);
+            })
+            .Case<TensorType>([&](auto tensorTy) {
+              // Create a dense const tensor and use it directly
+              // as an input to the kernel
+              return createDenseTensor(builder, initType, tensorTy, seed);
+            })
+            .Default([&](auto t) { return std::nullopt; });
 
     if (!arg)
       return failure();
@@ -365,6 +365,9 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
 
   // Apply the default preprocessing pass
   passManager.addPass(tpp::createDefaultTppPass(tppToLoops, linalgToLoops));
+
+  if (print == PrintStage::Mid)
+    passManager.addPass(createPrintIRPass());
 
   // Bufferization, if needed
   passManager.addNestedPass<func::FuncOp>(createTensorBufferizePass());

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -144,6 +144,7 @@ public:
   enum class PrintStage {
     None,
     Early, // After main generation, before optimization
+    Mid,   // After initial TPP-related optimizations
     Late,  // After optimizaiton, before LLVM dialect
     LLVM,  // Final MLIR, in LLVM dialect
     Invalid,

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -115,7 +115,7 @@ llvm::cl::opt<std::string> initType(
 // Print MLIR before lowering
 llvm::cl::opt<std::string> printMLIR(
     "print-mlir",
-    llvm::cl::desc("Print MLIR to stdout (early, def-pipe, late, llvm)"),
+    llvm::cl::desc("Print MLIR to stdout (early, mid, late, llvm)"),
     llvm::cl::init(""));
 
 // Print LLVM IR before lowering

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -113,23 +113,25 @@ llvm::cl::opt<std::string> initType(
     llvm::cl::init(""));
 
 // Print MLIR before lowering
-llvm::cl::opt<std::string>
-    printMLIR("print-mlir", llvm::cl::desc("Print MLIR to stdout (early, late, llvm)"),
-                llvm::cl::init(""));
+llvm::cl::opt<std::string> printMLIR(
+    "print-mlir",
+    llvm::cl::desc("Print MLIR to stdout (early, def-pipe, late, llvm)"),
+    llvm::cl::init(""));
 
 // Print LLVM IR before lowering
 llvm::cl::opt<bool> printLLVM("print-llvm",
-                             llvm::cl::desc("print LLVM IR before lowering"),
-                             llvm::cl::init(false));
+                              llvm::cl::desc("print LLVM IR before lowering"),
+                              llvm::cl::init(false));
 
 // Parses MLIR print stage
 MLIRBench::PrintStage parsePrintStage(StringRef stage) {
   return StringSwitch<MLIRBench::PrintStage>(stage)
-    .Case("", MLIRBench::PrintStage::None)
-    .Case("early", MLIRBench::PrintStage::Early)
-    .Case("late", MLIRBench::PrintStage::Late)
-    .Case("llvm", MLIRBench::PrintStage::LLVM)
-    .Default(MLIRBench::PrintStage::Invalid);
+      .Case("", MLIRBench::PrintStage::None)
+      .Case("early", MLIRBench::PrintStage::Early)
+      .Case("mid", MLIRBench::PrintStage::Mid)
+      .Case("late", MLIRBench::PrintStage::Late)
+      .Case("llvm", MLIRBench::PrintStage::LLVM)
+      .Default(MLIRBench::PrintStage::Invalid);
 }
 
 // This function will be called by the pass manager after parsing,


### PR DESCRIPTION
Extra utility options for default pipeline execution:
- `tpp-run` print IR right after DefaultTppPasses pass (the default pipeline)
- `tpp-opt` and `tpp-run` flag to disable default pipeline execution - useful for testing
 