### PR TITLE
`perf.bench` measurement tagging

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -180,6 +180,36 @@ def Perf_BenchOp : Perf_Op<"bench",
       yield %x, ...
     }
     ```
+
+    If there are any operation present within the `perf.bench` region with
+    the tag `perf_bench_tag`, the timers get inserted before the first and
+    after the last tagged operation. All other ops present in the region e.g.,
+    value initialization, ops inserted by other passes etc., are ignored
+    whenever possible. However, untagged ops are not moved, even when they
+    are located between two tagged ops, to avoid influencing operation ordering
+    and/or data dependencies.
+    An example of the tag usage:
+    ```mlir
+    perf.bench (%n, %deltas : memref<?xf64>) {
+      op1
+      op2 attr = {perf_bench_tag}
+      op3
+      op4 attr = {perf_bench_tag}
+      op5
+    }
+    ```
+    is materialized as:
+    ```mlir
+    loop %iv from 0 to %n step 1 {
+      op1
+      start_timer
+      op2 attr = {perf_bench_tag}
+      op3
+      op4 attr = {perf_bench_tag}
+      %delta = stop_timer
+      op5
+    }
+    ```
   }];
 
   let arguments = (ins I64:$numIters,
@@ -203,6 +233,13 @@ def Perf_BenchOp : Perf_Op<"bench",
 
   let extraClassDeclaration = [{
     YieldOp getYieldOp();
+
+    static void tagOp(Operation* op) {
+      op->setAttr(getTagAttrStrName(),
+                  UnitAttr::get(op->getContext()));
+    }
+
+    static StringRef getTagAttrStrName() { return "perf_bench_tag"; }
   }];
 
   let hasVerifier = 1;

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -110,6 +110,7 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertForAllToParallelOpPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createHeapToStackPass(unsigned maxAllocSizeInBytes = 4096);
+std::unique_ptr<OperationPass<func::FuncOp>> createPerfTagCallsPass();
 
 void registerTestStructuralMatchers();
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -370,4 +370,13 @@ def HeapToStack : Pass<"heap-to-stack", "func::FuncOp"> {
   let constructor = "mlir::tpp::createHeapToStackPass()";
 }
 
+def PerfTagCalls : Pass<"perf-tag-calls", "func::FuncOp"> {
+  let summary = "Perf tag all function calls within perf.bench.";
+  let description = [{
+    Mark all function calls found within perf.bench region
+    with the perf.bench measurement tag.
+  }];
+  let constructor = "mlir::tpp::createPerfTagCallsPass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_library(MLIRTPP
     ConvertForAllToParallelOp.cpp
     CombineTpp.cpp
     HeapToStack.cpp
+    PerfTagCalls.cpp
 
   # Utils
     TensorInit.cpp

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -46,6 +46,11 @@ llvm::cl::opt<bool>
                    llvm::cl::init(false));
 
 llvm::cl::opt<bool>
+    defPerfTagCalls("def-perf-tag-calls",
+                    llvm::cl::desc("Default pipeline - perf tag func calls"),
+                    llvm::cl::init(true));
+
+llvm::cl::opt<bool>
     disableDefPipe("disable-def-pipe",
                    llvm::cl::desc("Disable default pipeline execution"),
                    llvm::cl::init(false));
@@ -159,6 +164,8 @@ private:
     pm.clear();
 
     pm.addNestedPass<func::FuncOp>(createConvertCheckToLoopsPass());
+    if (defPerfTagCalls)
+      pm.addNestedPass<func::FuncOp>(createPerfTagCallsPass());
     pm.addNestedPass<func::FuncOp>(createConvertPerfToLoopsPass());
 
     // Note that LICM should be performed before any function calls are

--- a/lib/TPP/PerfTagCalls.cpp
+++ b/lib/TPP/PerfTagCalls.cpp
@@ -1,0 +1,42 @@
+//===- PerfTagCalls.cpp ------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/PerfOps.h"
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+struct PerfTagCalls : public PerfTagCallsBase<PerfTagCalls> {
+  void tagCallOps(perf::BenchOp benchOp) {
+    for (auto &op : benchOp.getRegion().getOps()) {
+      if (isa<func::CallOp>(op))
+        perf::BenchOp::tagOp(&op);
+    }
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+    IRRewriter rewriter(&getContext());
+    module->walk([&](perf::BenchOp benchOp) { tagCallOps(benchOp); });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createPerfTagCallsPass() {
+  return std::make_unique<PerfTagCalls>();
+}

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -139,17 +139,17 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
   %output = arith.constant 0 : i64
 
-  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
-  // CHECK: %[[res:.*]] = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]]) -> (i64) {
-  // CHECK:   %[[timer:.*]] = func.call @perf_start_timer()
-  // CHECK:   %[[mulres:.*]] = linalg.matmul
-  // CHECK:   %[[sum:.*]] = arith.addi
-  // CHECK:   %[[delta:.*]] = func.call @perf_stop_timer(%[[timer]])
-  // CHECK:   %[[tcast0:.*]] = tensor.cast %[[mulres]]
-  // CHECK:   func.call @perf_sink_tensor_f32(%[[tcast0]])
-  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
-  // CHECK:   scf.yield %[[sum]]
-  // CHECK: }
+  // CHECK:     %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK:     %[[res:.*]] = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]]) -> (i64) {
+  // CHECK:       %[[timer:.*]] = func.call @perf_start_timer()
+  // CHECK:       %[[mulres:.*]] = linalg.matmul
+  // CHECK:       %[[sum:.*]] = arith.addi
+  // CHECK:       %[[delta:.*]] = func.call @perf_stop_timer(%[[timer]])
+  // CHECK:       memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK:       %[[tcast0:.*]] = tensor.cast %[[mulres]]
+  // CHECK-DAG:   func.call @perf_sink_tensor_f32(%[[tcast0]])
+  // CHECK:       scf.yield %[[sum]]
+  // CHECK:     }
   %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>

--- a/test/Conversion/PerfToLoops/perf-to-loops.mlir
+++ b/test/Conversion/PerfToLoops/perf-to-loops.mlir
@@ -1,6 +1,4 @@
 // RUN: tpp-opt %s -convert-perf-to-loops -split-input-file -canonicalize | FileCheck %s
-// XFAIL:* 
-// See: #277
 
 // CHECK-LABEL: @perf_single_op
 func.func @perf_single_op(%arg0: tensor<4x8xf32>,
@@ -11,24 +9,24 @@ func.func @perf_single_op(%arg0: tensor<4x8xf32>,
   %size = arith.index_cast %arg3 : i64 to index
   %deltas = memref.alloc(%size) : memref<?xf64>
 
-  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
-  // CHECK: scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] {
-  // CHECK:   %[[timer:.*]] = perf.start_timer
-  // CHECK:   %[[val:.*]] = linalg.matmul
-  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
-  // CHECK:   perf.sink(%[[val]])
-  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
-  // CHECK: }
+  // CHECK:     %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK:     scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] {
+  // CHECK:       %[[timer:.*]] = perf.start_timer
+  // CHECK:       %[[val:.*]] = linalg.matmul
+  // CHECK:       %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK-DAG:   memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK-DAG:   perf.sink(%[[val]])
+  // CHECK:     }
   perf.bench (%arg3, %deltas : memref<?xf64>) {
     %D = linalg.matmul ins(%arg0, %arg1: tensor<4x8xf32>, tensor<8x4xf32>) outs(%arg2: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>
   }
 
-  // CHECK: %[[mean:.*]] = perf.mean(%[[deltas]] {{.*}})
+  // CHECK: perf.mean(%[[deltas]] {{.*}})
   %mean = perf.mean(%deltas : memref<?xf64>) : f64
 
   memref.dealloc %deltas : memref<?xf64>
-  // CHECK: return %[[mean]]
+
   return %mean : f64
 }
 
@@ -47,16 +45,16 @@ func.func @perf_multi_op(%arg0: tensor<4x8xf32>,
   // CHECK: %[[deltas:.*]] = memref.alloc
   %deltas = memref.alloc() : memref<50xf64>
 
-  // CHECK: scf.for %[[i:.*]] = %[[lb]] to %[[numIter]] step %[[step]] {
-  // CHECK:   %[[timer:.*]] = perf.start_timer
-  // CHECK:   tensor.empty
-  // CHECK:   linalg.fill
-  // CHECK:   linalg.matmul
-  // CHECK:   %[[val:.*]] = linalg.generic
-  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
-  // CHECK:   perf.sink(%[[val]])
-  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
-  // CHECK: }
+  // CHECK:     scf.for %[[i:.*]] = %[[lb]] to %[[numIter]] step %[[step]] {
+  // CHECK:       %[[timer:.*]] = perf.start_timer
+  // CHECK:       tensor.empty
+  // CHECK:       linalg.fill
+  // CHECK:       linalg.matmul
+  // CHECK:       %[[val:.*]] = linalg.generic
+  // CHECK:       %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK-DAG:   memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK-DAG:   perf.sink(%[[val]])
+  // CHECK:     }
   perf.bench (%c50, %deltas : memref<50xf64>) {
     %0 = tensor.empty() : tensor<4x4xf32>
     %1 = linalg.fill ins(%f42 : f32) outs(%0 : tensor<4x4xf32>) -> tensor<4x4xf32>
@@ -70,11 +68,67 @@ func.func @perf_multi_op(%arg0: tensor<4x8xf32>,
     perf.yield
   }
 
-  // CHECK: %[[mean:.*]] = perf.mean(%[[deltas]] {{.*}})
+  // CHECK: perf.mean(%[[deltas]] {{.*}})
   %mean = perf.mean(%deltas : memref<50xf64>) : f64
 
   memref.dealloc %deltas : memref<50xf64>
-  // CHECK: return %[[mean]]
+
+  return %mean : f64
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: @perf_tagged_ops
+func.func @perf_tagged_ops(%arg0: tensor<4x8xf32>,
+          %arg1: tensor<8x4xf32>, %arg2: tensor<4x4xf32>) -> f64 {
+  // CHECK-DAG: %[[numIter:.*]] = arith.constant 50 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  %f42 = arith.constant 42.0 : f32
+  %c50 = arith.constant 50 : i64
+  // CHECK: %[[deltas:.*]] = memref.alloc
+  %deltas = memref.alloc() : memref<50xf64>
+
+  // CHECK:     scf.for %[[i:.*]] = %[[lb]] to %[[numIter]] step %[[step]] {
+  // CHECK:       tensor.empty
+  // CHECK:       linalg.fill
+  // CHECK:       %[[timer:.*]] = perf.start_timer
+  // CHECK:       linalg.matmul
+  // CHECK:       linalg.generic
+  // CHECK:       %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:       memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK:       tensor.empty
+  // CHECK:       %[[val:.*]] = linalg.matmul
+  // CHECK-DAG:   perf.sink(%[[val]])
+  // CHECK:     }
+  perf.bench (%c50, %deltas : memref<50xf64>) {
+    %0 = tensor.empty() : tensor<4x4xf32>
+    %1 = linalg.fill ins(%f42 : f32) outs(%0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+    %D = linalg.matmul {perf_bench_tag} ins(%arg0, %arg1: tensor<4x8xf32>, tensor<8x4xf32>)
+                       outs(%arg2: tensor<4x4xf32>) -> tensor<4x4xf32>
+    %2 = linalg.generic {indexing_maps = [#map, #map],
+                         iterator_types = ["parallel", "parallel"]}
+                         ins(%D : tensor<4x4xf32>)
+                         outs(%1 : tensor<4x4xf32>)
+                         attrs = {perf_bench_tag} {
+      ^bb0(%in : f32, %out: f32):
+          %3 = arith.addf %in, %out : f32
+          linalg.yield %3 : f32
+    } -> tensor<4x4xf32>
+    %3 = tensor.empty() : tensor<4x4xf32>
+    %4 = linalg.matmul ins(%2, %2: tensor<4x4xf32>, tensor<4x4xf32>)
+                       outs(%3: tensor<4x4xf32>) -> tensor<4x4xf32>
+    perf.sink(%4) : tensor<4x4xf32>
+    perf.yield
+  }
+
+  // CHECK: perf.mean(%[[deltas]] {{.*}})
+  %mean = perf.mean(%deltas : memref<50xf64>) : f64
+
+  memref.dealloc %deltas : memref<50xf64>
+
   return %mean : f64
 }
 
@@ -92,16 +146,16 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
   %output = arith.constant 0 : i64
 
-  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
-  // CHECK: %[[res:.*]] = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]]) -> (i64) {
-  // CHECK:   %[[timer:.*]] = perf.start_timer
-  // CHECK:   %[[mulres:.*]] = linalg.matmul
-  // CHECK:   %[[sum:.*]] = arith.addi
-  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
-  // CHECK:   perf.sink(%[[mulres]])
-  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
-  // CHECK:   scf.yield %[[sum]]
-  // CHECK: }
+  // CHECK:     %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK:     %[[res:.*]] = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]]) -> (i64) {
+  // CHECK:       %[[timer:.*]] = perf.start_timer
+  // CHECK:       %[[mulres:.*]] = linalg.matmul
+  // CHECK:       %[[sum:.*]] = arith.addi
+  // CHECK:       %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:       memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK-DAG:   perf.sink(%[[mulres]])
+  // CHECK:       scf.yield %[[sum]]
+  // CHECK:     }
   %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
@@ -135,15 +189,17 @@ func.func @perf_example_multi_arg(%A: tensor<4x8xf32>,
   %output = arith.constant 0 : i64
   %output1 = tensor.empty() : tensor<4x4xf32>
 
-  // CHECK: %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
-  // CHECK: %[[res:.*]]:2 = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]], %[[iarg1:.*]] = %[[output1]]) -> (i64, tensor<4x4xf32>) {
-  // CHECK:   %[[timer:.*]] = perf.start_timer
-  // CHECK:   %[[mulres:.*]] = linalg.matmul
-  // CHECK:   %[[sum:.*]] = arith.addi %[[iarg0]], %[[k]]
-  // CHECK:   %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
-  // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
-  // CHECK:   scf.yield %[[sum]], %[[mulres]]
-  // CHECK: }
+  // CHECK:     %[[ub:.*]] = arith.index_cast %arg3 : i64 to index
+  // CHECK:     %[[res:.*]]:2 = scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] iter_args(%[[iarg0:.*]] = %[[output]], %[[iarg1:.*]] = %[[output1]]) -> (i64, tensor<4x4xf32>) {
+  // CHECK:       %[[timer:.*]] = perf.start_timer
+  // CHECK:       %[[mulres:.*]] = linalg.matmul
+  // TODO: Fix the checks
+  // Disabled due to a bug - see: #277
+  // C_HECK:       %[[sum:.*]] = arith.addi %[[iarg0]], %[[k]]
+  // CHECK:       %[[delta:.*]] = perf.stop_timer(%[[timer]] {{.*}})
+  // CHECK:       memref.store %[[delta]], %[[deltas]][%[[i]]]
+  // CHECK-DAG:   scf.yield {{.*}}, %[[mulres]]
+  // CHECK:     }
   %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output, %output1 : i64, tensor<4x4xf32>) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -240,8 +240,14 @@ Value MLIRBench::createTimerLoop(unsigned n) {
   auto loop = builder.create<perf::BenchOp>(unkLoc, count, acc);
   builder.setInsertionPointToStart(loop.getBody());
 
-  // Call the kernel, ignore output
-  callKernel();
+  // Call the kernel
+  auto call = callKernel();
+
+  // Mark the kernel call as the only operation which performance should be
+  // measured. This ensures that any additional ops created by other passes,
+  // such as bufferization's allocations and copies, do not influence time
+  // measurements.
+  perf::BenchOp::tagOp(call);
 
   // Revert insertion point and return the accumulation ID
   builder.setInsertionPointAfter(loop);


### PR DESCRIPTION
Introduces a new tagging mechanism to `perf.bench` to allow more fine-grained control over which ops' performance gets measured.

Because attributes do not survive bufferization, a separate utility pass is introduced that tags all function calls present within any found `perf.bench` regions. This eliminates the issue of including in the performance measurement the post-bufferization overhead - mostly memory (de)allocation and copies.

This utility pass is part of the default pipeline and enabled by default as this is our primary use case. Optionally, it can be disabled through a new `tpp-run`/`tpp-opt` option flag.

See individual commits for more details.

TODO:
- add `perf-tag-calls` tests