### PR TITLE
`heap-to-stack` pass

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -108,6 +108,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createTppLoweringPass(bool loops = false);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertForAllToParallelOpPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createHeapToStackPass(unsigned maxAllocSizeInBytes = 4096);
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -357,4 +357,17 @@ def ConvertForAllToParallelOp : Pass<"convert-forall-to-parallel",
   let constructor = "mlir::tpp::createConvertForAllToParallelOpPass()";
 }
 
+def HeapToStack : Pass<"heap-to-stack", "func::FuncOp"> {
+  let summary = "Convert buffers from heap to stack";
+  let description = [{
+    Convert buffers from heap-based to stack-based allocations.
+  }];
+  let options = [
+    Option<"maxAllocSizeInBytes", "max-alloc-size-in-bytes", "unsigned",
+           /*default=*/"4096",
+           "Maximal size in bytes to promote allocations to stack.">
+  ];
+  let constructor = "mlir::tpp::createHeapToStackPass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_library(MLIRTPP
     ConvInitSimplify.cpp
     ConvertForAllToParallelOp.cpp
     CombineTpp.cpp
+    HeapToStack.cpp
 
   # Utils
     TensorInit.cpp

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -208,6 +208,7 @@ private:
     // Postprocess buffers.
     pm.addPass(bufferization::createBufferHoistingPass());
     pm.addPass(bufferization::createBufferDeallocationPass());
+    pm.addPass(createHeapToStackPass());
 
     // Run general cleanup to normalize IR.
     pm.addPass(createCleanupPass());

--- a/lib/TPP/HeapToStack.cpp
+++ b/lib/TPP/HeapToStack.cpp
@@ -65,8 +65,8 @@ struct HeapToStackAllocation : public OpRewritePattern<memref::AllocOp> {
     rewriter.eraseOp(deallocOp);
 
     // Replace the original buffer with an equivalent stack allocation.
-    rewriter.replaceOpWithNewOp<memref::AllocaOp>(alloc,
-                                                  alloc.getMemref().getType());
+    rewriter.replaceOpWithNewOp<memref::AllocaOp>(
+        alloc, alloc.getMemref().getType(), alloc.getAlignmentAttr());
 
     return success();
   }

--- a/lib/TPP/HeapToStack.cpp
+++ b/lib/TPP/HeapToStack.cpp
@@ -6,15 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "TPP/Dialect/Tpp/TppUtils.h"
 #include "TPP/Passes.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/IR/AffineMap.h"
-#include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace mlir;

--- a/lib/TPP/HeapToStack.cpp
+++ b/lib/TPP/HeapToStack.cpp
@@ -1,0 +1,99 @@
+//===- HeapToStack.cpp -------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Tpp/TppUtils.h"
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+// Convert buffers from heap to stack allocation.
+struct HeapToStackAllocation : public OpRewritePattern<memref::AllocOp> {
+  using OpRewritePattern<memref::AllocOp>::OpRewritePattern;
+  HeapToStackAllocation(MLIRContext *context, unsigned maxAllocSizeInBytes,
+                        PatternBenefit benefit = 1)
+      : OpRewritePattern<memref::AllocOp>(context, benefit),
+        maxAllocSizeInBytes(maxAllocSizeInBytes) {}
+
+  LogicalResult matchAndRewrite(memref::AllocOp alloc,
+                                PatternRewriter &rewriter) const override {
+    auto type = alloc.getType().dyn_cast<ShapedType>();
+
+    // Ignore dynamically sized buffers as their total size is unknown.
+    if (!type.hasStaticShape())
+      return rewriter.notifyMatchFailure(alloc,
+                                         "Expected statically sized buffer");
+
+    // Check allocation size. Only move small buffers to stack.
+    unsigned bitwidth = mlir::DataLayout::closest(alloc).getTypeSizeInBits(
+        type.getElementType());
+    unsigned size = type.getNumElements() * bitwidth;
+    if (size > (maxAllocSizeInBytes * 8))
+      return rewriter.notifyMatchFailure(
+          alloc, "Buffer exceeds maximum convertion size");
+
+    // Find matching deallocation operation.
+    // If the lifetime of the given allocation extends beyond the current scope,
+    // the buffer cannot be converted to stack.
+    Operation *deallocOp = nullptr;
+    for (Operation *user : alloc->getUsers()) {
+      if (isa<memref::DeallocOp>(user)) {
+        deallocOp = user;
+        break;
+      }
+    }
+    if (!deallocOp)
+      return rewriter.notifyMatchFailure(
+          alloc, "Expected deallocator to be present within the same scope");
+
+    // Remove the deallocator as stack lifetime is managed automatically.
+    rewriter.eraseOp(deallocOp);
+
+    // Replace the original buffer with an equivalent stack allocation.
+    rewriter.replaceOpWithNewOp<memref::AllocaOp>(alloc,
+                                                  alloc.getMemref().getType());
+
+    return success();
+  }
+
+private:
+  unsigned maxAllocSizeInBytes;
+};
+
+struct HeapToStack : public HeapToStackBase<HeapToStack> {
+  HeapToStack() = default;
+  HeapToStack(unsigned maxAllocSizeInBytes) {
+    this->maxAllocSizeInBytes = maxAllocSizeInBytes;
+  }
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(getOperation().getContext());
+    patterns.add<HeapToStackAllocation>(patterns.getContext(),
+                                        maxAllocSizeInBytes);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createHeapToStackPass(unsigned maxAllocSizeInBytes) {
+  return std::make_unique<HeapToStack>(maxAllocSizeInBytes);
+}

--- a/lib/TPP/HeapToStack.cpp
+++ b/lib/TPP/HeapToStack.cpp
@@ -55,12 +55,6 @@ struct HeapToStackAllocation : public OpRewritePattern<memref::AllocOp> {
       return rewriter.notifyMatchFailure(
           alloc, "Expected to find matching deallocator");
 
-    // If the lifetime of the given allocation extends beyond the current scope,
-    // the buffer cannot be converted to stack.
-    if (alloc->getParentRegion() != deallocOp->getParentRegion())
-      return rewriter.notifyMatchFailure(
-          alloc, "Expected deallocator to be in the same scope");
-
     // Remove the deallocator as stack lifetime is managed automatically.
     rewriter.eraseOp(deallocOp);
 

--- a/test/Passes/DefaultPipeline/mlp-to-stack.mlir
+++ b/test/Passes/DefaultPipeline/mlp-to-stack.mlir
@@ -1,0 +1,45 @@
+// RUN: tpp-opt %s -default-tpp-passes -split-input-file | FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+
+func.func @mlp(%arg0: tensor<8x48x32x32xbf16>,
+                  %arg1: tensor<48x48x16x32x2xbf16>,
+                  %arg2: tensor<1536xbf16>,
+                  %arg3: tensor<8x48x32x32xbf16>) -> tensor<8x48x32x32xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x48x32x32xbf16>, tensor<48x48x16x32x2xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> tensor<8x48x32x32xbf16>
+  %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<1536xbf16> into tensor<48x32xbf16>
+  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%0, %expanded : tensor<8x48x32x32xbf16>, tensor<48x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %add = arith.addf %in, %in_0 : bf16
+      linalg.yield %add : bf16
+  } -> tensor<8x48x32x32xbf16>
+  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%2 : tensor<8x48x32x32xbf16>) outs(%arg3 : tensor<8x48x32x32xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %max = arith.maxf %in, %cst : bf16
+      linalg.yield %max : bf16
+  } -> tensor<8x48x32x32xbf16>
+  return %3 : tensor<8x48x32x32xbf16>
+}
+
+// CHECK-LABEL: func.func @mlp(
+// CHECK:     call @xsmm_brgemm_dispatch
+// CHECK:     scf.parallel
+// CHECK-NOT:   memref.alloc()
+// CHECK:       memref.alloca() {alignment
+// CHECK:       call @xsmm_brgemm_invoke
+// CHECK-NOT:   memref.alloc()
+// CHECK:       memref.alloca() {alignment
+// CHECK-NOT:   memref.dealloc
+// CHECK:       scf.yield

