### PR TITLE
XSMM runner fix + debug

### DIFF
--- a/test/Integration/xsmm-binary-bf16.mlir
+++ b/test/Integration/xsmm-binary-bf16.mlir
@@ -1,0 +1,17 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+memref.global "private" constant @__constant_bias : memref<3x3xbf16> = dense<1.0> {alignment = 64 : i64}
+
+func.func @entry(%arg0: memref<3x3xbf16>, %arg1: memref<3x3xbf16>) {
+  %0 = memref.get_global @__constant_bias : memref<3x3xbf16>
+  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3](broadcast none dataType bf16)
+  xsmm.binary add(dataType bf16, %1, %arg0, %0, %arg1) : (i64, memref<3x3xbf16>, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
+
+  return
+}
+
+// CHECK: ( 2, 2, 2 )
+// CHECK: ( 2, 2, 2 )
+// CHECK: ( 2, 2, 2 )

--- a/test/Integration/xsmm-binary.mlir
+++ b/test/Integration/xsmm-binary.mlir
@@ -1,0 +1,17 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+memref.global "private" constant @__constant_bias : memref<3x3xf32> = dense<1.0> {alignment = 64 : i64}
+
+func.func @entry(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  %0 = memref.get_global @__constant_bias : memref<3x3xf32>
+  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3](broadcast none dataType f32)
+  xsmm.binary add(dataType f32, %1, %arg0, %0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>, memref<3x3xf32>) -> ()
+
+  return
+}
+
+// CHECK: ( 2, 2, 2 )
+// CHECK: ( 2, 2, 2 )
+// CHECK: ( 2, 2, 2 )

--- a/test/Integration/xsmm-quarternary-bf16.mlir
+++ b/test/Integration/xsmm-quarternary-bf16.mlir
@@ -1,0 +1,16 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>, %arg2: memref<4xbf16>, %arg3: memref<4x4xbf16>) {
+  %c16_i64 = arith.constant 16 : i64
+  %func = xsmm.quarternary.dispatch fused_brgemm [4, 4, 4, 4, 4, 4](dataType bf16, isVNNI true)
+  xsmm.quarternary fused_brgemm(dataType bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4xbf16>, memref<4x4xbf16>, i64) -> ()
+
+  return
+}
+
+// CHECK: ( 1, 1, 1, 1 )
+// CHECK: ( 1, 1, 1, 1 )
+// CHECK: ( 1, 1, 1, 1 )
+// CHECK: ( 1, 1, 1, 1 )

--- a/test/Integration/xsmm-quarternary.mlir
+++ b/test/Integration/xsmm-quarternary.mlir
@@ -1,0 +1,15 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3xbf16>, %arg3: memref<3x3xf32>) {
+  %c16_i64 = arith.constant 16 : i64
+  %func = xsmm.quarternary.dispatch fused_brgemm [3, 3, 4, 4, 3, 3](dataType f32, isVNNI false)
+  xsmm.quarternary fused_brgemm(dataType bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3xbf16>, memref<3x3xf32>, i64) -> ()
+
+  return
+}
+
+// CHECK: ( 1, 1, 1 )
+// CHECK: ( 1, 1, 1 )
+// CHECK: ( 1, 1, 1 )

--- a/test/Integration/xsmm-ternary-bf16.mlir
+++ b/test/Integration/xsmm-ternary-bf16.mlir
@@ -1,0 +1,17 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
+                              %arg2: memref<4x4xbf16>) {
+  %c64_i64 = arith.constant 64 : i64
+  %0 = xsmm.ternary.dispatch brgemm [4, 4, 4, 4, 4, 4](dataType bf16, isVNNI true)
+  xsmm.ternary brgemm(dataType bf16, %0, %arg0, %arg1, %arg2, %c64_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
+
+  return
+}
+
+// CHECK: ( 256, 256, 256, 256 )
+// CHECK: ( 256, 256, 256, 256 )
+// CHECK: ( 256, 256, 256, 256 )
+// CHECK: ( 256, 256, 256, 256 )

--- a/test/Integration/xsmm-ternary.mlir
+++ b/test/Integration/xsmm-ternary.mlir
@@ -1,0 +1,15 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
+  %c2_i64 = arith.constant 2 : i64
+  %0 = xsmm.ternary.dispatch brgemm [3, 3, 4, 4, 3, 3](dataType f32, isVNNI false)
+  xsmm.ternary brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
+
+  return
+}
+
+// CHECK: ( 9, 9, 9 )
+// CHECK: ( 9, 9, 9 )
+// CHECK: ( 9, 9, 9 )

--- a/test/Integration/xsmm-unary-bf16.mlir
+++ b/test/Integration/xsmm-unary-bf16.mlir
@@ -9,7 +9,6 @@ func.func @entry(%arg0: memref<3x3xbf16>) {
   return
 }
 
- // CHECK: ( 1, 1, 1 )
- // CHECK: ( 1, 1, 1 )
- // CHECK: ( 1, 1, 1 )
- 
+// CHECK: ( 1, 1, 1 )
+// CHECK: ( 1, 1, 1 )
+// CHECK: ( 1, 1, 1 )

--- a/test/Integration/xsmm-unary-bf16.mlir
+++ b/test/Integration/xsmm-unary-bf16.mlir
@@ -1,0 +1,15 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: memref<3x3xbf16>) {
+  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType bf16)
+  xsmm.unary relu(dataType bf16, %0, %arg0, %arg0) : (i64, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
+
+  return
+}
+
+ // CHECK: ( 1, 1, 1 )
+ // CHECK: ( 1, 1, 1 )
+ // CHECK: ( 1, 1, 1 )
+ 

--- a/test/Integration/xsmm-unary.mlir
+++ b/test/Integration/xsmm-unary.mlir
@@ -9,7 +9,6 @@ func.func @entry(%arg0: memref<3x3xf32>) {
   return
 }
 
- // CHECK: ( 1, 1, 1 )
- // CHECK: ( 1, 1, 1 )
- // CHECK: ( 1, 1, 1 )
- 
+// CHECK: ( 1, 1, 1 )
+// CHECK: ( 1, 1, 1 )
+// CHECK: ( 1, 1, 1 )

--- a/test/Integration/xsmm-unary.mlir
+++ b/test/Integration/xsmm-unary.mlir
@@ -1,0 +1,15 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+func.func @entry(%arg0: memref<3x3xf32>) {
+  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType f32)
+  xsmm.unary relu(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
+
+  return
+}
+
+ // CHECK: ( 1, 1, 1 )
+ // CHECK: ( 1, 1, 1 )
+ // CHECK: ( 1, 1, 1 )
+ 


### PR DESCRIPTION
Modifies XSMM runner to automatically retarget bf16 compute type to f32 in XSMM binary dispatch calls, which fixes XSMM crashes due to no hardware support for native bf16 type computation.
Additionally, extra debug info is now generated when libxsmm cannot generate specified compute kernel.
Also, adds integration tests for different types of XSMM ops i.e., unary, binary, etc.

Fixes #421