### PR TITLE
Handling dependency for StructuredOps

### DIFF
--- a/lib/TPP/Dialect/Tpp/CMakeLists.txt
+++ b/lib/TPP/Dialect/Tpp/CMakeLists.txt
@@ -13,10 +13,12 @@ add_mlir_dialect_library(TPPTppDialect
     # add_mlir_dialect macro force-prefixes with MLIR
     MLIRTppOpsIncGen
     MLIRTppAttrDefIncGen
+    TPPIR
 
   LINK_LIBS PUBLIC
     MLIRIR
     MLIRInferTypeOpInterface
+    TPPIR
 )
 
 target_include_directories(TPPTppDialect

--- a/lib/TPP/IR/CMakeLists.txt
+++ b/lib/TPP/IR/CMakeLists.txt
@@ -3,4 +3,7 @@ add_mlir_library(TPPIR
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP
+
+  DEPENDS
+    MLIRLinalgDialect
 )


### PR DESCRIPTION
Fixing compilation errors below that show up while building TPP alongside IREE.

```
In file included from iree/third_party/tpp-mlir/include/TPP/IR/StructuredOpMatcher.h:12,
                from iree/third_party/tpp-mlir/lib/TPP/IR/StructuredOpMatcher.cpp:9:
iree/third_party/llvm-project/mlir/include/mlir/Dialect/Linalg/IR/Linalg.h:81:10: fatal error: mlir/Dialect/Linalg/IR/LinalgOpsDialect.h.inc: No such file or directory
  81 | #include "mlir/Dialect/Linalg/IR/LinalgOpsDialect.h.inc"
     |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and 
```
/swtools/binutils/2.39/bin/ld: llvm-external-projects/mlir-tpp-dialects/lib/TPP/Dialect/Tpp/libTPPTppDialect.a(TppUtils.cpp.o): in function `mlir::tpp::utils::isTppMatmul(mlir::linalg::LinalgOp, llvm::SmallVectorImpl<mlir::Value>*)':
iree/third_party/tpp-mlir/lib/TPP/Dialect/Tpp/TppUtils.cpp:278: undefined reference to `mlir::tpp::structured_match::StructuredOpMatcher::operation(std::function<bool (mlir::Operation*)>)'
/swtools/binutils/2.39/bin/ld: iree/third_party/tpp-mlir/lib/TPP/Dialect/Tpp/TppUtils.cpp:279: undefined reference to `mlir::tpp::structured_match::StructuredOpMatcher::operation(std::function<bool (mlir::Operation*)>)'
/swtools/binutils/2.39/bin/ld: iree/third_party/tpp-mlir/lib/TPP/Dialect/Tpp/TppUtils.cpp:280: undefined reference to `mlir::tpp::structured_match::StructuredOpMatcher::dim(mlir::tpp::structured_match::RangeDims, llvm::SmallVector<mlir::utils::IteratorType, 12u>)'
/swtools/binutils/2.39/bin/ld: iree/third_party/tpp-mlir/lib/TPP/Dialect/Tpp/TppUtils.cpp:283: undefined reference to `mlir::tpp::structured_match::StructuredOpMatcher::input(mlir::tpp::structured_match::Operand, std::function<bool (mlir::OpOperand*, mlir::Operation*)>)'
```