### PR TITLE
perf.bench 'args' -> 'iter_args'

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -98,8 +98,8 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
 
 def Perf_BenchOp : Perf_Op<"bench",
     [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
-     RangedTypesMatchWith<"result types match types of args",
-                          "args",
+     RangedTypesMatchWith<"result types match types of iter_args",
+                          "iterArgs",
                           "bodyResults",
                           "$_self">,
      RangedTypesMatchWith<"result types match types of yield",
@@ -143,7 +143,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     An example of a benchmark with an output result:
 
     ```mlir
-    %sum = perf.bench (%n, %deltas : memref<?xf64>) args(%val : i32) {
+    %sum = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%val : i32) {
       %sum_next = arith.addi %val, %cst : i32
       perf.yield %sum_next : i32
     } -> i32
@@ -154,10 +154,10 @@ def Perf_BenchOp : Perf_Op<"bench",
     a benchmarking loop.
     For example, the following input:
     ```mlir
-    %res, ... = perf.bench (%n, %deltas : memref<?xf64>) args(%x, ... : ...) {
+    %res, ... = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%x, ... : ...) {
       ... // body - ops under measurement
 
-      // Yield current iteration values to the next iteration args (%x, ...)
+      // Yield current iteration values to the next iteration iter_args (%x, ...)
       // or to the bench op results (%res, ...) if it is the final iteration.
       perf.yield %x, ...
     } -> type(%res), ...
@@ -175,7 +175,7 @@ def Perf_BenchOp : Perf_Op<"bench",
       // Store measured time delta.
       store %delta, %deltas[%iv]
 
-      // Yield current iteration values to the next iteration args (%x, ...)
+      // Yield current iteration values to the next iteration iter_args (%x, ...)
       // or to the loop results (%res, ...) if it is the final iteration.
       yield %x, ...
     }
@@ -184,13 +184,13 @@ def Perf_BenchOp : Perf_Op<"bench",
 
   let arguments = (ins I64:$numIters,
                        RankedOrUnrankedMemRefOf<[F64]>:$deltas,
-                       Variadic<AnyType>:$args);
+                       Variadic<AnyType>:$iterArgs);
   let results = (outs Variadic<AnyType>:$bodyResults);
   let regions = (region SizedRegion<1>:$region);
 
   let assemblyFormat = [{
     `(` $numIters `,` $deltas `:` type($deltas) `)`
-    (`args` `(` $args^ `:` type($args) `)`)?
+    (`iter_args` `(` $iterArgs^ `:` type($iterArgs) `)`)?
     $region attr-dict
     (`->` type($bodyResults)^)?
   }];
@@ -198,7 +198,7 @@ def Perf_BenchOp : Perf_Op<"bench",
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "Value":$numIters, "Value":$deltas,
-      CArg<"ValueRange", "std::nullopt">:$args)>
+      CArg<"ValueRange", "std::nullopt">:$iterArgs)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/TPP/ConvertPerfToLoops.cpp
+++ b/lib/TPP/ConvertPerfToLoops.cpp
@@ -40,8 +40,8 @@ struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
     auto zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     auto one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     auto loop = rewriter.create<scf::ForOp>(loc, zero, numIters, one,
-                                            benchOp.getArgs());
-    if (benchOp.getArgs().empty()) {
+                                            benchOp.getIterArgs());
+    if (benchOp.getIterArgs().empty()) {
       // Erase the default loop yield, it will be inserted later.
       rewriter.eraseOp(loop.getRegion().front().getTerminator());
     }
@@ -71,10 +71,10 @@ struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
 
     // Replace uses of bench args within the benchmark body with their
     // equivalent loop-carried variables.
