### PR TITLE
Adding CI scripts to be used in CI

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Builds the project (tests, installs, post-install)
+
+SCRIPT_DIR=$(realpath $(dirname $0))
+
+die_syntax() {
+  echo "Syntax: $0 -b BLD_DIR [-c] [-i] [-p] [-B]"
+  echo ""
+  echo "  -c: Optional, runs check-all"
+  echo "  -i: Optional, installs"
+  echo "  -p: Optional, post-install (copy all build stuff to install dir)"
+  echo "  -B: Optional, runs benchmarks"
+  exit 1
+}
+
+# Cmd-line opts
+while getopts "b:cipB" arg; do
+  case ${arg} in
+    b)
+      BLD_DIR=$(realpath ${OPTARG})
+      if [ ! -f ${BLD_DIR}/CMakeCache.txt ]; then
+        echo "'${OPTARG}' not a build directory"
+        die_syntax
+      fi
+      ;;
+    c)
+      CHECK=1
+      ;;
+    i)
+      INSTALL=1
+      ;;
+    p)
+      POST_INSTALL=1
+      ;;
+    B)
+      BENCHMARKS=1
+      ;;
+    ?)
+      echo "Invalid option: ${OPTARG}"
+      die_syntax
+      ;;
+  esac
+done
+
+# Mandatory arguments
+if [ ! "${BLD_DIR}" ]; then
+  die_syntax
+fi
+
+# Build
+if not ninja -C ${BLD_DIR}; then
+  echo "Error building, will stop"
+  exit 1
+fi
+
+# Test
+if [ "${CHECK}" != "" ]; then
+  if not ninja -C ${BLD_DIR} check-all; then
+    echo "Error testing, will stop"
+    exit 1
+  fi
+fi
+
+# Install
+if [ "${INSTALL}" != "" ]; then
+  if not ninja -C ${BLD_DIR} install; then
+    echo "Error installing, will stop"
+    exit 1
+  fi
+fi
+
+# Post Install
+if [ "${POST_INSTALL}" != "" ]; then
+  CMAKE_CACHE_FILE=${BLD_DIR}/CMakeCache.txt
+  INST_DIR=$(grep "CMAKE_INSTALL_PREFIX:PATH=" ${CMAKE_CACHE_FILE} | cut -d"=" -f2)
+  if not cp -rv ${BLD_DIR}/* ${INST_DIR}; then
+    echo "Error on post-install"
+    exit 1
+  fi
+fi
+
+# Benchmarks
+if [ "${BENCHMARKS}" != "" ]; then
+  if not ninja -C ${BLD_DIR} benchmarks; then
+    echo "Error running benchmarks"
+    exit 1
+  fi
+fi

--- a/scripts/ci/cmake.sh
+++ b/scripts/ci/cmake.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Runs CMake on the source / build directories
+
+SCRIPT_DIR=$(realpath $(dirname $0))
+
+die_syntax() {
+  echo "Syntax: $0 -s SRC_DIR -b BLD_DIR -m MLIR_DIR [-i INST_DIR] [-t (Release|Debug|RelWithDebInfo)] [-c (clang|gcc)] [-g (gcc toolchain)] [-l (ld|lld|gold|mold)] [-S] [-n N]"
+  echo ""
+  echo "  -i: Optional install dir, default to system"
+  echo "  -t: Optional build type flag, default to Release"
+  echo "  -c: Optional compiler flag, default to clang"
+  echo "  -g: Optional gcc toolchain flag, may be needed by clang"
+  echo "  -l: Optional linker flag, default to system linker"
+  echo "  -S: Optional sanitizer flag, default to none"
+  echo "  -n: Optional link jobs flag, default same as CPUs"
+  exit 1
+}
+
+# Cmd-line opts
+while getopts "s:b:i:m:t:c:g:l:n:S" arg; do
+  case ${arg} in
+    s)
+      SRC_DIR=$(realpath ${OPTARG})
+      if [ ! -d ${SRC_DIR}/.git ]; then
+        echo "Source '${OPTARG}' not a Git directory"
+        die_syntax
+      fi
+      ;;
+    b)
+      BLD_DIR=$(realpath ${OPTARG})
+      if not mkdir -p ${BLD_DIR}; then
+        echo "Error creating build directory '${OPTARG}'"
+        die_syntax
+      fi
+      ;;
+    i)
+      INST_DIR=$(realpath ${OPTARG})
+      if not mkdir -p ${INST_DIR}; then
+        echo "Error creating install directory '${OPTARG}'"
+        die_syntax
+      fi
+      ;;
+    m)
+      MLIR_DIR=$(realpath ${OPTARG})
+      if [ ! -f ${MLIR_DIR}/MLIRConfig.cmake ]; then
+        echo "MLIR '${OPTARG}' not a CMake directory"
+        die_syntax
+      fi
+      ;;
+    g)
+      GCC_DIR=$(realpath ${OPTARG})
+      GCC_TOOLCHAIN_OPTIONS="-DCMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN=${GCC_DIR} -DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=${GCC_DIR}"
+      ;;
+    c)
+      if [ "${OPTARG}" == "clang" ]; then
+        CC=clang
+        CXX=clang++
+      elif [ "${OPTARG}" == "gcc" ]; then
+        CC=gcc
+        CXX=g++
+      else
+        echo "Compiler "${OPTARG}" not recognized"
+        die_syntax
+      fi
+      ;;
+    t)
+      if [ "${OPTARG}" == "Release" ]; then
+        BUILD_OPTIONS="${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=${OPTARG}"
+      elif [ "${OPTARG}" == "Debug" ]; then
+        BUILD_OPTIONS="${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=${OPTARG}"
+      elif [ "${OPTARG}" == "RelWithDebInfo" ]; then
+        BUILD_OPTIONS="${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=${OPTARG}"
+      else
+        echo "Build type "${OPTARG}" not recognized"
+        die_syntax
+      fi
+      ;;
+    l)
+      if [ "${OPTARG}" == "ld" ]; then
+        LINKER_OPTIONS="${LINKER_OPTIONS} -DLLVM_USE_LINKER=${OPTARG}"
+      elif [ "${OPTARG}" == "lld" ]; then
+        LINKER_OPTIONS="${LINKER_OPTIONS} -DLLVM_USE_LINKER=${OPTARG}"
+      elif [ "${OPTARG}" == "gold" ]; then
+        LINKER_OPTIONS="${LINKER_OPTIONS} -DLLVM_USE_LINKER=${OPTARG}"
+      elif [ "${OPTARG}" == "mold" ]; then
+        LINKER_OPTIONS="${LINKER_OPTIONS} -DLLVM_USE_LINKER=${OPTARG}"
+      else
+        echo "Compiler "${OPTARG}" not recognized"
+        die_syntax
+      fi
+      ;;
+    S)
+      SAN_OPTIONS="-DUSE_SANITIZER=\"Address;Memory;Leak;Undefined\""
+      ;;
+    n)
+      PROCS=$(nproc)
+      if [ "${OPTARG}" -gt "0" ] && [ "${OPTARG}" -lt "${PROCS}" ]; then
+        LINKER_OPTIONS="${LINKER_OPTIONS} -DCMAKE_JOB_POOLS=link=${OPTARG}"
+      else
+        echo "Invalid value for number of linker jobs '${OPTARG}'"
+        die_syntax
+      fi
+      ;;
+    ?)
+      echo "Invalid option: ${OPTARG}"
+      die_syntax
+      ;;
+  esac
+done
+
+# Mandatory arguments
+if [ ! "${BLD_DIR}" ] || [ ! "${SRC_DIR}" ] || [ ! "${MLIR_DIR}" ]; then
+  die_syntax
+fi
+
+if [ ! "${CC}" ] || [ ! "${CXX}" ]; then
+  CC=clang
+  CXX=clang++
+fi
+
+# Check deps
+$SCRIPT_DIR/deps.sh
+
+TPP_LIT=$(which lit)
+
+# CMake
+cmake -Wno-dev -G Ninja \
+    -B${BLD_DIR} -S${SRC_DIR} \
+    -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} \
+    -DCMAKE_INSTALL_PREFIX=${INST_DIR} \
+    -DMLIR_DIR=${MLIR_DIR} \
+    -DLLVM_EXTERNAL_LIT=${TPP_LIT} \
+    ${BUILD_OPTIONS} \
+    ${GCC_TOOLCHAIN_OPTIONS} \
+    ${LINKER_OPTIONS} \
+    ${SAN_OPTIONS}

--- a/scripts/ci/deps.sh
+++ b/scripts/ci/deps.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Check and install all dependencies
+
+# Program deps
+check_program() {
+  PROG=$1
+  if not which $PROG > /dev/null; then
+    echo "Required program '$PROG' not found"
+    exit 1
+  fi
+}
+check_program pip
+check_program cmake
+check_program ninja
+
+# Python deps
+pip install --upgrade --user lit
+check_program lit
+
+echo "All dependencies satisfied"


### PR DESCRIPTION
These scripts reproduce the README recipe as well as the CI recipes and should be used in build YAML files instead of direct scripting on the UI.

There are three separate scripts:
 * deps.sh: Check basic dependencies (lit, ninja, cmake)
 * cmake.sh: runs the CMake command with all the options
 * build.sh: builds and optionally checks, installs, benchmarks

These scripts should be called from a build-manager YAML file (Buildkite, ADO, Jenkins) with the appropriate parameters. Multiple calls to the same script should be harmless and preferred, when separating into different steps (build, check, install, ...).

With these, we can already replace our main builds (`tpp-mlir` and `tpp-benchmarks`), with the YAML contents from our experimental `tpp-scripts` build.

Later on, we'll move the YAML files inside the `tpp-mlir` repository and the build infrastructure will have no more hard-coded logic, meaning we can change it on different branches, but also use different build infrastructure (ex. Buildkite and Github Actions and ADO) at the same time.