### PR TITLE
Perf dialect - `perf.median` operation

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -273,6 +273,44 @@ def Perf_MeanOp : Perf_Op<"mean", []> {
 }
 
 //===----------------------------------------------------------------------===//
+// MedianOp
+//===----------------------------------------------------------------------===//
+
+def Perf_MedianOp : Perf_Op<"median", []> {
+  let summary = "Compute median value.";
+  let description = [{
+    The `perf.median` operation computes median value of the provided
+    time deltas.
+
+    Example:
+
+    ```mlir
+
+    %deltas = perf.bench (%n) {
+      ... // benchmarked code
+    } -> memref<?xf64>
+
+    %mean = perf.median(%deltas : memref<?xf64>) : f64
+
+    ```
+  }];
+
+  let arguments = (ins RankedOrUnrankedMemRefOf<[F64]>:$input);
+  let results = (outs F64:$result);
+
+  let assemblyFormat = [{
+    `(` $input `:` type($input) `)` attr-dict
+    `:` type($result)
+  }];
+
+  let extraClassDeclaration = [{
+    static std::string getLibraryCallName() {
+      return "perf_median";
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // StdevOp
 //===----------------------------------------------------------------------===//
 

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -98,8 +98,8 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
 
 def Perf_BenchOp : Perf_Op<"bench",
     [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
-     RangedTypesMatchWith<"result types match types of args",
-                          "args",
+     RangedTypesMatchWith<"result types match types of iter_args",
+                          "iterArgs",
                           "bodyResults",
                           "$_self">,
      RangedTypesMatchWith<"result types match types of yield",
@@ -143,7 +143,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     An example of a benchmark with an output result:
 
     ```mlir
-    %sum = perf.bench (%n, %deltas : memref<?xf64>) args(%val : i32) {
+    %sum = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%val : i32) {
       %sum_next = arith.addi %val, %cst : i32
       perf.yield %sum_next : i32
     } -> i32
@@ -154,10 +154,10 @@ def Perf_BenchOp : Perf_Op<"bench",
     a benchmarking loop.
     For example, the following input:
     ```mlir
-    %res, ... = perf.bench (%n, %deltas : memref<?xf64>) args(%x, ... : ...) {
+    %res, ... = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%x, ... : ...) {
       ... // body - ops under measurement
 
-      // Yield current iteration values to the next iteration args (%x, ...)
+      // Yield current iteration values to the next iteration iter_args (%x, ...)
       // or to the bench op results (%res, ...) if it is the final iteration.
       perf.yield %x, ...
     } -> type(%res), ...
@@ -175,7 +175,7 @@ def Perf_BenchOp : Perf_Op<"bench",
       // Store measured time delta.
       store %delta, %deltas[%iv]
 
-      // Yield current iteration values to the next iteration args (%x, ...)
+      // Yield current iteration values to the next iteration iter_args (%x, ...)
       // or to the loop results (%res, ...) if it is the final iteration.
       yield %x, ...
     }
@@ -184,13 +184,13 @@ def Perf_BenchOp : Perf_Op<"bench",
 
   let arguments = (ins I64:$numIters,
                        RankedOrUnrankedMemRefOf<[F64]>:$deltas,
-                       Variadic<AnyType>:$args);
+                       Variadic<AnyType>:$iterArgs);
   let results = (outs Variadic<AnyType>:$bodyResults);
   let regions = (region SizedRegion<1>:$region);
 
   let assemblyFormat = [{
     `(` $numIters `,` $deltas `:` type($deltas) `)`
-    (`args` `(` $args^ `:` type($args) `)`)?
+    (`iter_args` `(` $iterArgs^ `:` type($iterArgs) `)`)?
     $region attr-dict
     (`->` type($bodyResults)^)?
   }];
@@ -198,7 +198,7 @@ def Perf_BenchOp : Perf_Op<"bench",
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "Value":$numIters, "Value":$deltas,
-      CArg<"ValueRange", "std::nullopt">:$args)>
+      CArg<"ValueRange", "std::nullopt">:$iterArgs)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/TPP/ConvertPerfToFunc.cpp
+++ b/lib/TPP/ConvertPerfToFunc.cpp
@@ -360,6 +360,19 @@ struct ConvertMeanOp : public OpRewritePattern<perf::MeanOp> {
   }
 };
 
