### PR TITLE
tpp-run - omp pass

### DIFF
--- a/test/Integration/tpp-run-parallel.mlir
+++ b/test/Integration/tpp-run-parallel.mlir
@@ -1,0 +1,33 @@
+// RUN: tpp-run %s -def-parallel=0 -e entry -entry-point-result=void -print-mlir=late -print 2>&1 | \
+// RUN: FileCheck %s --check-prefix=SERIAL
+
+// TODO: reenable when OpenMP is readibly available everywhere
+// R_UN: tpp-run %s -def-parallel=1 -e entry -entry-point-result=void -print-mlir=late -print 2>&1 | \
+// R_UN: FileCheck %s --check-prefix=PARALLEL
+
+func.func @entry(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %alloc = memref.alloc() : memref<8x8xf32>
+  scf.parallel (%arg1, %arg2) = (%c0, %c0) to (%c8, %c8) step (%c1, %c1) {
+    %0 = memref.load %arg0[%arg1, %arg2] : memref<8x8xf32>
+    memref.store %0, %alloc[%arg1, %arg2] : memref<8x8xf32>
+    scf.yield
+  }
+  return %alloc : memref<8x8xf32>
+}
+
+// SERIAL-LABEL: func.func @_entry
+// SERIAL: scf.parallel
+// SERIAL:   memref.load
+// SERIAL:   memref.store
+
+// PARALLEL-LABEL: func.func @_entry
+// PARALLEL: omp.parallel
+// PARALLEL:   omp.wsloop
+// PARALLEL:     memref.load
+// PARALLEL:     memref.store
+
+// SERIAL-COUNT-8: ( 1, 1, 1, 1, 1, 1, 1, 1 )
+// PARALLEL-COUNT-8: ( 1, 1, 1, 1, 1, 1, 1, 1 )

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -92,11 +92,9 @@ func.func @entry(%A: tensor<4x8xf32>,
 // LATE:   memref.cast
 // LATE:   memref.cast
 // LATE:   call @xsmm_matmul_invoke
-// LATE:   cf.cond_br %{{.*}}, [[BODY:.*]], [[LATCH:.*]]
-// LATE:   [[BODY]]:
+// LATE:   scf.for
 // LATE:     memref.load
 // LATE:     arith.addf
-// LATE:   [[LATCH]]:
 // LATE-DAG: @xsmm_matmul_invoke
 // LATE-DAG: @xsmm_matmul_dispatch
 // LATE-LABEL: @entry
@@ -128,24 +126,18 @@ func.func @entry(%A: tensor<4x8xf32>,
 // LOOPS-DAG:  memref.global "private" constant @__constant_8x4xf32 : memref<8x4xf32> = dense<1.000000e+00> {alignment = 64 : i64}
 // LOOPS-LABEL: @_entry
 // LOOPS:   memref.get_global @__constant_8x4xf32 : memref<8x4xf32>
-// LOOPS:   cf.cond_br %{{.*}}, [[BODY:.*]], [[LATCH:.*]]
-// LOOPS: [[BODY]]:
-// LOOPS:   memref.load
-// LOOPS:   memref.load
-// LOOPS:   memref.load
-// LOOPS:   arith.mulf
-// LOOPS:   arith.addf
-// LOOPS:   memref.store
-// LOOPS:   arith.addi
-// LOOPS: [[LATCH]]:
-// LOOPS:   cf.cond_br %{{.*}}, [[BODY1:.*]], [[LATCH1:.*]]
-// LOOPS: [[BODY1]]:
-// LOOPS:   memref.load
-// LOOPS:   memref.load
-// LOOPS:   arith.addf
-// LOOPS:   memref.store
-// LOOPS:   arith.addi
-// LOOPS: [[LATCH1]]:
+// LOOPS:   scf.for
+// LOOPS:     memref.load
+// LOOPS:     memref.load
+// LOOPS:     memref.load
+// LOOPS:     arith.mulf
+// LOOPS:     arith.addf
+// LOOPS:     memref.store
+// LOOPS:   scf.for
+// LOOPS:     memref.load
+// LOOPS:     memref.load
+// LOOPS:     arith.addf
+// LOOPS:     memref.store
 // LOOPS-LABEL: @entry
 // LOOPS:   call @_entry({{.*}}) : (memref<4x8xf32>, memref<4x4xf32>, memref<f32>) -> ()
 

--- a/tools/tpp-run/CMakeLists.txt
+++ b/tools/tpp-run/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_options(tpp-run PRIVATE
   -L${LLVM_LIBRARY_DIR}
   -lmlir_c_runner_utils
   -lmlir_runner_utils
+  -fopenmp
   -Wl,--as-needed
 )
 

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -385,12 +385,12 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
     passManager.addPass(createPrintIRPass());
 
   // Lower to LLVM
+  passManager.addPass(createConvertVectorToLLVMPass());
   passManager.addPass(createFinalizeMemRefToLLVMConversionPass());
   passManager.addPass(createConvertSCFToCFPass());
   passManager.addPass(createConvertOpenMPToLLVMPass());
-  passManager.addPass(createConvertVectorToLLVMPass());
-  passManager.addPass(createConvertFuncToLLVMPass());
   passManager.addPass(createConvertMathToLLVMPass());
+  passManager.addPass(createConvertFuncToLLVMPass());
   passManager.addNestedPass<func::FuncOp>(createArithToLLVMConversionPass());
   passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   passManager.addPass(createReconcileUnrealizedCastsPass());

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -377,7 +377,6 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
   passManager.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
   passManager.addPass(createConvertSCFToOpenMPPass());
   passManager.addPass(createConvertVectorToSCFPass());
-  passManager.addPass(createConvertSCFToCFPass());
   passManager.addPass(arith::createArithExpandOpsPass());
   passManager.addPass(createLowerAffinePass());
 
@@ -386,10 +385,11 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
     passManager.addPass(createPrintIRPass());
 
   // Lower to LLVM
+  passManager.addPass(createFinalizeMemRefToLLVMConversionPass());
+  passManager.addPass(createConvertSCFToCFPass());
   passManager.addPass(createConvertOpenMPToLLVMPass());
   passManager.addPass(createConvertVectorToLLVMPass());
   passManager.addPass(createConvertFuncToLLVMPass());
-  passManager.addPass(createFinalizeMemRefToLLVMConversionPass());
   passManager.addPass(createConvertMathToLLVMPass());
   passManager.addNestedPass<func::FuncOp>(createArithToLLVMConversionPass());
   passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -375,9 +375,10 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
   passManager.addPass(tpp::createConvertPerfToFuncPass());
   passManager.addPass(createConvertTensorToLinalgPass());
   passManager.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
-  passManager.addPass(arith::createArithExpandOpsPass());
+  passManager.addPass(createConvertSCFToOpenMPPass());
   passManager.addPass(createConvertVectorToSCFPass());
   passManager.addPass(createConvertSCFToCFPass());
+  passManager.addPass(arith::createArithExpandOpsPass());
   passManager.addPass(createLowerAffinePass());
 
   // Print IR of optimized kernel and main
@@ -385,6 +386,7 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
     passManager.addPass(createPrintIRPass());
 
   // Lower to LLVM
+  passManager.addPass(createConvertOpenMPToLLVMPass());
   passManager.addPass(createConvertVectorToLLVMPass());
   passManager.addPass(createConvertFuncToLLVMPass());
   passManager.addPass(createFinalizeMemRefToLLVMConversionPass());


### PR DESCRIPTION
Adds omp lowering passes to the runner to enable parallel execution. The parallelization is opt-in i.e., disabled by default and controlled with `def-parallel` flag.
Additionally, the backend passes are slightly reordered to address presence of unrealized casts.

Fixes #449 