### PR TITLE
Introduce structured matcher

### DIFF
--- a/include/TPP/CMakeLists.txt
+++ b/include/TPP/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(Dialect)
+add_subdirectory(IR)
 
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name TppCompiler)

--- a/include/TPP/CMakeLists.txt
+++ b/include/TPP/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory(Dialect)
-add_subdirectory(IR)
 
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name TppCompiler)

--- a/include/TPP/Dialect/Tpp/TppTraits.h
+++ b/include/TPP/Dialect/Tpp/TppTraits.h
@@ -7,14 +7,19 @@ namespace mlir {
 namespace OpTrait {
 namespace tpp {
 
-LogicalResult verifyBroadcastableShapeImpl(Operation *op);
-LogicalResult verifyUnitStrideInnerLoopImpl(Operation *op);
+LogicalResult verifyBroadcastableShape(Operation *op,
+                                       bool emitDiagnostic = true);
+LogicalResult verifyUnitStrideInnerLoop(Operation *op,
+                                        bool emitDiagnostic = true);
+
+LogicalResult checkBroadcastableShape(Operation *op);
+LogicalResult checkUnitStrideInnerLoop(Operation *op);
 
 template <typename ConcreteType>
 struct BroadcastableShape
     : public OpTrait::TraitBase<ConcreteType, BroadcastableShape> {
   static LogicalResult verifyTrait(Operation *op) {
-    return verifyBroadcastableShapeImpl(op);
+    return verifyBroadcastableShape(op);
   }
 };
 
@@ -22,7 +27,7 @@ template <typename ConcreteType>
 struct UnitStrideInnerLoop
     : public OpTrait::TraitBase<ConcreteType, UnitStrideInnerLoop> {
   static LogicalResult verifyTrait(Operation *op) {
-    return verifyUnitStrideInnerLoopImpl(op);
+    return verifyUnitStrideInnerLoop(op);
   }
 };
 

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -55,8 +55,17 @@ struct Operand {
   const size_t idx;
 };
 
-struct IsProjectedPermutation {};
-struct IsIdentity {};
+struct IsProjectedPermutation {
+  IsProjectedPermutation() = default;
+  bool operator()(AffineMap map) const {
+    return map.isProjectedPermutation(/*allowZeroInResults=*/true);
+  }
+};
+
+struct IsIdentity {
+  IsIdentity() = default;
+  bool operator()(AffineMap map) const { return map.isIdentity(); }
+};
 
 struct HasStaticShape {};
 
@@ -150,16 +159,14 @@ public:
       verifyInterface(std::function<LogicalResult(Operation *op)>);
 
   // Predicate on OpOperands.
-  StructuredOpMatcher &input(AllOperands tag, IsProjectedPermutation);
-  StructuredOpMatcher &input(AllOperands tag, IsIdentity);
   StructuredOpMatcher &input(AllOperands tag, HasStaticShape);
+  StructuredOpMatcher &input(AllOperands tag, std::function<bool(AffineMap)>);
   StructuredOpMatcher &input(Operand operand,
                              std::function<bool(AffineMap map)>);
 
   // Predicates on OpOperands.
-  StructuredOpMatcher &output(AllOperands tag, IsProjectedPermutation);
-  StructuredOpMatcher &output(AllOperands tag, IsIdentity);
   StructuredOpMatcher &output(AllOperands tag, HasStaticShape);
+  StructuredOpMatcher &output(AllOperands tag, std::function<bool(AffineMap)>);
   StructuredOpMatcher &output(Operand operand,
                               std::function<bool(AffineMap map)>);
 

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -35,21 +35,6 @@ private:
   const size_t upperBound;
 };
 
-struct AllDimsBut {
-  AllDimsBut() = delete;
-  explicit AllDimsBut(std::initializer_list<size_t> range) {
-    llvm::append_range(exceptions, range);
-  }
-  explicit AllDimsBut(RangeDims range) {
-    for (auto i = range.getLowerBound(); i < range.getUpperBound(); i++)
-      exceptions.push_back(i);
-  }
-  ArrayRef<size_t> getExceptions() const { return exceptions; }
-
-private:
-  SmallVector<size_t> exceptions;
-};
-
 struct AllOperands {};
 struct Operand {
   Operand() = delete;
@@ -178,7 +163,6 @@ public:
   StructuredOpMatcher &dim(RangeDims range,
                            SmallVector<mlir::utils::IteratorType> kinds);
   StructuredOpMatcher &dim(RangeDims range, mlir::utils::IteratorType kind);
-  StructuredOpMatcher &dim(AllDimsBut, mlir::utils::IteratorType kind);
 
   // Predicates on region.
   template <typename OpTy>

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -45,6 +45,7 @@ struct Operand {
 
 struct IsProjectedPermutation {
   IsProjectedPermutation() = default;
+  
   bool operator()(AffineMap map) const {
     return map.isProjectedPermutation(/*allowZeroInResults=*/true);
   }
@@ -52,6 +53,7 @@ struct IsProjectedPermutation {
 
 struct IsIdentity {
   IsIdentity() = default;
+  
   bool operator()(AffineMap map) const { return map.isIdentity(); }
 };
 

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -140,9 +140,9 @@ public:
   // Predicates on operation.
   StructuredOpMatcher &hasBufferSemantics();
   StructuredOpMatcher &hasTensorSemantics();
-  StructuredOpMatcher &inputs(std::function<bool(size_t)>);
-  StructuredOpMatcher &outputs(std::function<bool(size_t)>);
-  StructuredOpMatcher &inputs(BinaryPredicate);
+  StructuredOpMatcher &numDpsInputs(std::function<bool(size_t)>);
+  StructuredOpMatcher &numDpsInits(std::function<bool(size_t)>);
+  StructuredOpMatcher &numDpsInputs(BinaryPredicate);
   StructuredOpMatcher &
       verifyInterface(std::function<LogicalResult(Operation *op)>);
 

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -107,7 +107,7 @@ struct EqualsTo {
   explicit EqualsTo(size_t value) : value(value){};
   const size_t value;
 
-  auto operator()(size_t value) -> bool { return value == this->value; }
+  bool operator()(size_t value) const { return value == this->value; }
 };
 
 struct LessThanOrEqualTo {

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -1,0 +1,199 @@
+//===- StructuredOpMatcher.h -------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_STRUCTUREDOPMATCHERS_H
+#define TPP_STRUCTUREDOPMATCHERS_H
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "llvm/ADT/SmallVector.h"
+#include <functional>
+
+namespace mlir {
+class Operation;
+namespace tpp {
+namespace structured_match {
+
+struct AllDims {};
+struct RangeDims {
+  RangeDims() = delete;
+  explicit RangeDims(size_t lowerBound, size_t upperBound)
+      : lowerBound(lowerBound), upperBound(upperBound) {
+    assert(upperBound >= lowerBound);
+  };
+  size_t getSize() const { return upperBound - lowerBound; };
+  SmallVector<size_t> getRange() const {
+    return llvm::to_vector(llvm::seq<size_t>(lowerBound, upperBound));
+  }
+  const size_t lowerBound;
+  const size_t upperBound;
+};
+struct AllDimsBut {
+  AllDimsBut() = delete;
+  explicit AllDimsBut(std::initializer_list<size_t> range) {
+    llvm::append_range(exceptions, range);
+  }
+  explicit AllDimsBut(RangeDims range) {
+    for (auto i = range.lowerBound; i < range.upperBound; i++)
+      exceptions.push_back(i);
+  }
+  ArrayRef<size_t> getExceptions() const { return exceptions; }
+
+private:
+  SmallVector<size_t> exceptions;
+};
+
+struct AllOperands {};
+struct Operand {
+  Operand() = delete;
+  Operand(size_t idx) : idx(idx){};
+
+  const size_t idx;
+};
+
+struct IsProjectedPermutation {};
+struct IsIdentity {};
+
+struct HasStaticShape {};
+
+struct NumEqualsTo {
+  NumEqualsTo() = delete;
+  explicit NumEqualsTo(size_t value) : value(value){};
+  const size_t value;
+
+  bool operator()(size_t value) { return value == this->value; }
+};
+
+struct LessThanOrEqualTo {
+  LessThanOrEqualTo() = delete;
+  explicit LessThanOrEqualTo(size_t value) : value(value){};
+  const size_t value;
+
+  bool operator()(size_t value) { return value <= this->value; }
+};
+
+struct GreaterThanOrEqualTo {
+  GreaterThanOrEqualTo() = delete;
+  explicit GreaterThanOrEqualTo(size_t value) : value(value){};
+  const size_t value;
+
+  bool operator()(size_t value) const { return value >= this->value; };
+};
+
+struct HasAffineMapEqualsTo {
+  HasAffineMapEqualsTo() = delete;
+  explicit HasAffineMapEqualsTo(AffineMap map) : map(map){};
+  AffineMap map;
+
+  bool operator()(AffineMap map) const { return map == this->map; }
+};
+
+// OR or AND between predicates (functors).
+struct BinaryPredicate {
+public:
+  enum BinaryPredicateKind { _OR, _AND };
+
+private:
+  const BinaryPredicateKind binaryPredicateKind;
+
+public:
+  std::function<bool(size_t)> predicateOnLhs;
+  std::function<bool(size_t)> predicateOnRhs;
+
+public:
+  BinaryPredicateKind getKind() const { return binaryPredicateKind; }
+  BinaryPredicate() = delete;
+  BinaryPredicate(BinaryPredicateKind binaryPredicateKind,
+                  std::function<bool(size_t)> lhs,
+                  std::function<bool(size_t)> rhs)
+      : binaryPredicateKind(binaryPredicateKind),
+        predicateOnLhs(std::move(lhs)), predicateOnRhs(std::move(rhs)) {}
+};
+
+struct _OR : public BinaryPredicate {
+  _OR(std::function<bool(size_t)> lhs, std::function<bool(size_t)> rhs)
+      : BinaryPredicate(BinaryPredicateKind::_OR, lhs, rhs) {}
+
+  static bool classof(const BinaryPredicate *binaryPredicate) {
+    return binaryPredicate->getKind() == BinaryPredicateKind::_OR;
+  }
+};
+
+class StructuredOpMatcher {
+  using PredicateFn = std::function<bool(linalg::LinalgOp)>;
+
+public:
+  StructuredOpMatcher() = default;
+
+  StructuredOpMatcher(PredicateFn &&firstPredicate) {
+    predicates.push_back(std::move(firstPredicate));
+  }
+
+  template <typename OpTy> static StructuredOpMatcher make() {
+    return StructuredOpMatcher(
+        [](linalg::LinalgOp op) { return isa<OpTy>(op.getOperation()); });
+  }
+
+  bool match(Operation *op);
+
+  // Predicates on operation.
+  StructuredOpMatcher &hasBufferSemantics();
+  StructuredOpMatcher &hasTensorSemantics();
+  StructuredOpMatcher &inputs(std::function<bool(size_t)>);
+  StructuredOpMatcher &outputs(std::function<bool(size_t)>);
+  StructuredOpMatcher &inputs(BinaryPredicate);
+  StructuredOpMatcher &
+      verifyInterface(std::function<LogicalResult(Operation *op)>);
+
+  // Predicate on OpOperands.
+  StructuredOpMatcher &input(AllOperands tag, IsProjectedPermutation);
+  StructuredOpMatcher &input(AllOperands tag, IsIdentity);
+  StructuredOpMatcher &input(AllOperands tag, HasStaticShape);
+  StructuredOpMatcher &input(Operand operand,
+                             std::function<bool(AffineMap map)>);
+
+  // Predicates on OpOperands.
+  StructuredOpMatcher &output(AllOperands tag, IsProjectedPermutation);
+  StructuredOpMatcher &output(AllOperands tag, IsIdentity);
+  StructuredOpMatcher &output(AllOperands tag, HasStaticShape);
+  StructuredOpMatcher &output(Operand operand,
+                              std::function<bool(AffineMap map)>);
+
+  // Predicates on Iterators.
+  StructuredOpMatcher &dim(std::function<bool(size_t)>);
+  StructuredOpMatcher &dim(AllDims, mlir::utils::IteratorType kind);
+  StructuredOpMatcher &dim(RangeDims range,
+                           SmallVector<mlir::utils::IteratorType> kinds);
+  StructuredOpMatcher &dim(AllDimsBut, mlir::utils::IteratorType kind);
+  StructuredOpMatcher &dim(AllDims,
+                           SmallVector<mlir::utils::IteratorType> kinds);
+
+  // Predicates on region.
+  template <typename OpTy>
+  StructuredOpMatcher &
+  hasRegionWithSingleOp(SmallVectorImpl<Value> *capturedOperands) {
+    return hasRegionWithSingleOpImpl(OpTy::getOperationName(),
+                                     capturedOperands);
+  }
+  StructuredOpMatcher &
+  hasRegion(std::function<bool(Operation *op,
+                               SmallVectorImpl<Value> *capturedOperands)>,
+            SmallVectorImpl<Value> *capturedOperands);
+
+private:
+  llvm::SmallVector<PredicateFn> predicates;
+
+  StructuredOpMatcher &
+  hasRegionWithSingleOpImpl(StringRef operationName,
+                            SmallVectorImpl<Value> *capturedOperands);
+};
+
+} // namespace structured_match
+} // namespace tpp
+} // namespace mlir
+
+#endif // TPP_STRUCTUREDOPMATCHERS_H

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -21,24 +21,27 @@ namespace structured_match {
 struct AllDims {};
 struct RangeDims {
   RangeDims() = delete;
+  explicit RangeDims(AllDims)
+      : lowerBound(0), upperBound(std::numeric_limits<size_t>::max()) {}
   explicit RangeDims(size_t lowerBound, size_t upperBound)
       : lowerBound(lowerBound), upperBound(upperBound) {
     assert(upperBound >= lowerBound);
-  };
-  size_t getSize() const { return upperBound - lowerBound; };
-  SmallVector<size_t> getRange() const {
-    return llvm::to_vector(llvm::seq<size_t>(lowerBound, upperBound));
   }
+  size_t getLowerBound() const { return lowerBound; };
+  size_t getUpperBound() const { return upperBound; };
+
+private:
   const size_t lowerBound;
   const size_t upperBound;
 };
+
 struct AllDimsBut {
   AllDimsBut() = delete;
   explicit AllDimsBut(std::initializer_list<size_t> range) {
     llvm::append_range(exceptions, range);
   }
   explicit AllDimsBut(RangeDims range) {
-    for (auto i = range.lowerBound; i < range.upperBound; i++)
+    for (auto i = range.getLowerBound(); i < range.getUpperBound(); i++)
       exceptions.push_back(i);
   }
   ArrayRef<size_t> getExceptions() const { return exceptions; }
@@ -172,12 +175,10 @@ public:
 
   // Predicates on Iterators.
   StructuredOpMatcher &dim(std::function<bool(size_t)>);
-  StructuredOpMatcher &dim(AllDims, mlir::utils::IteratorType kind);
   StructuredOpMatcher &dim(RangeDims range,
                            SmallVector<mlir::utils::IteratorType> kinds);
+  StructuredOpMatcher &dim(RangeDims range, mlir::utils::IteratorType kind);
   StructuredOpMatcher &dim(AllDimsBut, mlir::utils::IteratorType kind);
-  StructuredOpMatcher &dim(AllDims,
-                           SmallVector<mlir::utils::IteratorType> kinds);
 
   // Predicates on region.
   template <typename OpTy>

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -111,6 +111,8 @@ createConvertForAllToParallelOpPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createHeapToStackPass(unsigned maxAllocSizeInBytes = 4096);
 
+void registerTestStructuralMatchers();
+
 } // namespace tpp
 } // namespace mlir
 

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(Dialect)
+add_subdirectory(IR)
 
 get_property(mlir_dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
@@ -36,6 +37,9 @@ add_mlir_library(MLIRTPP
     ConvertPerfToLoops.cpp
     ConvertPerfToFunc.cpp
 
+  # Test Passes
+    TestMatchers.cpp
+
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP
 
@@ -44,6 +48,7 @@ add_mlir_library(MLIRTPP
     TPPLinalgXTransformOps
 
     LINK_LIBS PUBLIC
+    TPPIR
     TPPTppDialect
     TPPXsmmDialect
     TPPVNNIDialect

--- a/lib/TPP/IR/CMakeLists.txt
+++ b/lib/TPP/IR/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mlir_library(TPPIR
+  StructuredOpMatcher.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/TPP
+)

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -240,26 +240,6 @@ structured_match::StructuredOpMatcher::dim(RangeDims range,
   return *this;
 }
 
-structured_match::StructuredOpMatcher &
-structured_match::StructuredOpMatcher::dim(AllDimsBut allDimsBut,
-                                           utils::IteratorType kind) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
-    llvm::DenseSet<size_t> exceptions(allDimsBut.getExceptions().begin(),
-                                      allDimsBut.getExceptions().end());
-    auto iteratorTypes = linalgOp.getIteratorTypesArray();
-    // Reverse iterators to have the innermost one at index 0.
-    std::reverse(iteratorTypes.begin(), iteratorTypes.end());
-    for (auto [idx, iteratorType] : llvm::enumerate(iteratorTypes)) {
-      if (exceptions.contains(idx))
-        continue;
-      if (iteratorType != kind)
-        return false;
-    }
-    return true;
-  });
-  return *this;
-}
-
 //===---------------------------------------------------------------------===//
 // Region predicates.
 //===---------------------------------------------------------------------===//

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -35,7 +35,7 @@ bool structured_match::StructuredOpMatcher::match(Operation *op) {
 //===---------------------------------------------------------------------===//
 
 structured_match::StructuredOpMatcher &
-structured_match::StructuredOpMatcher::outputs(
+structured_match::StructuredOpMatcher::numDpsInits(
     std::function<bool(size_t)> fun) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     size_t numDpsInits = static_cast<size_t>(linalgOp.getNumDpsInits());
@@ -45,7 +45,8 @@ structured_match::StructuredOpMatcher::outputs(
 }
 
 structured_match::StructuredOpMatcher &
-structured_match::StructuredOpMatcher::inputs(std::function<bool(size_t)> fun) {
+structured_match::StructuredOpMatcher::numDpsInputs(
+    std::function<bool(size_t)> fun) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     size_t numDpsInputs = static_cast<size_t>(linalgOp.getNumDpsInputs());
     return fun(numDpsInputs);
@@ -54,7 +55,7 @@ structured_match::StructuredOpMatcher::inputs(std::function<bool(size_t)> fun) {
 }
 
 structured_match::StructuredOpMatcher &
-structured_match::StructuredOpMatcher::inputs(
+structured_match::StructuredOpMatcher::numDpsInputs(
     structured_match::BinaryPredicate binaryPredicate) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     if (isa<_OR>(&binaryPredicate)) {

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -164,7 +164,8 @@ structured_match::StructuredOpMatcher::hasRegionWithSingleOpImpl(
     if (!region.hasOneBlock())
       return false;
     unsigned numberOfOpsInRegion =
-        (operationName.compare("linalg.yield") == 0) ? 1 : 2;
+        (operationName.compare(linalg::YieldOp::getOperationName()) == 0) ? 1
+                                                                          : 2;
     if (std::distance(region.front().begin(), region.front().end()) !=
         numberOfOpsInRegion)
       return false;

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -1,0 +1,353 @@
+//===- StructuredOpMatcher.cpp -----------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/IR/StructuredOpMatcher.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "structured-matchers"
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+// Entry point.
+bool structured_match::StructuredOpMatcher::match(Operation *op) {
+  auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op);
+  if (!linalgOp)
+    return false;
+  LLVM_DEBUG(llvm::dbgs() << "Running matcher on: " << *op << "\n");
+
+  for (auto [idx, predicate] : llvm::enumerate(predicates)) {
+    if (!predicate(linalgOp)) {
+      LLVM_DEBUG(llvm::dbgs() << "Exit on predicate: " << idx << "\n");
+      return false;
+    }
+  }
+  return true;
+}
+
+//===---------------------------------------------------------------------===//
+// Operation predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::outputs(
+    std::function<bool(size_t)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    size_t numDpsInits = static_cast<size_t>(linalgOp.getNumDpsInits());
+    return fun(numDpsInits);
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::inputs(std::function<bool(size_t)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    size_t numDpsInputs = static_cast<size_t>(linalgOp.getNumDpsInputs());
+    return fun(numDpsInputs);
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::inputs(
+    structured_match::BinaryPredicate binaryPredicate) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    if (isa<_OR>(&binaryPredicate)) {
+      return (binaryPredicate.predicateOnLhs(linalgOp.getNumDpsInputs()) ||
+              binaryPredicate.predicateOnRhs(linalgOp.getNumDpsInputs()));
+    }
+    return false;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::hasBufferSemantics() {
+  predicates.push_back([](linalg::LinalgOp linalgOp) -> bool {
+    return linalgOp.hasBufferSemantics();
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::hasTensorSemantics() {
+  predicates.push_back([](linalg::LinalgOp linalgOp) -> bool {
+    return linalgOp.hasTensorSemantics();
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::verifyInterface(
+    std::function<LogicalResult(Operation *op)> fun) {
+  predicates.push_back([&](linalg::LinalgOp linalgOp) -> bool {
+    if (failed(fun(linalgOp)))
+      return false;
+    return true;
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Input predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::input(AllOperands tag, IsIdentity) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
+      if (!linalgOp.getMatchingIndexingMap(operand).isIdentity())
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::input(AllOperands tag,
+                                             IsProjectedPermutation) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
+      if (!linalgOp.getMatchingIndexingMap(operand).isProjectedPermutation(
+              /*allowZeroInResults=*/true))
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::input(AllOperands tag, HasStaticShape) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
+      auto operandType = operand->get().getType();
+      if (auto shapedType = operandType.dyn_cast_or_null<ShapedType>())
+        if (!shapedType.hasStaticShape())
+          return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::input(
+    Operand operand, std::function<bool(AffineMap map)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    size_t idxOperand = operand.idx;
+    assert(idxOperand < static_cast<size_t>(linalgOp.getNumDpsInputs()));
+    AffineMap tiedIndexingMap = linalgOp.getMatchingIndexingMap(
+        linalgOp.getDpsInputOperand(idxOperand));
+    return fun(tiedIndexingMap);
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Output predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::output(AllOperands tag, IsIdentity) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
+      if (!linalgOp.getMatchingIndexingMap(operand).isIdentity())
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::output(AllOperands tag,
+                                              IsProjectedPermutation) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
+      if (!linalgOp.getMatchingIndexingMap(operand).isProjectedPermutation())
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::output(AllOperands tag, HasStaticShape) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
+      auto operandType = operand->get().getType();
+      if (auto shapedType = operandType.dyn_cast_or_null<ShapedType>())
+        if (!shapedType.hasStaticShape())
+          return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::output(
+    Operand operand, std::function<bool(AffineMap map)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    size_t idxOperand = operand.idx;
+    assert(idxOperand < static_cast<size_t>(linalgOp.getNumDpsInits()));
+    AffineMap tiedIndexingMap =
+        linalgOp.getMatchingIndexingMap(linalgOp.getDpsInitOperand(idxOperand));
+    return fun(tiedIndexingMap);
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Dim predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(std::function<bool(size_t)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    size_t numberOfIterator = linalgOp.getIteratorTypesArray().size();
+    return fun(numberOfIterator);
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(AllDims tag,
+                                           utils::IteratorType kind) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
+    for (auto iteratorType : iteratorTypes)
+      if (iteratorType != kind)
+        return false;
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(
+    AllDims tag, SmallVector<utils::IteratorType> kinds) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
+    return iteratorTypes == kinds;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(
+    RangeDims range, SmallVector<utils::IteratorType> kinds) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    if (kinds.size() != range.getSize())
+      return false;
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
+    // Reverse iterators to have the innermost one at index 0.
+    std::reverse(iteratorTypes.begin(), iteratorTypes.end());
+    for (auto [idx, rangeIdx] : llvm::enumerate(range.getRange())) {
+      if (iteratorTypes[rangeIdx] != kinds[idx])
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(AllDimsBut allDimsBut,
+                                           utils::IteratorType kind) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    llvm::DenseSet<size_t> exceptions(allDimsBut.getExceptions().begin(),
+                                      allDimsBut.getExceptions().end());
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
+    // Reverse iterators to have the innermost one at index 0.
+    std::reverse(iteratorTypes.begin(), iteratorTypes.end());
+    for (auto [idx, iteratorType] : llvm::enumerate(iteratorTypes)) {
+      if (exceptions.contains(idx))
+        continue;
+      if (iteratorType != kind)
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Region predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::hasRegionWithSingleOpImpl(
+    StringRef operationName, SmallVectorImpl<Value> *capturedOperands) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) {
+    Region &region = linalgOp->getRegion(0);
+
+    if (!region.hasOneBlock())
+      return false;
+    unsigned numberOfOpsInRegion =
+        (operationName.compare("linalg.yield") == 0) ? 1 : 2;
+    if (std::distance(region.front().begin(), region.front().end()) !=
+        numberOfOpsInRegion)
+      return false;
+    if (linalgOp.getNumDpsInits() != 1)
+      return false;
+
+    // Require only a single yield operand defined by innerOp.
+    Operation *yieldOp = linalgOp.getBlock()->getTerminator();
+    if (yieldOp->getNumOperands() != 1)
+      return false;
+    // Only linalg.yield, exit true.
+    if (numberOfOpsInRegion == 1) {
+      if (capturedOperands) {
+        auto arg0 = dyn_cast<BlockArgument>(yieldOp->getOperand(0));
+        if (!arg0 || arg0.getParentBlock() != linalgOp.getBlock())
+          return false;
+        capturedOperands->push_back(linalgOp.getMatchingOpOperand(arg0)->get());
+        capturedOperands->push_back(linalgOp.getDpsInitOperand(0)->get());
+      }
+      return true;
+    }
+
+    // Check on the only inner operation.
+    Operation *innerOp = &(*linalgOp.getBlock()->getOperations().begin());
+    if (innerOp->getName().getStringRef() != operationName)
+      return false;
+    if (yieldOp->getOperand(0).getDefiningOp() != innerOp)
+      return false;
+    // The operand of the innerOp must comes from the region
+    // args of the generic.
+    auto arg0 = dyn_cast<BlockArgument>(innerOp->getOperand(0));
+    auto arg1 = dyn_cast<BlockArgument>(innerOp->getOperand(1));
+    if (!arg0 || !arg1)
+      return false;
+    if (arg0.getParentBlock() != linalgOp.getBlock() ||
+        arg1.getParentBlock() != linalgOp.getBlock())
+      return false;
+    if (capturedOperands) {
+      capturedOperands->push_back(linalgOp.getMatchingOpOperand(arg0)->get());
+      capturedOperands->push_back(linalgOp.getMatchingOpOperand(arg1)->get());
+      capturedOperands->push_back(linalgOp.getDpsInitOperand(0)->get());
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::hasRegion(
+    std::function<bool(Operation *op, SmallVectorImpl<Value> *capturedOperands)>
+        fun,
+    SmallVectorImpl<Value> *capturedOperands) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) {
+    return fun(linalgOp, capturedOperands);
+  });
+  return *this;
+}

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -99,13 +99,12 @@ structured_match::StructuredOpMatcher::verifyInterface(
 //===---------------------------------------------------------------------===//
 
 structured_match::StructuredOpMatcher &
-structured_match::StructuredOpMatcher::input(AllOperands tag, HasStaticShape) {
+structured_match::StructuredOpMatcher::input(
+    AllOperands tag, std::function<bool(OpOperand *operand)> fun) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
-      auto operandType = operand->get().getType();
-      if (auto shapedType = operandType.dyn_cast_or_null<ShapedType>())
-        if (!shapedType.hasStaticShape())
-          return false;
+      if (!fun(operand))
+        return false;
     }
     return true;
   });
@@ -144,13 +143,12 @@ structured_match::StructuredOpMatcher::input(
 //===---------------------------------------------------------------------===//
 
 structured_match::StructuredOpMatcher &
-structured_match::StructuredOpMatcher::output(AllOperands tag, HasStaticShape) {
+structured_match::StructuredOpMatcher::output(
+    AllOperands tag, std::function<bool(OpOperand *operand)> fun) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
-      auto operandType = operand->get().getType();
-      if (auto shapedType = operandType.dyn_cast_or_null<ShapedType>())
-        if (!shapedType.hasStaticShape())
-          return false;
+      if (!fun(operand))
+        return false;
     }
     return true;
   });

--- a/lib/TPP/TestMatchers.cpp
+++ b/lib/TPP/TestMatchers.cpp
@@ -89,7 +89,7 @@ void testTppAdd(FunctionOpInterface funcOp) {
       .output(AllOperands(), HasMap(Identity()))
       .operation(NumOfLoops(LessThanOrEqualTo(2)))
       .dim(RangeDims(AllDims()), utils::IteratorType::parallel)
-      .hasRegionWithSingleOp<arith::AddFOp>(&operands);
+      .region(WithSingleOp<arith::AddFOp>(), &operands);
   // clang-format on
 
   funcOp->walk([&](linalg::LinalgOp linalgOp) {
@@ -146,7 +146,7 @@ void testTppIdentity(FunctionOpInterface funcOp) {
       .input(AllOperands(), HasMap(ProjectedPermutation()))
       .operation(VerifyInterface(OpTrait::tpp::checkUnitStrideInnerLoop))
       .operation(VerifyInterface(OpTrait::tpp::checkBroadcastableShape))
-      .hasRegionWithSingleOp<linalg::YieldOp>(&operands);
+      .region(WithSingleOp<linalg::YieldOp>(), &operands);
   // clang-format on
 
   funcOp->walk([&](linalg::LinalgOp linalgOp) {

--- a/lib/TPP/TestMatchers.cpp
+++ b/lib/TPP/TestMatchers.cpp
@@ -64,10 +64,7 @@ void testVnniBrgemm(FunctionOpInterface funcOp) {
                       utils::IteratorType::parallel,
                       utils::IteratorType::parallel,
                       utils::IteratorType::reduction,
-                      utils::IteratorType::reduction})
-      .dim(AllDimsBut(
-           RangeDims(/*lowerBound=*/0, /*upperBound=*/5)),
-                      utils::IteratorType::parallel);
+                      utils::IteratorType::reduction});
   // clang-format on
 
   funcOp->walk([&](linalg::LinalgOp linalgOp) {

--- a/lib/TPP/TestMatchers.cpp
+++ b/lib/TPP/TestMatchers.cpp
@@ -1,0 +1,187 @@
+//===- TestMatchers.cpp - Pass to test matchers ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Tpp/TppTraits.h"
+#include "TPP/IR/StructuredOpMatcher.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+using namespace mlir::tpp::structured_match;
+
+namespace {
+// This is a test pass for verifying matchers.
+struct TestStructuralMatchers
+    : public PassWrapper<TestStructuralMatchers,
+                         InterfacePass<FunctionOpInterface>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestStructuralMatchers)
+
+  void runOnOperation() override;
+  StringRef getArgument() const final { return "test-structural-matchers"; }
+  StringRef getDescription() const final {
+    return "Test C++ pattern matchers.";
+  }
+};
+} // namespace
+
+void testMatmul(FunctionOpInterface funcOp) {
+  // clang-format off
+  auto matcher =
+    StructuredOpMatcher::make<linalg::MatmulOp>()
+      .hasTensorSemantics()
+      .inputs(NumEqualsTo(2))
+      .input(AllOperands(), HasStaticShape())
+      .outputs(NumEqualsTo(1))
+      .output(AllOperands(), HasStaticShape());
+  // clang-format on
+
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcher.match(linalgOp))
+      llvm::outs() << "match linalg.matmul\n";
+    else
+      llvm::outs() << "not a match\n";
+  });
+}
+
+void testVnniBrgemm(FunctionOpInterface funcOp) {
+  // clang-format off
+  auto matcher = 
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .hasTensorSemantics()
+      .inputs(NumEqualsTo(2))
+      .input(AllOperands(), HasStaticShape())
+      .outputs(NumEqualsTo(1))
+      .output(AllOperands(), HasStaticShape())
+      .dim(GreaterThanOrEqualTo(5))
+      .dim(RangeDims(/*lowerBound=*/0, /*upperBound=*/5), 
+                     {utils::IteratorType::reduction,
+                      utils::IteratorType::parallel,
+                      utils::IteratorType::parallel,
+                      utils::IteratorType::reduction,
+                      utils::IteratorType::reduction})
+      .dim(AllDimsBut(
+           RangeDims(/*lowerBound=*/0, /*upperBound=*/5)),
+                      utils::IteratorType::parallel);
+  // clang-format on
+
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcher.match(linalgOp))
+      llvm::outs() << "match vnni.brgemm\n";
+    else
+      llvm::outs() << "not a match\n";
+  });
+}
+
+void testTppAdd(FunctionOpInterface funcOp) {
+  // clang-format off
+  SmallVector<Value> operands;
+  auto matcher =
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .hasBufferSemantics()
+      .inputs(NumEqualsTo(2))
+      .input(AllOperands(), HasStaticShape())
+      .input(AllOperands(), IsIdentity())
+      .outputs(NumEqualsTo(1))
+      .output(AllOperands(), HasStaticShape())
+      .output(AllOperands(), IsIdentity())
+      .dim(LessThanOrEqualTo(2))
+      .dim(AllDims(), utils::IteratorType::parallel)
+      .hasRegionWithSingleOp<arith::AddFOp>(&operands);
+  // clang-format on
+
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcher.match(linalgOp))
+      llvm::outs() << "match tpp.add\n";
+    else
+      llvm::outs() << "not a match\n";
+  });
+}
+
+void testPredicates(FunctionOpInterface funcOp) {
+  // clang-format off
+  auto matcher =
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .inputs(_OR(NumEqualsTo(2), NumEqualsTo(1)));
+  // clang-format on
+
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcher.match(linalgOp))
+      llvm::outs() << "match op with 1 or 2 inputs\n";
+    else
+      llvm::outs() << "not a match\n";
+  });
+}
+
+void testInterfaces(FunctionOpInterface funcOp) {
+  // clang-format off
+  auto matcher =
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .verifyInterface(OpTrait::tpp::checkUnitStrideInnerLoop);
+  // clang-format on
+
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcher.match(linalgOp))
+      llvm::outs() << "match interface\n";
+    else
+      llvm::outs() << "not a match\n";
+  });
+}
+
+void testTppIdentity(FunctionOpInterface funcOp) {
+  // clang-format off
+  SmallVector<Value> operands;
+  auto matcher = 
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .hasBufferSemantics()
+      .outputs(NumEqualsTo(1))
+      .inputs(_OR(NumEqualsTo(1), NumEqualsTo(0)))
+      .dim(AllDims(), utils::IteratorType::parallel)
+      .output(AllOperands(), HasStaticShape())
+      .input(AllOperands(), HasStaticShape())
+      .output(AllOperands(), IsIdentity())
+      .input(AllOperands(), IsProjectedPermutation())
+      .verifyInterface(OpTrait::tpp::checkUnitStrideInnerLoop)
+      .verifyInterface(OpTrait::tpp::checkBroadcastableShape)
+      .hasRegionWithSingleOp<linalg::YieldOp>(&operands);
+  // clang-format on
+
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcher.match(linalgOp))
+      llvm::outs() << "match tpp.identity\n";
+    else
+      llvm::outs() << "not a match\n";
+  });
+}
+
+void TestStructuralMatchers::runOnOperation() {
+  auto f = getOperation();
+  llvm::outs() << f.getName() << "\n";
+  if (f.getName() == "test_matmul")
+    testMatmul(f);
+  if (f.getName() == "test_vnni_brgemm")
+    testVnniBrgemm(f);
+  if (f.getName() == "test_tpp_add")
+    testTppAdd(f);
+  if (f.getName() == "tpp_add_must_not_match")
+    testTppAdd(f);
+  if (f.getName() == "test_predicates")
+    testPredicates(f);
+  if (f.getName() == "test_interfaces")
+    testInterfaces(f);
+  if (f.getName() == "test_tpp_identity")
+    testTppIdentity(f);
+}
+
+namespace mlir {
+namespace tpp {
+void registerTestStructuralMatchers() {
+  PassRegistration<TestStructuralMatchers>();
+}
+} // namespace tpp
+} // namespace mlir

--- a/lib/TPP/TestMatchers.cpp
+++ b/lib/TPP/TestMatchers.cpp
@@ -35,9 +35,9 @@ void testMatmul(FunctionOpInterface funcOp) {
   auto matcher =
     StructuredOpMatcher::make<linalg::MatmulOp>()
       .hasTensorSemantics()
-      .inputs(NumEqualsTo(2))
+      .numDpsInputs(NumEqualsTo(2))
       .input(AllOperands(), HasStaticShape())
-      .outputs(NumEqualsTo(1))
+      .numDpsInits(NumEqualsTo(1))
       .output(AllOperands(), HasStaticShape());
   // clang-format on
 
@@ -54,9 +54,9 @@ void testVnniBrgemm(FunctionOpInterface funcOp) {
   auto matcher = 
     StructuredOpMatcher::make<linalg::GenericOp>()
       .hasTensorSemantics()
-      .inputs(NumEqualsTo(2))
+      .numDpsInputs(NumEqualsTo(2))
       .input(AllOperands(), HasStaticShape())
-      .outputs(NumEqualsTo(1))
+      .numDpsInits(NumEqualsTo(1))
       .output(AllOperands(), HasStaticShape())
       .dim(GreaterThanOrEqualTo(5))
       .dim(RangeDims(/*lowerBound=*/0, /*upperBound=*/5), 
@@ -81,10 +81,10 @@ void testTppAdd(FunctionOpInterface funcOp) {
   auto matcher =
     StructuredOpMatcher::make<linalg::GenericOp>()
       .hasBufferSemantics()
-      .inputs(NumEqualsTo(2))
+      .numDpsInputs(NumEqualsTo(2))
       .input(AllOperands(), HasStaticShape())
       .input(AllOperands(), IsIdentity())
-      .outputs(NumEqualsTo(1))
+      .numDpsInits(NumEqualsTo(1))
       .output(AllOperands(), HasStaticShape())
       .output(AllOperands(), IsIdentity())
       .dim(LessThanOrEqualTo(2))
@@ -104,7 +104,7 @@ void testPredicates(FunctionOpInterface funcOp) {
   // clang-format off
   auto matcher =
     StructuredOpMatcher::make<linalg::GenericOp>()
-      .inputs(_OR(NumEqualsTo(2), NumEqualsTo(1)));
+      .numDpsInputs(_OR(NumEqualsTo(2), NumEqualsTo(1)));
   // clang-format on
 
   funcOp->walk([&](linalg::LinalgOp linalgOp) {
@@ -136,8 +136,8 @@ void testTppIdentity(FunctionOpInterface funcOp) {
   auto matcher = 
     StructuredOpMatcher::make<linalg::GenericOp>()
       .hasBufferSemantics()
-      .outputs(NumEqualsTo(1))
-      .inputs(_OR(NumEqualsTo(1), NumEqualsTo(0)))
+      .numDpsInits(NumEqualsTo(1))
+      .numDpsInputs(_OR(NumEqualsTo(1), NumEqualsTo(0)))
       .dim(RangeDims(AllDims()), utils::IteratorType::parallel)
       .output(AllOperands(), HasStaticShape())
       .input(AllOperands(), HasStaticShape())

--- a/lib/TPP/TestMatchers.cpp
+++ b/lib/TPP/TestMatchers.cpp
@@ -91,7 +91,7 @@ void testTppAdd(FunctionOpInterface funcOp) {
       .output(AllOperands(), HasStaticShape())
       .output(AllOperands(), IsIdentity())
       .dim(LessThanOrEqualTo(2))
-      .dim(AllDims(), utils::IteratorType::parallel)
+      .dim(RangeDims(AllDims()), utils::IteratorType::parallel)
       .hasRegionWithSingleOp<arith::AddFOp>(&operands);
   // clang-format on
 
@@ -141,7 +141,7 @@ void testTppIdentity(FunctionOpInterface funcOp) {
       .hasBufferSemantics()
       .outputs(NumEqualsTo(1))
       .inputs(_OR(NumEqualsTo(1), NumEqualsTo(0)))
-      .dim(AllDims(), utils::IteratorType::parallel)
+      .dim(RangeDims(AllDims()), utils::IteratorType::parallel)
       .output(AllOperands(), HasStaticShape())
       .input(AllOperands(), HasStaticShape())
       .output(AllOperands(), IsIdentity())

--- a/test/Passes/test-matchers.mlir
+++ b/test/Passes/test-matchers.mlir
@@ -1,0 +1,252 @@
+// RUN: tpp-opt %s -mlir-disable-threading=true -pass-pipeline="builtin.module(func.func(test-structural-matchers))" -o /dev/null 2>&1 | FileCheck %s
+
+// CHECK-LABEL: test
+func.func @test() {
+  return
+}
+
+// CHECK-LABEL: test_matmul
+func.func @test_matmul(%arg0: tensor<32x32xf32>, 
+                       %arg1: tensor<32x32xf32>, %arg2: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %cst = arith.constant 0.0 : f32
+  // CHECK: not a match
+  %0 = linalg.fill ins(%cst : f32) outs(%arg2: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: match linalg.matmul
+  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<32x32xf32>, tensor<32x32xf32>) 
+                     outs(%0: tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %1 : tensor<32x32xf32>
+}
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4 floordiv 2, d3, d1)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+
+// CHECK-LABEL: test_vnni_brgemm
+func.func @test_vnni_brgemm(%arg0: tensor<48x32x32xbf16>, 
+                            %arg1: tensor<48x16x32x2xbf16>, 
+                            %arg2: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  // CHECK: match vnni.brgemm
+  // CHECK-NOT: not a match
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} 
+    ins(%arg0, %arg1 : tensor<48x32x32xbf16>, tensor<48x16x32x2xbf16>) 
+    outs(%arg2 : tensor<32x32xbf16>) {
+      ^bb0(%in: bf16, %in_8: bf16, %out: bf16):
+        %11 = arith.mulf %in, %in_8 : bf16
+        %12 = arith.addf %out, %11 : bf16
+        linalg.yield %12 : bf16
+  } -> tensor<32x32xbf16>
+  return %0: tensor<32x32xbf16>
+}
+
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+#map4 = affine_map<(d0) -> (d0)>
+#map5 = affine_map<() -> ()>
+
+// CHECK-LABEL: test_tpp_add
+func.func @test_tpp_add(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>,
+                        %arg2: memref<32x32xf32>, %arg3: memref<1xf32>,
+                        %arg4: memref<1xf32>, %arg5: memref<1xf32>,
+                        %arg6: memref<f32>, %arg7: memref<f32>, 
+                        %arg8: memref<f32>,
+                        %arg9: memref<32x32x32xf32>,
+                        %arg10: memref<32x32x32xf32>,
+                        %arg11: memref<32x32x32xf32>,
+                        %arg12: memref<4x4xf32>,
+                        %arg13: memref<4x4xf32, strided<[4, 1], offset: ?>>) {
+  // CHECK-COUNT-4: match tpp.add
+  // CHECK-NOT: not a match
+  linalg.generic {
+    indexing_maps = [#map3, #map3, #map3],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg1: memref<32x32xf32>, memref<32x32xf32>)
+    outs(%arg2: memref<32x32xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  linalg.generic {
+    indexing_maps = [#map4, #map4, #map4],
+    iterator_types = ["parallel"]}
+    ins(%arg3, %arg4: memref<1xf32>, memref<1xf32>)
+    outs(%arg5: memref<1xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  // Empty map is an identity. Note we don't match
+  // this in the linalg to tpp conversion.
+  linalg.generic {
+    indexing_maps = [#map5, #map5, #map5],
+    iterator_types = []}
+    ins(%arg6, %arg7: memref<f32>, memref<f32>)
+    outs(%arg8: memref<f32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  linalg.generic {
+    indexing_maps = [#map3, #map3, #map3],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg13, %arg13: memref<4x4xf32, strided<[4, 1], offset: ?>>, 
+                        memref<4x4xf32, strided<[4, 1], offset: ?>>)
+    outs(%arg12: memref<4x4xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  return
+}
+
+#map6 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map7 = affine_map<(d0, d1) -> (d0, d1)>
+#map8 = affine_map<(d0, d1) -> (0, d1)>
+#map9 = affine_map<(d0, d1) -> (d0)>
+#map10 = affine_map<(d0, d1) -> (d1, d0)>
+
+// CHECK-LABEL: tpp_add_must_not_match
+func.func @tpp_add_must_not_match(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>,
+                                  %arg2: memref<3x3xf32>,
+                                  %arg3: memref<32x32x32xf32>,
+                                  %arg4: memref<32x32x32xf32>,
+                                  %arg5: memref<32x32x32xf32>,
+                                  %arg6: memref<3xf32>) {
+  // CHECK-NOT: match tpp.add
+  // CHECK-COUNT-5: not a match 
+  linalg.generic {
+    indexing_maps = [#map7, #map8, #map7],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg1: memref<3x3xf32>, memref<1x3xf32>)
+    outs(%arg2: memref<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  linalg.generic {
+    indexing_maps = [#map6, #map6, #map6],
+    iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%arg3, %arg4 : memref<32x32x32xf32>, memref<32x32x32xf32>)
+    outs(%arg5: memref<32x32x32xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  linalg.generic {
+    indexing_maps = [#map7, #map9, #map7],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg6 : memref<3x3xf32>, memref<3xf32>)
+    outs(%arg2: memref<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  linalg.generic {
+    indexing_maps = [#map7, #map10, #map7],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg0: memref<3x3xf32>, memref<3x3xf32>)
+    outs(%arg2: memref<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %1 = arith.addf %in, %in_1 : f32
+        linalg.yield %1 : f32
+  }
+  %c0 = arith.constant 0.0 : f32
+  %c1 = arith.constant 1.0 : f32  
+  linalg.generic {
+    indexing_maps = [#map7, #map7, #map7],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg0: memref<3x3xf32>, memref<3x3xf32>) 
+    outs(%arg2: memref<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %0 = arith.addf %c0, %c1 : f32
+        linalg.yield %0 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: test_predicates
+func.func @test_predicates(%arg0: memref<3x3xf32>) {
+  // CHECK: match op with 1 or 2 inputs
+  linalg.generic {
+    indexing_maps = [#map7, #map7, #map7],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg0: memref<3x3xf32>, memref<3x3xf32>)
+    outs(%arg0: memref<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %0 = arith.addf %in, %in_1 : f32
+        linalg.yield %0 : f32
+  }
+  // CHECK: match op with 1 or 2 inputs
+  linalg.generic {
+    indexing_maps = [#map7, #map7],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0: memref<3x3xf32>)
+    outs(%arg0: memref<3x3xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %0 = arith.addf %in, %in : f32
+        linalg.yield %0 : f32
+  }
+  // CHECK: not a match
+  linalg.generic {
+    indexing_maps = [#map7],
+    iterator_types = ["parallel", "parallel"]}
+    outs(%arg0: memref<3x3xf32>) {
+      ^bb0(%out: f32):
+        %0 = arith.addf %out, %out : f32
+        linalg.yield %0 : f32
+  }
+  return 
+}
+
+// CHECK-LABEL: test_interfaces
+func.func @test_interfaces(%arg0: memref<8x8xf32, strided<[8, 2], offset: 0>>,
+                           %arg1: memref<8x8xf32>) {
+  // CHECK: not a match
+  // CHECK-NOT: match interface
+  linalg.generic {
+    indexing_maps = [#map7],
+    iterator_types = ["parallel", "parallel"]}
+    outs(%arg0: memref<8x8xf32, strided<[8, 2], offset:0>>) {
+      ^bb0(%out: f32):
+        %0 = arith.addf %out, %out : f32
+        linalg.yield %0 : f32
+  }
+  // CHECK: match interface
+  // CHECK-NOT: not a match
+  linalg.generic {
+    indexing_maps = [#map7],
+    iterator_types = ["parallel", "parallel"]}
+    outs(%arg1: memref<8x8xf32>) {
+      ^bb0(%out: f32):
+        %0 = arith.addf %out, %out : f32
+        linalg.yield %0 : f32
+  }
+  return 
+}
+
+#map11 = affine_map<(d0, d1) -> (d0, d1)>
+#map12 = affine_map<(d0, d1) -> (d1)>
+
+// CHECK-LABEL: test_tpp_identity
+func.func @test_tpp_identity(%arg0: memref<3xf32>, %arg1: memref<5x3xf32>) {
+  // CHECK: match tpp.identity
+  // CHECK-NOT: not a match
+  linalg.generic {
+    indexing_maps = [#map12, #map11],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0: memref<3xf32>)
+    outs(%arg1: memref<5x3xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        linalg.yield %in : f32
+  }
+  // CHECK: match tpp.identity
+  // CHECK-NOT: not a match
+  linalg.generic {
+    indexing_maps = [#map11],
+    iterator_types = ["parallel", "parallel"]}
+    outs(%arg1: memref<5x3xf32>) {
+      ^bb0(%out: f32):
+        linalg.yield %out : f32
+  } 
+  return
+}

--- a/tpp-opt/tpp-opt.cpp
+++ b/tpp-opt/tpp-opt.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv) {
   mlir::check::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::vnni::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::perf::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::tpp::registerTestStructuralMatchers();
 
   // Add the following to include *all* MLIR Core dialects, or selectively
   // include what you need like above. You only need to register dialects that


### PR DESCRIPTION
Introduce structured matchers to specify predicates on linalg operations. Users can specify matching predicates at operation, operand, dimension, and region levels. Example:

```c++

auto matcher = StructuredOpMatcher::make<linalg::GenericOp>()
  .operation(HasTensorSemantics())                         // operation level pred.
  .operation(NumDpsInputs(_OR(EqualsTo(1), EqualsTo(0))))  // operation level pred.
  .input(AllOperands(), HasStaticShape())       // operand level pred.
  .output(AllOperands(), HasMap(Identity()))  // operand level pred.
  .dim(AllDims(), utils::IteratorType::parallel) // dim level pred.
  .region(WithSingleOp<arith::AddFOp>(), &captures); // reg level pred.

```

The original authors of this API are the IREE developers (Alex Zinenko et al. see:
https://github.com/openxla/iree/commit/0573f4f5be5ebf8f89686ac2cabe1d784c9e2112). We reworked the API to satisfy our needs by simplifying it and introducing predicates based on c++ functors. We did not want to take IREE LLVM as our dependency.

See https://dl.acm.org/doi/10.1145/3372266 for more details on structured and access matchers.