### PR TITLE
`def-heap-to-stack` flag

### DIFF
--- a/benchmarks/benchmarks.json
+++ b/benchmarks/benchmarks.json
@@ -37,7 +37,7 @@
     "bf16_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-bf16-3layers-1024.mlir",
-      "flags": [],
+      "flags": [ "-run-args='-def-heap-to-stack=1'" ],
       "extensions": [ "avx512.*" ]
     },
     "bf16_3x1024_unpacked_mlir": {
@@ -55,7 +55,8 @@
     "vnni_3x1024_mlir": {
       "type": "MLIR",
       "benchmark": "mlp-vnni-3layers-1536.mlir",
-      "flags": [ "--disable-lsan" ],
+      "flags": [ "--disable-lsan",
+                 "-run-args='-def-heap-to-stack=1'" ],
       "extensions": [ "avx512_vnni" ]
     }
   }},

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -31,13 +31,19 @@ using namespace mlir;
 using namespace mlir::tpp;
 
 // Extra command line options to control the default TPP utility passes.
-llvm::cl::opt<bool> packMatmul("def-pack-matmul",
-                               llvm::cl::desc("Default pipeline - pack matmul"),
-                               llvm::cl::init(true));
+llvm::cl::opt<bool>
+    defPackMatmul("def-pack-matmul",
+                  llvm::cl::desc("Default pipeline - pack matmul"),
+                  llvm::cl::init(true));
 
 llvm::cl::opt<bool> defPipePack("def-pack",
                                 llvm::cl::desc("Default pipeline - packing"),
                                 llvm::cl::init(true));
+
+llvm::cl::opt<bool>
+    defHeapToStack("def-heap-to-stack",
+                   llvm::cl::desc("Default pipeline - heap to stack allocs"),
+                   llvm::cl::init(false));
 
 llvm::cl::opt<bool>
     disableDefPipe("disable-def-pipe",
@@ -208,7 +214,8 @@ private:
     // Postprocess buffers.
     pm.addPass(bufferization::createBufferHoistingPass());
     pm.addPass(bufferization::createBufferDeallocationPass());
-    pm.addPass(createHeapToStackPass());
+    if (defHeapToStack)
+      pm.addPass(createHeapToStackPass());
 
     // Run general cleanup to normalize IR.
     pm.addPass(createCleanupPass());
@@ -258,7 +265,7 @@ private:
       pm.addPass(createRewriteConvToMatmulOrBrgemmPass());
 
       // Convert ops to packed layouts.
-      if (packMatmul)
+      if (defPackMatmul)
         pm.addPass(createPackMatmulPass({32, 32, 32}));
       pm.addPass(createPackVNNIPass());
     }

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -def-heap-to-stack=1 -default-tpp-passes -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>

--- a/test/Passes/DefaultPipeline/mlp-to-stack.mlir
+++ b/test/Passes/DefaultPipeline/mlp-to-stack.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -def-heap-to-stack=1 -default-tpp-passes -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>


### PR DESCRIPTION
Adds a flag to control conversion of heap to stack allocations in the default pipeline.
The conversion pass is disabled by default to avoid problems with total stack size and the pass is selectively enabled only when it is crucial for overall performance.