### PR TITLE
MLP bf16 3 layer unpacked benchmark

### DIFF
--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -32,7 +32,12 @@
     "bf16_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-3layers-1024.mlir",
-      "flags": [ "-run-args='-def-pack=0'" ]
+      "flags": []
+    },
+    "bf16_3x1024_unpacked_mlir": {
+      "type": "MLIR",
+      "benchmark": "mlp-bf16-3layers-1024-unpacked.mlir",
+      "flags": []
     },
     "bf16_10x3584_mlir": {
       "type": "MLIR",

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -239,7 +239,7 @@ class BenchmarkDriver(object):
 
                 # Clean up output
                 stdout = re.sub("\n", "", run.stdout)
-                print(f"{run.name:20}: {stdout}")
+                print(f"{run.name:28}: {stdout}")
             print("")
 
         return True

--- a/benchmarks/mlir/mlp-bf16-3layers-1024-unpacked.mlir
+++ b/benchmarks/mlir/mlp-bf16-3layers-1024-unpacked.mlir
@@ -1,0 +1,59 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3
+// 2*256x1024x1024 (536870912) + 256x1024 (262144) + 256x1024 262144) x 3 = 1,072,168,960
+// BENCH_TOTAL_FLOPS: 1072168960
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @entry(%arg0: tensor<256x1024xbf16>, %arg3: tensor<256x1024xbf16>, %arg6: tensor<256x1024xbf16>, %arg9: tensor<256x1024xbf16> ) -> tensor<256x1024xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %arg1 = arith.constant dense<0.01> : tensor<1024x1024xbf16>
+  %arg4 = arith.constant dense<0.02> : tensor<1024x1024xbf16>
+  %arg7 = arith.constant dense<0.03> : tensor<1024x1024xbf16>
+  %arg2 = arith.constant dense<0.4> : tensor<256x1024xbf16>
+  %arg5 = arith.constant dense<0.5> : tensor<256x1024xbf16>
+  %arg8 = arith.constant dense<0.6> : tensor<256x1024xbf16>
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<256x1024xbf16>, tensor<1024x1024xbf16>) outs(%arg3 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+  %2 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel"]}
+  ins(%0, %arg2 : tensor<256x1024xbf16>, tensor<256x1024xbf16>) outs(%arg3 : tensor<256x1024xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %add = arith.addf %in, %in_0 : bf16
+      linalg.yield %add : bf16
+  } -> tensor<256x1024xbf16>
+  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<256x1024xbf16>) outs(%arg3 : tensor<256x1024xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %max = arith.maxf %in, %cst : bf16
+      linalg.yield %max : bf16
+  } -> tensor<256x1024xbf16>
+
+  %4 = linalg.matmul ins(%3, %arg4 : tensor<256x1024xbf16>, tensor<1024x1024xbf16>) outs(%arg6 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+  %6 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%4, %arg5 : tensor<256x1024xbf16>, tensor<256x1024xbf16>) outs(%arg6 : tensor<256x1024xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %add = arith.addf %in, %in_0 : bf16
+      linalg.yield %add : bf16
+  } -> tensor<256x1024xbf16>
+  %7 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%6 : tensor<256x1024xbf16>) outs(%arg6 : tensor<256x1024xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %max = arith.maxf %in, %cst : bf16
+      linalg.yield %max : bf16
+  } -> tensor<256x1024xbf16>
+
+  %8 = linalg.matmul ins(%7, %arg7 : tensor<256x1024xbf16>, tensor<1024x1024xbf16>) outs(%arg9 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+  %10 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%8, %arg8 : tensor<256x1024xbf16>, tensor<256x1024xbf16>) outs(%arg9 : tensor<256x1024xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %add = arith.addf %in, %in_0 : bf16
+      linalg.yield %add : bf16
+  } -> tensor<256x1024xbf16>
+  %11 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%10 : tensor<256x1024xbf16>) outs(%arg9 : tensor<256x1024xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %max = arith.maxf %in, %cst : bf16
+      linalg.yield %max : bf16
+  } -> tensor<256x1024xbf16>
+
+  return %11 : tensor<256x1024xbf16>
+}

--- a/benchmarks/mlir/mlp-bf16-3layers-1024.mlir
+++ b/benchmarks/mlir/mlp-bf16-3layers-1024.mlir
@@ -9,18 +9,22 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-#map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
 