+struct ConvertMedianOp : public OpRewritePattern<perf::MedianOp> {
+  using OpRewritePattern<perf::MedianOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(perf::MedianOp medianOp,
+                                PatternRewriter &rewriter) const override {
+    auto res = buildPerfFuncCall(
+        medianOp.getLoc(), medianOp.getLibraryCallName(), medianOp, rewriter);
+    if (succeeded(res))
+      rewriter.eraseOp(medianOp);
+    return res;
+  }
+};
+
 struct ConvertStdevOp : public OpRewritePattern<perf::StdevOp> {
   using OpRewritePattern<perf::StdevOp>::OpRewritePattern;
 
@@ -393,7 +406,8 @@ struct ConvertSinkOp : public OpRewritePattern<perf::SinkOp> {
 
 void populatePerfToFuncPatterns(RewritePatternSet &patterns) {
   patterns.add<ConvertStartTimerOp, ConvertStopTimerOp, ConvertMeanOp,
-               ConvertStdevOp, ConvertSinkOp>(patterns.getContext());
+               ConvertMedianOp, ConvertStdevOp, ConvertSinkOp>(
+      patterns.getContext());
 }
 
 struct ConvertPerfToFunc : public ConvertPerfToFuncBase<ConvertPerfToFunc> {

--- a/lib/TPP/ConvertPerfToLoops.cpp
+++ b/lib/TPP/ConvertPerfToLoops.cpp
@@ -40,8 +40,8 @@ struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
     auto zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     auto one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     auto loop = rewriter.create<scf::ForOp>(loc, zero, numIters, one,
-                                            benchOp.getArgs());
-    if (benchOp.getArgs().empty()) {
+                                            benchOp.getIterArgs());
+    if (benchOp.getIterArgs().empty()) {
       // Erase the default loop yield, it will be inserted later.
       rewriter.eraseOp(loop.getRegion().front().getTerminator());
     }
@@ -71,10 +71,10 @@ struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
 
     // Replace uses of bench args within the benchmark body with their
     // equivalent loop-carried variables.
-    assert((benchOp.getArgs().size() == loop.getRegionIterArgs().size()) &&
+    assert((benchOp.getIterArgs().size() == loop.getRegionIterArgs().size()) &&
            "expect equal number of loop-carried variables");
     for (auto [benchArg, loopArg] :
-         llvm::zip_equal(benchOp.getArgs(), loop.getRegionIterArgs()))
+         llvm::zip_equal(benchOp.getIterArgs(), loop.getRegionIterArgs()))
       replaceAllUsesInRegionWith(benchArg, loopArg, loop.getRegion());
 
     // Pass perf.yield values through the scf.yield.

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -46,12 +46,12 @@ LogicalResult StopTimerOp::verify() {
 //===----------------------------------------------------------------------===//
 
 void BenchOp::build(OpBuilder &builder, OperationState &result, Value numIters,
-                    Value deltas, ValueRange args) {
+                    Value deltas, ValueRange iterArgs) {
   result.addOperands({numIters, deltas});
-  result.addOperands(args);
+  result.addOperands(iterArgs);
 
   // Results have to match the input arguments
-  for (Value v : args)
+  for (Value v : iterArgs)
     result.addTypes(v.getType());
 
   Region *bodyRegion = result.addRegion();
@@ -61,7 +61,7 @@ void BenchOp::build(OpBuilder &builder, OperationState &result, Value numIters,
   // Create the default terminator if the arguments are not provided.
   // Otherwise, leave this to the caller because we don't know which values to
   // return from the body.
-  if (args.empty()) {
+  if (iterArgs.empty()) {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(&bodyBlock);
     builder.create<perf::YieldOp>(result.location);

--- a/runtime/PerfRunnerUtils.cpp
+++ b/runtime/PerfRunnerUtils.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 
@@ -32,4 +33,23 @@ double _mlir_ciface_perf_stop_timer(int64_t startTimestamp) {
       std::chrono::high_resolution_clock::duration{startTimestamp}};
   return std::chrono::duration_cast<std::chrono::duration<double>>(stop - start)
       .count();
+}
+
+double _mlir_ciface_perf_median(UnrankedMemRefType<double> *buf) {
+  DynamicMemRefType<double> deltas(*buf);
+
+  // First, sort the measurements.
+  std::vector<double> data(deltas.begin(), deltas.end());
+  std::sort(data.begin(), data.end());
+
+  // Calculate median value.
+  int64_t n = data.size();
+  double median = 0.0f;
+  if (n % 2 == 0) {
+    median = (data[n / 2 - 1] + data[n / 2]) / 2.0;
+  } else {
+    median = data[n / 2];
+  }
+
+  return median;
 }

--- a/runtime/PerfRunnerUtils.h
+++ b/runtime/PerfRunnerUtils.h
@@ -23,4 +23,7 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_perf_start_timer();
 
 extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_perf_stop_timer(int64_t);
 
+extern "C" MLIR_RUNNERUTILS_EXPORT double
+_mlir_ciface_perf_median(UnrankedMemRefType<double> *);
+
 #endif // TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -48,6 +48,16 @@ func.func @func_mean(%arg0: memref<?xf64>) {
 
 // -----
 
+// CHECK-DAG: func.func private @perf_median(memref<*xf64>) -> f64 attributes {llvm.emit_c_interface}
+// CHECK-LABEL: @func_median
+func.func @func_median(%arg0: memref<?xf64>) {
+  // CHECK: call @perf_median({{.*}})
+  %median = perf.median(%arg0 : memref<?xf64>) : f64
+  return
+}
+
+// -----
+
 // CHECK:     func.func private @perf_stdev(%[[arg0:.*]]: memref<*xf64>, %[[mean:.*]]: f64) -> f64 {
 // CHECK-DAG:   %[[lb:.*]] = arith.constant 0 : index
 // CHECK-DAG:   %[[step:.*]] = arith.constant 1 : index

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -150,7 +150,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>

--- a/test/Conversion/PerfToLoops/perf-to-loops.mlir
+++ b/test/Conversion/PerfToLoops/perf-to-loops.mlir
@@ -102,7 +102,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>
@@ -144,7 +144,7 @@ func.func @perf_example_multi_arg(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]], %[[mulres]]
   // CHECK: }
-  %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) args(%output, %output1 : i64, tensor<4x4xf32>) {
+  %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output, %output1 : i64, tensor<4x4xf32>) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     %sum = arith.addi %output, %k : i64

--- a/test/Dialect/Perf/perf-invalid.mlir
+++ b/test/Dialect/Perf/perf-invalid.mlir
@@ -5,7 +5,7 @@ func.func @perf_no_outs(%n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
   %val = perf.bench (%n, %deltas : memref<?xf64>) {
     perf.sink(%n) : i64
   } -> i64
@@ -21,8 +21,8 @@ func.func @perf_invalid_outs_types(%a: i32, %b: i32, %n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
   } -> i32
@@ -39,8 +39,8 @@ func.func @perf_invalid_outs_order(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
   %out1 = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
-  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) args(%out1, %out : i64, i32) {
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
+  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out1, %out : i64, i32) {
     %c = arith.addi %a, %b : i32
     perf.yield %c, %n : i32, i64
   } -> i32, i64
@@ -57,7 +57,7 @@ func.func @perf_no_yield(%n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
     perf.sink(%n) : i64
   } -> i64
 
@@ -73,7 +73,7 @@ func.func @perf_invalid_yield_op(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
 
   // expected-error @below {{perf.bench' op expects region to terminate with 'perf.yield'}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i32) {
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i32) {
     %c = arith.addi %a, %b : i32
     // expected-note @below {{terminator here}}
     scf.yield %c : i32
@@ -91,7 +91,7 @@ func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
   } -> i64
@@ -109,7 +109,7 @@ func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
   %out1 = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) args(%out, %out1 : i32, i64) {
+  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out, %out1 : i32, i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %n, %c : i64, i32
   } -> i32, i64

--- a/test/Dialect/Perf/perf-ops.mlir
+++ b/test/Dialect/Perf/perf-ops.mlir
@@ -23,6 +23,15 @@ func.func @perf_mean(%arg0: memref<?xf64>) -> f64 {
 
 // -----
 
+// CHECK-LABEL: @perf_median
+func.func @perf_median(%arg0: memref<?xf64>) -> f64 {
+  // CHECK: perf.median
+  %median = perf.median(%arg0 : memref<?xf64>) : f64
+  return %median : f64
+}
+
+// -----
+
 // CHECK-LABEL: @perf_stdev
 func.func @perf_stdev(%arg0: memref<?xf64>, %mean: f64) -> f64 {
   // CHECK: perf.stdev

--- a/test/Dialect/Perf/perf-ops.mlir
+++ b/test/Dialect/Perf/perf-ops.mlir
@@ -115,7 +115,7 @@ func.func @perf_yield_result(%a: i32, %b: i32, %n: i64) -> i32 {
   %bench_res = arith.constant 0 : i32
 
   // CHECK: %[[out:.*]] = perf.bench
-  %out = perf.bench (%n, %deltas : memref<?xf64>) args(%bench_res : i32) {
+  %out = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%bench_res : i32) {
     // CHECK: %[[c:.*]] = arith.addi
     %c = arith.addi %a, %b : i32
     // CHECK: perf.yield %[[c]]
@@ -138,7 +138,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   %output = arith.constant 0 : i64
 
   // CHECK: %[[res:.*]] = perf.bench
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     // CHECK: %[[mulres:.*]] = linalg.matmul
     // CHECK: perf.sink(%[[mulres]])
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)

--- a/test/Integration/perf-average.mlir
+++ b/test/Integration/perf-average.mlir
@@ -1,0 +1,64 @@
+// RUN: tpp-run %s -e entry -entry-point-result=void -seed 123 -splat-to-random -init-type=random | \
+// RUN: FileCheck %s
+
+memref.global "private" constant @__data_random : memref<32xf64> = dense<1.000000e+00>
+memref.global "private" constant @__data_odd_sorted : memref<5xf64> = dense<[1.0, 3.0, 5.0, 7.0, 15.0]>
+memref.global "private" constant @__data_odd_unsorted : memref<5xf64> = dense<[5.0, 7.0, 15.0, 1.0, 3.0]>
+memref.global "private" constant @__data_even_sorted : memref<6xf64> = dense<[1.0, 2.0, 3.0, 5.0, 8.0, 9.0]>
+memref.global "private" constant @__data_even_unsorted : memref<6xf64> = dense<[8.0, 5.0, 1.0, 9.0, 3.0, 2.0]>
+
+func.func private @printResult(%result : f64) {
+  %c0 = arith.constant 0 : index
+  %d1 = arith.constant -1.000000e+00 : f64
+  %buf = memref.alloca() : memref<1xf64>
+  memref.store %result, %buf[%c0] : memref<1xf64>
+
+  %v0 = vector.transfer_read %buf[%c0], %d1 : memref<1xf64>, vector<1xf64>
+  vector.print %v0 : vector<1xf64>
+
+  return
+}
+
+func.func private @runTest(%buf : memref<*xf64>) {
+  %mean = perf.mean(%buf : memref<*xf64>) : f64
+  call @printResult(%mean) : (f64) -> ()
+  %median = perf.median(%buf : memref<*xf64>) : f64
+  call @printResult(%median) : (f64) -> ()
+
+  return
+}
+
+func.func @entry(%dummy: memref<1xf32>) {
+  %0 = memref.get_global @__data_random : memref<32xf64>
+  %b0 = memref.cast %0 : memref<32xf64> to memref<*xf64>
+  call @runTest(%b0) : (memref<*xf64>) -> ()
+
+  %1 = memref.get_global @__data_odd_sorted : memref<5xf64>
+  %b1 = memref.cast %1 : memref<5xf64> to memref<*xf64>
+  call @runTest(%b1) : (memref<*xf64>) -> ()
+
+  %2 = memref.get_global @__data_odd_unsorted : memref<5xf64>
+  %b2 = memref.cast %2 : memref<5xf64> to memref<*xf64>
+  call @runTest(%b2) : (memref<*xf64>) -> ()
+
+  %3 = memref.get_global @__data_even_sorted : memref<6xf64>
+  %b3 = memref.cast %3 : memref<6xf64> to memref<*xf64>
+  call @runTest(%b3) : (memref<*xf64>) -> ()
+
+  %4 = memref.get_global @__data_even_unsorted : memref<6xf64>
+  %b4 = memref.cast %4 : memref<6xf64> to memref<*xf64>
+  call @runTest(%b4) : (memref<*xf64>) -> ()
+
+  return
+}
+
+// CHECK: ( 0.481646 )
+// CHECK: ( 0.443908 )
+// CHECK: ( 6.2 )
+// CHECK: ( 5 )
+// CHECK: ( 6.2 )
+// CHECK: ( 5 )
+// CHECK: ( 4.66667 )
+// CHECK: ( 4 )
+// CHECK: ( 4.66667 )
+// CHECK: ( 4 )

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -11,6 +11,7 @@
 // Benchmark options
 // RUN: tpp-run %s -e entry -entry-point-result=void -print 2>&1 | FileCheck %s --check-prefix=BENCH_PRINT
 // RUN: tpp-run %s -e entry -entry-point-result=void -n 10  2>&1 | FileCheck %s --check-prefix=BENCH_STATS
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 10 -timer-median 2>&1 | FileCheck %s --check-prefix=BENCH_STATS
 
 // CPU options can't be tested as even the LLVM IR is identical
 // Splat and init options in tpp-run-splat-* tests

--- a/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
+++ b/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
@@ -31,7 +31,7 @@ func.func @perf_dialect(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
   %output = arith.constant 0 : i64
 
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %sum = arith.addi %n, %n : i64
     perf.yield %sum : i64
   } -> i64

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -248,7 +248,7 @@ Value MLIRBench::createTimerLoop(unsigned n) {
   return acc;
 }
 
-Value MLIRBench::getTimerStats(Value acc) {
+Value MLIRBench::getTimerStats(Value acc, bool computeMedian) {
   auto callMean =
       builder.create<perf::MeanOp>(unkLoc, builder.getF64Type(), acc);
   auto mean = callMean.getMean();

--- a/tools/tpp-run/MLIRBench.h
+++ b/tools/tpp-run/MLIRBench.h
@@ -128,8 +128,9 @@ public:
   /// Returns the memref containing measured time deltas
   Value createTimerLoop(unsigned);
 
-  /// Get the timer average/deviation
-  Value getTimerStats(Value);
+  /// Get the timer mean/deviation - optionally compute median
+  /// instead of the mean
+  Value getTimerStats(Value acc, bool computeMedian = false);
 
   /// Prints a float value (used for mean/dev)
   void printVector(Value);

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -113,15 +113,21 @@ llvm::cl::opt<std::string> initType(
     llvm::cl::init(""));
 
 // Print MLIR before lowering
-llvm::cl::opt<std::string> printMLIR(
-    "print-mlir",
-    llvm::cl::desc("Print MLIR to stdout (early, mid, late, llvm)"),
-    llvm::cl::init(""));
+llvm::cl::opt<std::string>
+    printMLIR("print-mlir",
+              llvm::cl::desc("Print MLIR to stdout (early, mid, late, llvm)"),
+              llvm::cl::init(""));
 
 // Print LLVM IR before lowering
 llvm::cl::opt<bool> printLLVM("print-llvm",
                               llvm::cl::desc("print LLVM IR before lowering"),
                               llvm::cl::init(false));
+
+// Compute median of the measured results instead of mean
+llvm::cl::opt<bool>
+    timerMedian("timer-median",
+                llvm::cl::desc("Compute median timer value instead of mean"),
+                llvm::cl::init(false));
 
 // Parses MLIR print stage
 MLIRBench::PrintStage parsePrintStage(StringRef stage) {
@@ -185,7 +191,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
     auto acc = bench.createTimerLoop(benchNumLoops);
     if (!acc)
       return bench.emitError("Cannot create timer loop");
-    auto stats = bench.getTimerStats(acc);
+    auto stats = bench.getTimerStats(acc, timerMedian);
     if (!stats)
       return bench.emitError("Cannot get timer stats");
     bench.printVector(stats);


### PR DESCRIPTION
Adds a new Perf dialect op `perf.median`, which allows user to compute median value of the measured time deltas.
The new op provides an alternative to the existing `perf.mean`. Due to more complex implementation logic, the median computation relies on runtime support.

Additionally, `perf.bench` optional arguments `args` are renamed  to `iter_args` to be consistent with `scf.for` naming as the two args are semantically identical.