--- a/test/Passes/heap-to-stack.mlir
+++ b/test/Passes/heap-to-stack.mlir
@@ -85,3 +85,18 @@ func.func @dynamic_size(%arg0: memref<8x?xbf16>, %arg1: memref<8xbf16>, %size: i
 // CHECK: memref.alloc(
 // CHECK: linalg.matvec
 // CHECK: memref.dealloc
+
+// -----
+
+func.func @alignment(%arg0: memref<8x8xbf16>, %arg1: memref<8x8xbf16>) -> memref<8x8xbf16> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xbf16>
+  linalg.matmul ins(%arg0, %alloc : memref<8x8xbf16>, memref<8x8xbf16>) outs(%arg1 : memref<8x8xbf16>)
+  memref.dealloc %alloc : memref<8x8xbf16>
+  return %arg1 : memref<8x8xbf16>
+}
+
+// CHECK-LABEL: func.func @alignment(
+// CHECK-NOT: memref.alloc()
+// CHECK: memref.alloca() {alignment = 64 : i64}
+// CHECK: linalg.matmul
+// CHECK-NOT: memref.dealloc

--- a/test/Passes/heap-to-stack.mlir
+++ b/test/Passes/heap-to-stack.mlir
@@ -1,0 +1,87 @@
+// RUN: tpp-opt %s -heap-to-stack -split-input-file | FileCheck %s
+
+func.func @alloc_small_1d(%arg0: memref<8x8xbf16>, %arg1: memref<8xbf16>) -> memref<8xbf16> {
+  %alloc = memref.alloc() : memref<8xbf16>
+  linalg.matvec ins(%arg0, %alloc : memref<8x8xbf16>, memref<8xbf16>) outs(%arg1 : memref<8xbf16>)
+  memref.dealloc %alloc : memref<8xbf16>
+  return %arg1 : memref<8xbf16>
+}
+
+// CHECK-LABEL: func.func @alloc_small_1d(
+// CHECK-NOT: memref.alloc()
+// CHECK: memref.alloca()
+// CHECK: linalg.matvec
+// CHECK-NOT: memref.dealloc
+
+// -----
+
+func.func @alloc_small_2d(%arg0: memref<8x8xbf16>, %arg1: memref<8x8xbf16>) -> memref<8x8xbf16> {
+  %alloc = memref.alloc() : memref<8x8xbf16>
+  linalg.matmul ins(%arg0, %alloc : memref<8x8xbf16>, memref<8x8xbf16>) outs(%arg1 : memref<8x8xbf16>)
+  memref.dealloc %alloc : memref<8x8xbf16>
+  return %arg1 : memref<8x8xbf16>
+}
+
+// CHECK-LABEL: func.func @alloc_small_2d(
+// CHECK-NOT: memref.alloc()
+// CHECK: memref.alloca()
+// CHECK: linalg.matmul
+// CHECK-NOT: memref.dealloc
+
+// -----
+
+func.func @alloc_large_1d(%arg0: memref<8x16384xbf16>, %arg1: memref<8xbf16>) -> memref<8xbf16> {
+  %alloc = memref.alloc() : memref<16384xbf16>
+  linalg.matvec ins(%arg0, %alloc : memref<8x16384xbf16>, memref<16384xbf16>) outs(%arg1 : memref<8xbf16>)
+  memref.dealloc %alloc : memref<16384xbf16>
+  return %arg1 : memref<8xbf16>
+}
+
+// CHECK-LABEL: func.func @alloc_large_1d(
+// CHECK-NOT: memref.alloca()
+// CHECK: memref.alloc()
+// CHECK: linalg.matvec
+// CHECK: memref.dealloc
+
+// -----
+
+func.func @alloc_large_2d(%arg0: memref<512x512xbf16>, %arg1: memref<512x512xbf16>) -> memref<512x512xbf16> {
+  %alloc = memref.alloc() : memref<512x512xbf16>
+  linalg.matmul ins(%arg0, %alloc : memref<512x512xbf16>, memref<512x512xbf16>) outs(%arg1 : memref<512x512xbf16>)
+  memref.dealloc %alloc : memref<512x512xbf16>
+  return %arg1 : memref<512x512xbf16>
+}
+
+// CHECK-LABEL: func.func @alloc_large_2d(
+// CHECK-NOT: memref.alloca()
+// CHECK: memref.alloc()
+// CHECK: linalg.matmul
+// CHECK: memref.dealloc
+
+// -----
+
+func.func @no_dealloc(%arg0: memref<8x8xbf16>, %arg1: memref<8x8xbf16>) -> memref<8x8xbf16> {
+  %alloc = memref.alloc() : memref<8x8xbf16>
+  linalg.matmul ins(%arg0, %alloc : memref<8x8xbf16>, memref<8x8xbf16>) outs(%arg1 : memref<8x8xbf16>)
+  return %arg1 : memref<8x8xbf16>
+}
+
+// CHECK-LABEL: func.func @no_dealloc(
+// CHECK-NOT: memref.alloca()
+// CHECK: memref.alloc()
+// CHECK: linalg.matmul
+
+// -----
+
+func.func @dynamic_size(%arg0: memref<8x?xbf16>, %arg1: memref<8xbf16>, %size: index) -> memref<8xbf16> {
+  %alloc = memref.alloc(%size) : memref<?xbf16>
+  linalg.matvec ins(%arg0, %alloc : memref<8x?xbf16>, memref<?xbf16>) outs(%arg1 : memref<8xbf16>)
+  memref.dealloc %alloc : memref<?xbf16>
+  return %arg1 : memref<8xbf16>
+}
+
+// CHECK-LABEL: func.func @dynamic_size(
+// CHECK-NOT: memref.alloca(
+// CHECK: memref.alloc(
+// CHECK: linalg.matvec
+// CHECK: memref.dealloc


### PR DESCRIPTION
Adds a new pass `heap-to-stack` which converts heap allocations to stack.
The pass is added to the default pipeline at the postprocessing stage.