-func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>, %arg2: tensor<1024xbf16>, %arg3: tensor<8x32x32x32xbf16>, %arg4: tensor<32x32x32x32xbf16>, %arg5: tensor<1024xbf16>, %arg6: tensor<8x32x32x32xbf16>, %arg7: tensor<32x32x32x32xbf16>, %arg8: tensor<1024xbf16>, %arg9: tensor<8x32x32x32xbf16> ) -> tensor<8x32x32x32xbf16> {
+func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg3: tensor<8x32x32x32xbf16>, %arg6: tensor<8x32x32x32xbf16>, %arg9: tensor<8x32x32x32xbf16> ) -> tensor<8x32x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
+  %arg1 = arith.constant dense<0.01> : tensor<32x32x32x32xbf16>
+  %arg4 = arith.constant dense<0.02> : tensor<32x32x32x32xbf16>
+  %arg7 = arith.constant dense<0.03> : tensor<32x32x32x32xbf16>
+  %arg2 = arith.constant dense<0.4> : tensor<8x32x32x32xbf16>
+  %arg5 = arith.constant dense<0.5> : tensor<8x32x32x32xbf16>
+  %arg8 = arith.constant dense<0.6> : tensor<8x32x32x32xbf16>
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x32x32xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
-  %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<1024xbf16> into tensor<32x32xbf16>
-  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %expanded : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
+  %2 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %arg2 : tensor<8x32x32x32xbf16>, tensor<8x32x32x32xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
@@ -37,8 +41,7 @@ func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
-  %expanded2 = tensor.expand_shape %arg5 [[0, 1]] : tensor<1024xbf16> into tensor<32x32xbf16>
-  %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4, %expanded2 : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>) outs(%arg6 : tensor<8x32x32x32xbf16>) {
+  %6 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4, %arg5 : tensor<8x32x32x32xbf16>, tensor<8x32x32x32xbf16>) outs(%arg6 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
@@ -55,8 +58,7 @@ func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
-  %expanded3 = tensor.expand_shape %arg8 [[0, 1]] : tensor<1024xbf16> into tensor<32x32xbf16>
-  %10 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%8, %expanded3 : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>) outs(%arg9 : tensor<8x32x32x32xbf16>) {
+  %10 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%8, %arg8 : tensor<8x32x32x32xbf16>, tensor<8x32x32x32xbf16>) outs(%arg9 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16

--- a/benchmarks/mlir/mlp-vnni-3layers-1536.mlir
+++ b/benchmarks/mlir/mlp-vnni-3layers-1536.mlir
@@ -12,10 +12,15 @@
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
 
-func.func @entry(%arg0: tensor<8x48x32x32xbf16>, %arg1: tensor<48x48x16x32x2xbf16>, %arg2: tensor<1536xbf16>, %arg4: tensor<48x48x16x32x2xbf16>, %arg5: tensor<1536xbf16>, %arg7: tensor<48x48x16x32x2xbf16>, %arg8: tensor<1536xbf16> ) -> tensor<8x48x32x32xbf16> {
+func.func @entry(%arg0: tensor<8x48x32x32xbf16>,
+                  %arg1: tensor<48x48x16x32x2xbf16>,
+                  %arg2: tensor<1536xbf16>,
+                  %arg3: tensor<8x48x32x32xbf16>,
+                  %arg4: tensor<48x48x16x32x2xbf16>,
+                  %arg5: tensor<1536xbf16>,
+                  %arg7: tensor<48x48x16x32x2xbf16>,
+                  %arg8: tensor<1536xbf16> ) -> tensor<8x48x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
-  %arg3_buf = tensor.empty(): tensor<8x48x32x32xbf16>
-  %arg3 = linalg.fill ins(%cst:bf16) outs(%arg3_buf:tensor<8x48x32x32xbf16>)->tensor<8x48x32x32xbf16>
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x48x32x32xbf16>, tensor<48x48x16x32x2xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
@@ -23,12 +28,14 @@ func.func @entry(%arg0: tensor<8x48x32x32xbf16>, %arg1: tensor<48x48x16x32x2xbf1
       linalg.yield %add : bf16
   } -> tensor<8x48x32x32xbf16>
   %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<1536xbf16> into tensor<48x32xbf16>
-  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %expanded : tensor<8x48x32x32xbf16>, tensor<48x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%0, %expanded : tensor<8x48x32x32xbf16>, tensor<48x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x48x32x32xbf16>
-  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<8x48x32x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%2 : tensor<8x48x32x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16


### PR DESCRIPTION
List of changes:
- adds a new MLP benchmark model: bf16 3 layer 1024 unpacked
- adjusts existing MLP bf16 3 layer 1024 packed model to match operations of the unpacked version
- moves MLP vnni benchmark layer outputs to passed arguments to avoid explicit linalg.fill for better code generation

Low performance of the new unpacked MLP test is due to issues with pack propagation. When other PRs address that we should see improvements.