### PR TITLE
Do not allow scalar output in tpps

### DIFF
--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -27,11 +27,18 @@ def TppVNNIMemrefInput : StaticMemRefRankOf<[AnyFloat], [3]>;
 def TppBRGEMMemrefInput : StaticMemRefRankOf<[AnyFloat], [3]>;
 def TppBRGEMMVNNIMemrefInput : StaticMemRefRankOf<[AnyFloat], [4]>;
 
-// Tpp operands is a scalar float or a static memref with rank 1 or 2.
-def TppOperand : AnyTypeOf<[TppMemRef, AnyFloat]>;
+// Tpp operands:
+// input operand: is a scalar float or a static memref with rank 1 or 2.
+// output operand: static memref with rank 1 or 2.
+def TppInputOperand : AnyTypeOf<[TppMemRef, AnyFloat]>;
+def TppOutputOperand : AnyTypeOf<[TppMemRef]>;
 
 // Tpp operands for VNNI layout.
 def TppVNNIOperand : AnyTypeOf<[TppVNNIMemrefInput, AnyFloat]>;
+
+//===----------------------------------------------------------------------===//
+// Tpp Traits
+//===----------------------------------------------------------------------===//
 
 // Tpp operation trait - make sure the operand are broadcastable.
 // Two dimensions are compatible when:
@@ -51,10 +58,11 @@ class Tpp_UnaryOp<string mnemonic, list<Trait> traits = []> :
   Tpp_Op<mnemonic, !listconcat(traits, [BroadcastableShape,
                                         UnitStrideInnerLoop])> {
   
-  let arguments = (ins TppOperand:$input, TppOperand:$output);
+  let arguments = (ins TppInputOperand:$input, TppOutputOperand:$output);
   
   let assemblyFormat = [{
-    `ins` `(` $input `:` type($input) `)` `outs` `(` $output `:` type($output) `)` 
+    `ins` `(` $input `:` type($input) `)` 
+    `outs` `(` $output `:` type($output) `)` 
     attr-dict
   }];
 }
@@ -106,8 +114,6 @@ def Tpp_ReluOp : Tpp_UnaryOp<"relu"> {
 
     ```
   }];
-
-  let hasVerifier = 1; 
 }
 
 //===----------------------------------------------------------------------===//
@@ -118,7 +124,8 @@ class Tpp_BinaryOp<string mnemonic, list<Trait> traits = []> :
   Tpp_Op<mnemonic, !listconcat(traits, [BroadcastableShape, 
                                         UnitStrideInnerLoop])> {
 
-  let arguments = (ins TppOperand:$lhs, TppOperand:$rhs, TppOperand:$out);
+  let arguments = (ins TppInputOperand:$lhs, TppInputOperand:$rhs, 
+                       TppOutputOperand:$out);
 
   let assemblyFormat = [{
         `ins` `(` $lhs `:` type($lhs) `,` $rhs `:` type($rhs) `)`
@@ -160,8 +167,6 @@ def Tpp_AddOp : Tpp_BinaryOp<"add"> {
 
     ```
   }];
-
-  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -183,8 +188,8 @@ def Tpp_MatmulOp : Tpp_Op<"matmul"> {
     ```
   }];
 
-  let arguments = (ins TppOperand:$matrixA, TppOperand:$matrixB,
-                       TppOperand:$matrixC);
+  let arguments = (ins TppInputOperand:$matrixA, TppInputOperand:$matrixB,
+                       TppOutputOperand:$matrixC);
 
   let assemblyFormat = [{
       `ins` `(` $matrixA `:` type($matrixA) `,` $matrixB `:` type($matrixB) `)`
@@ -232,8 +237,8 @@ def Tpp_VNNIMatmulOp : Tpp_Op<"vnni_matmul"> {
     ```
   }];
 
