### PR TITLE
Remove parallel loop fusion

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -208,9 +208,6 @@ private:
   void constructPipeline() override {
     pm.clear();
 
-    // Postprocess loops.
-    pm.addPass(createParallelLoopFusionPass());
-
     // Postprocess buffers.
     pm.addPass(bufferization::createBufferHoistingPass());
     pm.addPass(bufferization::createBufferDeallocationPass());


### PR DESCRIPTION
Parallel fusion used to fuse all the scf parallels into one, however we want barrier syncs between brgemms for functional correctness.