-    assert((benchOp.getArgs().size() == loop.getRegionIterArgs().size()) &&
+    assert((benchOp.getIterArgs().size() == loop.getRegionIterArgs().size()) &&
            "expect equal number of loop-carried variables");
     for (auto [benchArg, loopArg] :
-         llvm::zip_equal(benchOp.getArgs(), loop.getRegionIterArgs()))
+         llvm::zip_equal(benchOp.getIterArgs(), loop.getRegionIterArgs()))
       replaceAllUsesInRegionWith(benchArg, loopArg, loop.getRegion());
 
     // Pass perf.yield values through the scf.yield.

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -46,12 +46,12 @@ LogicalResult StopTimerOp::verify() {
 //===----------------------------------------------------------------------===//
 
 void BenchOp::build(OpBuilder &builder, OperationState &result, Value numIters,
-                    Value deltas, ValueRange args) {
+                    Value deltas, ValueRange iterArgs) {
   result.addOperands({numIters, deltas});
-  result.addOperands(args);
+  result.addOperands(iterArgs);
 
   // Results have to match the input arguments
-  for (Value v : args)
+  for (Value v : iterArgs)
     result.addTypes(v.getType());
 
   Region *bodyRegion = result.addRegion();
@@ -61,7 +61,7 @@ void BenchOp::build(OpBuilder &builder, OperationState &result, Value numIters,
   // Create the default terminator if the arguments are not provided.
   // Otherwise, leave this to the caller because we don't know which values to
   // return from the body.
-  if (args.empty()) {
+  if (iterArgs.empty()) {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(&bodyBlock);
     builder.create<perf::YieldOp>(result.location);

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -150,7 +150,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>

--- a/test/Conversion/PerfToLoops/perf-to-loops.mlir
+++ b/test/Conversion/PerfToLoops/perf-to-loops.mlir
@@ -102,7 +102,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>
@@ -144,7 +144,7 @@ func.func @perf_example_multi_arg(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]], %[[mulres]]
   // CHECK: }
-  %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) args(%output, %output1 : i64, tensor<4x4xf32>) {
+  %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output, %output1 : i64, tensor<4x4xf32>) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     %sum = arith.addi %output, %k : i64

--- a/test/Dialect/Perf/perf-invalid.mlir
+++ b/test/Dialect/Perf/perf-invalid.mlir
@@ -5,7 +5,7 @@ func.func @perf_no_outs(%n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
   %val = perf.bench (%n, %deltas : memref<?xf64>) {
     perf.sink(%n) : i64
   } -> i64
@@ -21,8 +21,8 @@ func.func @perf_invalid_outs_types(%a: i32, %b: i32, %n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
   } -> i32
@@ -39,8 +39,8 @@ func.func @perf_invalid_outs_order(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
   %out1 = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of args}}
-  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) args(%out1, %out : i64, i32) {
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
+  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out1, %out : i64, i32) {
     %c = arith.addi %a, %b : i32
     perf.yield %c, %n : i32, i64
   } -> i32, i64
@@ -57,7 +57,7 @@ func.func @perf_no_yield(%n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
     perf.sink(%n) : i64
   } -> i64
 
@@ -73,7 +73,7 @@ func.func @perf_invalid_yield_op(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
 
   // expected-error @below {{perf.bench' op expects region to terminate with 'perf.yield'}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i32) {
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i32) {
     %c = arith.addi %a, %b : i32
     // expected-note @below {{terminator here}}
     scf.yield %c : i32
@@ -91,7 +91,7 @@ func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) args(%out : i64) {
+  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
   } -> i64
@@ -109,7 +109,7 @@ func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
   %out1 = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) args(%out, %out1 : i32, i64) {
+  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out, %out1 : i32, i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %n, %c : i64, i32
   } -> i32, i64

--- a/test/Dialect/Perf/perf-ops.mlir
+++ b/test/Dialect/Perf/perf-ops.mlir
@@ -115,7 +115,7 @@ func.func @perf_yield_result(%a: i32, %b: i32, %n: i64) -> i32 {
   %bench_res = arith.constant 0 : i32
 
   // CHECK: %[[out:.*]] = perf.bench
-  %out = perf.bench (%n, %deltas : memref<?xf64>) args(%bench_res : i32) {
+  %out = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%bench_res : i32) {
     // CHECK: %[[c:.*]] = arith.addi
     %c = arith.addi %a, %b : i32
     // CHECK: perf.yield %[[c]]
@@ -138,7 +138,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   %output = arith.constant 0 : i64
 
   // CHECK: %[[res:.*]] = perf.bench
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     // CHECK: %[[mulres:.*]] = linalg.matmul
     // CHECK: perf.sink(%[[mulres]])
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)

--- a/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
+++ b/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
@@ -31,7 +31,7 @@ func.func @perf_dialect(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
   %output = arith.constant 0 : i64
 
-  %res = perf.bench (%n, %deltas : memref<?xf64>) args(%output : i64) {
+  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %sum = arith.addi %n, %n : i64
     perf.yield %sum : i64
   } -> i64


### PR DESCRIPTION
Rename `perf.bench` optional arguments `args` to `iter_args` to be consistent with `scf.for` naming as they are semantically identical.