-  let arguments = (ins TppOperand:$matrixA, TppVNNIOperand:$matrixB,
-                       TppOperand:$matrixC);
+  let arguments = (ins TppInputOperand:$matrixA, TppVNNIOperand:$matrixB,
+                       TppOutputOperand:$matrixC);
 
   let assemblyFormat = [{
       `ins` `(` $matrixA `:` type($matrixA) `,` $matrixB `:` type($matrixB) `)`
@@ -367,16 +372,20 @@ def Tpp_VNNIBrgemmOp : Tpp_Op<"vnni_brgemm"> {
 
 def Tpp_FusedBrgemmOp : Tpp_Op<"fused_brgemm"> {
   let summary = [{
-    Performs batch reduced matrix multiplication followed by bias addition and relu}];
+    Performs batch reduced matrix multiplication followed by bias 
+    addition and relu
+  }];
 
   let description = [{
-    The `tpp.fused_brgemm` is an implementation of the Batch GEMM operation in oneAPI.
+    The `tpp.fused_brgemm` is an implementation of the Batch GEMM operation 
+    in oneAPI.
 
     Example:
 
     ```mlir
 
-      tpp.fused_brgemm ins(%1: memref<3x6x4xf32>, %2: memref<3x4x4xf32>, %3: memref<4xf32>, %4: i64)
+      tpp.fused_brgemm ins(%1: memref<3x6x4xf32>, %2: memref<3x4x4xf32>, 
+                           %3: memref<4xf32>, %4: i64)
                       outs(%5: memref<6x4xf32>)
     ```
   }];

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -111,34 +111,6 @@ void FusedBrgemmOp::build(OpBuilder &builder, OperationState &state,
       tpp::FusedOpTypeAttr::get(builder.getContext(), tpp::FusedOpType::NONE),
       output);
 }
-//===----------------------------------------------------------------------===//
-// AdddOp
-//===----------------------------------------------------------------------===//
-
-// Accept only shaped operands for AddOp. We currently do not support
-// broadcasting and TPP operations are memory to memory thus disallow scalar
-// operand for now.
-LogicalResult AddOp::verify() {
-  Type lhsType = getLhs().getType();
-  Type rhsType = getRhs().getType();
-  Type outputType = getOut().getType();
-  if ((!lhsType.isa<ShapedType>()) || (!rhsType.isa<ShapedType>()) ||
-      (!outputType.isa<ShapedType>()))
-    return emitOpError("expects all operands to be shaped type");
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// ReluOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult ReluOp::verify() {
-  Type inputType = getInput().getType();
-  Type outputType = getOutput().getType();
-  if ((!inputType.isa<ShapedType>()) || (!outputType.isa<ShapedType>()))
-    return emitOpError("expects both operands to be shaped type");
-  return success();
-}
 
 //===----------------------------------------------------------------------===//
 // VNNIMatmulOp

--- a/lib/TPP/Dialect/Tpp/TppTraits.cpp
+++ b/lib/TPP/Dialect/Tpp/TppTraits.cpp
@@ -116,8 +116,6 @@ mlir::OpTrait::tpp::verifyUnitStrideInnerLoop(Operation *op,
   return success();
 }
 
-// Verify the output tensor to be
-
 LogicalResult mlir::OpTrait::tpp::checkBroadcastableShape(Operation *op) {
   return verifyBroadcastableShape(op, /*emitDiagnostic=*/false);
 }

--- a/lib/TPP/Dialect/Tpp/TppTraits.cpp
+++ b/lib/TPP/Dialect/Tpp/TppTraits.cpp
@@ -116,6 +116,8 @@ mlir::OpTrait::tpp::verifyUnitStrideInnerLoop(Operation *op,
   return success();
 }
 
+// Verify the output tensor to be
+
 LogicalResult mlir::OpTrait::tpp::checkBroadcastableShape(Operation *op) {
   return verifyBroadcastableShape(op, /*emitDiagnostic=*/false);
 }

--- a/test/Conversion/TppToLoops/tpp-to-loops.mlir
+++ b/test/Conversion/TppToLoops/tpp-to-loops.mlir
@@ -88,17 +88,6 @@ func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3xf32>) {
 // CHECK:     %[[tostore:.*]] = memref.load %[[ARG1]][%[[j]]] : memref<3xf32>
 // CHECK:     memref.store %[[tostore]], %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
 
-// -----
-
-// CHECK-LABEL: @identity_to_loops_scalar(
-// CHECK-SAME: %[[ARG0:.+]]: f32, %[[ARG1:.+]]: f32)
-func.func @identity_to_loops_scalar(%arg0: f32, %arg1: f32) -> f32 {
-  tpp.identity ins(%arg0: f32) outs(%arg1: f32)
-  // CHECK: arith.addf %[[ARG0]], %[[ARG0]] : f32
-  %0 = arith.addf %arg1, %arg1 : f32
-  return %0: f32
-}
-
 
 // -----
 

--- a/test/Dialect/Tpp/tpp-invalid.mlir
+++ b/test/Dialect/Tpp/tpp-invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: tpp-opt %s -split-input-file -verify-diagnostics
 
 func.func @tpp_add_invalid(%arg0: f32, %arg1: f32) {
-  // expected-error @below {{'tpp.add' op expects all operands to be shaped type}}
+  // expected-error @below {{operand #2 must be 1D/2D memref of floating-point values, but got 'f32'}}
   tpp.add ins(%arg0: f32, %arg0: f32) outs(%arg1: f32)
   return
 }
@@ -9,7 +9,7 @@ func.func @tpp_add_invalid(%arg0: f32, %arg1: f32) {
 // -----
 
 func.func @tpp_relu_invalid(%arg0: f32, %arg1: f32) {
-  // expected-error @below {{'tpp.relu' op expects both operands to be shaped type}}
+  // expected-error @below {{operand #1 must be 1D/2D memref of floating-point values, but got 'f32'}}
   tpp.relu ins(%arg0: f32) outs(%arg1: f32)
   return
 }
@@ -17,7 +17,7 @@ func.func @tpp_relu_invalid(%arg0: f32, %arg1: f32) {
 // -----
 
 func.func @tpp_relu_invalid(%arg0: memref<f32>, %arg1: memref<f32>) {
-  // expected-error @below {{'tpp.relu' op operand #0 must be 1D/2D memref of floating-point values or floating-point, but got 'memref<f32>'}}
+  // expected-error @below {{operand #0 must be 1D/2D memref of floating-point values or floating-point, but got 'memref<f32>'}}
   tpp.relu ins(%arg0: memref<f32>) outs(%arg1: memref<f32>)
   return
 }
@@ -25,7 +25,7 @@ func.func @tpp_relu_invalid(%arg0: memref<f32>, %arg1: memref<f32>) {
 // -----
 
 func.func @tpp_add_invalid(%arg0: memref<f32>, %arg1: memref<f32>) {
-  // expected-error @below {{'tpp.add' op operand #0 must be 1D/2D memref of floating-point values or floating-point, but got 'memref<f32>'}}
+  // expected-error @below {{operand #0 must be 1D/2D memref of floating-point values or floating-point, but got 'memref<f32>'}}
   tpp.add ins(%arg0: memref<f32>, %arg1: memref<f32>) outs(%arg1: memref<f32>)
   return
 }
@@ -42,7 +42,7 @@ func.func @tpp_identity_invalid(%arg0: memref<1x2xf32>, %arg1: memref<2x2xf32>) 
 // -----
 
 func.func @myfunc(%arg0: memref<?x?xf32>, %arg1: memref<2x2xf32>) -> memref<2x2xf32> {
-  // expected-error @below {{'tpp.identity' op operand #0 must be 1D/2D memref of floating-point values or floating-point, but got 'memref<?x?xf32>'}}
+  // expected-error @below {{operand #0 must be 1D/2D memref of floating-point values or floating-point, but got 'memref<?x?xf32>'}}
   tpp.identity ins(%arg0: memref<?x?xf32>) outs(%arg1: memref<2x2xf32>)
   return %arg1: memref<2x2xf32>
 }
@@ -51,7 +51,7 @@ func.func @myfunc(%arg0: memref<?x?xf32>, %arg1: memref<2x2xf32>) -> memref<2x2x
 
 func.func @tpp_identity_invalid(%arg0: memref<3x3xf32>, %arg1: memref<2x3xf32>) -> memref<3x3xf32> {
 
-  // expected-error @below {{op result type not broadcast compatible with broadcasted operands's shapes}}
+  // expected-error @below {{result type not broadcast compatible with broadcasted operands's shapes}}
   tpp.identity ins(%arg1: memref<2x3xf32>) outs(%arg0: memref<3x3xf32>)
   return %arg0: memref<3x3xf32>
 }
@@ -60,7 +60,7 @@ func.func @tpp_identity_invalid(%arg0: memref<3x3xf32>, %arg1: memref<2x3xf32>) 
 
 func.func @tpp_matmul_invalid(%arg0: memref<3x2xf32>, %arg1: memref<4x3xf32>,
                               %arg2: memref<5x5xf32>) -> memref<5x5xf32> {
-  // expected-error @below {{'tpp.matmul' op fails to verify operands dimensions mismatch}}
+  // expected-error @below {{fails to verify operands dimensions mismatch}}
   tpp.matmul ins(%arg0: memref<3x2xf32>, %arg1: memref<4x3xf32>) outs(%arg2: memref<5x5xf32>)
   return %arg2: memref<5x5xf32>
 }
@@ -70,7 +70,7 @@ func.func @tpp_matmul_invalid(%arg0: memref<3x2xf32>, %arg1: memref<4x3xf32>,
 // The batch dimension must agree in both arg0 and arg1.
 func.func @tpp_brgemm_invalid(%arg0: memref<7x2x3xf32>, %arg1: memref<8x3x2xf32>,
                               %arg2: memref<2x2xf32>) -> memref<2x2xf32> {
-  // expected-error @below {{'tpp.brgemm' op fails to verify operands dimensions mismatch}}
+  // expected-error @below {{fails to verify operands dimensions mismatch}}
   tpp.brgemm ins(%arg0: memref<7x2x3xf32>, %arg1: memref<8x3x2xf32>) outs(%arg2: memref<2x2xf32>)
   return %arg2: memref<2x2xf32>
 }
@@ -79,7 +79,7 @@ func.func @tpp_brgemm_invalid(%arg0: memref<7x2x3xf32>, %arg1: memref<8x3x2xf32>
 
 func.func @tpp_matmul_invalid(%arg0: memref<6x5xbf16>, %arg1: memref<5x6x2xbf16>,
                               %arg2: memref<6x6xbf16>) -> memref<6x6xbf16> {
-  // expected-error @below {{'tpp.vnni_matmul' op fails to verify operands dimensions mismatch}}
+  // expected-error @below {{fails to verify operands dimensions mismatch}}
   tpp.vnni_matmul ins(%arg0: memref<6x5xbf16>, %arg1: memref<5x6x2xbf16>) outs(%arg2: memref<6x6xbf16>)
   return %arg2: memref<6x6xbf16>
 }
@@ -89,7 +89,7 @@ func.func @tpp_matmul_invalid(%arg0: memref<6x5xbf16>, %arg1: memref<5x6x2xbf16>
 // Mixed types
 func.func @tpp_matmul_invalid(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>,
                               %arg2: memref<6x6xf32>) -> memref<6x6xf32> {
-  // expected-error @below {{'tpp.vnni_matmul' op requires the same element type for all operands}}
+  // expected-error @below {{requires the same element type for all operands}}
   tpp.vnni_matmul ins(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>) outs(%arg2: memref<6x6xf32>)
   return %arg2: memref<6x6xf32>
 }
@@ -99,7 +99,7 @@ func.func @tpp_matmul_invalid(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16
 // Mixed types
 func.func @tpp_matmul_invalid(%arg0: memref<3x2xf32>, %arg1: memref<2x3xf32>,
                               %arg2: memref<3x3xbf16>) -> memref<3x3xbf16> {
-  // expected-error @below {{'tpp.matmul' op requires the same element type for all operands}}
+  // expected-error @below {{requires the same element type for all operands}}
   tpp.matmul ins(%arg0: memref<3x2xf32>, %arg1: memref<2x3xf32>) outs(%arg2: memref<3x3xbf16>)
   return %arg2: memref<3x3xbf16>
 }
@@ -107,7 +107,7 @@ func.func @tpp_matmul_invalid(%arg0: memref<3x2xf32>, %arg1: memref<2x3xf32>,
 // -----
 
 func.func @tpp_add_check_broadcast_operand(%arg0: memref<2x3xf32>, %arg1: memref<3x3xf32>) {
-  // expected-error @below {{'tpp.add' op operands don't have broadcast-compatible shapes}}
+  // expected-error @below {{operands don't have broadcast-compatible shapes}}
   tpp.add ins(%arg0: memref<2x3xf32>, %arg1: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
   return
 }
@@ -115,7 +115,7 @@ func.func @tpp_add_check_broadcast_operand(%arg0: memref<2x3xf32>, %arg1: memref
 // -----
 
 func.func @tpp_add_check_broadcast_result(%arg0: memref<8x1xf32>, %arg1: memref<8x8xf32>) {
-  // expected-error @below {{'tpp.add' op result type not broadcast compatible with broadcasted operands's shapes}}
+  // expected-error @below {{result type not broadcast compatible with broadcasted operands's shapes}}
   tpp.add ins(%arg1: memref<8x8xf32>, %arg1: memref<8x8xf32>) outs(%arg0: memref<8x1xf32>)
   return 
 }


### PR DESCRIPTION
Tpp are memory-to-memory operations and we should not allow a scalar as output memref. With this changes the tpp.relu and tpp.add verifier can be removed as we check operand shape directly in TD. Update tests and avoid checking operand prefix, this is automatically generate and there is not need for us to check.