### PR TITLE
Move matmul helper in linalgx utils (NFC)

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -37,10 +37,6 @@ bool hasTppMark(linalg::LinalgOp linalgOp);
 // Returns true if the linalg operation is marked with 'target'.
 bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target);
 
-// Returns true if the linalg operation has a MulAdd region.
-bool hasMulAddBody(linalg::LinalgOp linalgOp,
-                   SmallVectorImpl<Value> *capturedOperands = nullptr);
-
 // Returns true if the linalg operation has copy semantics.
 bool hasCopySemantics(linalg::LinalgOp linalgOp);
 

--- a/include/TPP/TransformUtils.h
+++ b/include/TPP/TransformUtils.h
@@ -56,10 +56,10 @@ Value getSliceOperand(OpBuilder &builder, linalg::LinalgOp linalgOp,
 FailureOr<SmallVector<Range>> getLoopsToMaterialize(RewriterBase &rewriter,
                                                     linalg::LinalgOp linalgOp,
                                                     unsigned upTo);
-// Return true if the convolution is blocked.
+// Return true if `op` is a blocked convolution.
 bool isBlockedConvolution(Operation *op);
 
-// Return true if the matmul is blocked.
+// Return true if `op` is a blocked matmul.
 bool isBlockedMatmul(Operation *op);
 
 // Validate a tile configuration for a linalgOp when we can statically do that.
@@ -69,6 +69,14 @@ bool isBlockedMatmul(Operation *op);
 bool validateFullTilesOnDims(TilingInterface tileOp,
                              ArrayRef<OpFoldResult> tiles,
                              ArrayRef<size_t> dims = {});
+
+// Return true if `op` is a linalg.matmul
+bool isMatmulOp(Operation *op,
+                SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg operation has a MulAdd region.
+bool hasMulAddBody(linalg::LinalgOp linalgOp,
+                   SmallVectorImpl<Value> *capturedOperands = nullptr);
 
 } // namespace utils
 } // namespace linalgx

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "TPP/Dialect/Tpp/TppUtils.h"
-
 #include "TPP/Dialect/Tpp/TppTraits.h"
 #include "TPP/IR/StructuredOpMatcher.h"
+#include "TPP/TransformUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -24,114 +24,6 @@
 namespace mlir {
 namespace tpp {
 namespace utils {
-
-// taken from LinalgInterfaces.cpp
-// Returns true if the use-def chain from `v` to `from` consists of 0 or more
-// unary single-operand operations.
-// TODO: relax to multi-operands with constants, which are technically unary ops
-// as needed (e.g. add5).
-static bool isChainOfUnaryOpsFrom(Value v, Value from) {
-  while (true) {
-    if (v == from)
-      return true;
-    Operation *op = v.getDefiningOp();
-    if (!op || op->getNumOperands() != 1)
-      return false;
-    v = op->getOperand(0);
-  };
-}
-
-// taken from LinalgInterfaces.cpp
-// Returns the unique instance of OpType in `block` if it is indeed unique.
-// Returns null if none or more than 1 instances exist.
-template <typename OpType> static OpType getSingleOpOfType(Block &block) {
-  OpType res = nullptr;
-  block.walk([&](OpType op) {
-    if (res) {
-      res = nullptr;
-      return WalkResult::interrupt();
-    }
-    res = op;
-    return WalkResult::advance();
-  });
-  return res;
-}
-
-// Taken from: LinalgInterfaces.cpp
-// Detect whether res is any permutation of `u5(u1(c) + u2(u3(a) * u4(b)))`
-// on the field (AddOpType, MulOpType), where u1, u2, u3, u4 and u5 represent
-// unary operations that may change the type.
-template <typename AddOpType, typename MulOpType>
-static bool isAddMul(linalg::LinalgOp linalgOp,
-                     SmallVectorImpl<Value> *capturedOperands) {
-  Block &block = linalgOp->getRegion(0).front();
-  if (block.getNumArguments() != 3)
-    return false;
-  Operation *yieldOp = block.getTerminator();
-  if (yieldOp->getNumOperands() != 1)
-    return false;
-
-  AddOpType addOp = getSingleOpOfType<AddOpType>(block);
-  MulOpType mulOp = getSingleOpOfType<MulOpType>(block);
-  if (!addOp || !mulOp)
-    return false;
-
-  BlockArgument argA = block.getArgument(0), argB = block.getArgument(1);
-  Value a = mulOp->getOperand(0), b = mulOp->getOperand(1);
-  Value mul = mulOp->getResult(0);
-  BlockArgument argC = block.getArgument(2);
-  Value c1 = addOp->getOperand(0), c2 = addOp->getOperand(1);
-  Value add = addOp->getResult(0);
-  Value res = yieldOp->getOperand(0);
-  // Result traces back to add.
-  auto un = isChainOfUnaryOpsFrom;
-  bool success = un(res, add);
-  // One of the operands of add traces back to argC, the other to the mul.
-  success |= (un(c1, argC) && un(c2, mul)) || ((un(c1, mul)) && un(c2, argC));
-  // One of the operands of mul traces back to argA, the other to argB.
-  success |= (un(a, argA) && un(b, argB)) || ((un(a, argB)) && un(b, argA));
-  if (capturedOperands) {
-    capturedOperands->push_back(linalgOp.getMatchingOpOperand(argA)->get());
-    capturedOperands->push_back(linalgOp.getMatchingOpOperand(argB)->get());
-    capturedOperands->push_back(linalgOp.getMatchingOpOperand(argC)->get());
-  }
-  return success;
-}
-
-bool hasMulAddBody(linalg::LinalgOp linalgOp,
-                   SmallVectorImpl<Value> *capturedOperands) {
-  if (linalgOp->getNumRegions() != 1)
-    return false;
-  Region &region = linalgOp->getRegion(0);
-  if (!region.hasOneBlock())
-    return false;
-  if (std::distance(region.front().begin(), region.front().end()) != 3)
-    return false;
-  bool isFloat =
-      isAddMul<arith::AddFOp, arith::MulFOp>(linalgOp, capturedOperands);
-  bool isInt =
-      isAddMul<arith::AddIOp, arith::MulIOp>(linalgOp, capturedOperands);
-  return (isFloat || isInt);
-}
-
-namespace {
-// Helper matcher functor for matmul detection.
-struct WithMulAddBody {
-  WithMulAddBody() = delete;
-  WithMulAddBody(SmallVectorImpl<Value> *captures) : captures(captures){};
-
-  bool operator()(Region *region, Operation *op) {
-    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-    if (!linalgOp)
-      return false;
-
-    return hasMulAddBody(linalgOp, captures);
-  }
-
-private:
-  SmallVectorImpl<Value> *captures;
-};
-} // namespace
 
 bool hasStaticShape(linalg::LinalgOp linalgOp) {
   return !linalgOp.hasDynamicShape();
@@ -281,32 +173,9 @@ static bool isTppUnaryOp(linalg::GenericOp linalgOp) {
 
 // Returns true if the linalg.generic maps to a tpp.gemm.
 bool isTppMatmul(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
-  if (isa_and_nonnull<linalg::MatmulOp>(linalgOp))
-    return true;
-  if (!isa_and_nonnull<linalg::GenericOp>(linalgOp))
+  if (linalgOp.hasTensorSemantics())
     return false;
-
-  using namespace tpp::structured_match;
-  using MapList = ArrayRef<ArrayRef<AffineExpr>>;
-  auto infer = [](MapList m) { return AffineMap::inferFromExprList(m); };
-  AffineExpr i, j, k;
-  bindDims(linalgOp.getContext(), i, j, k);
-  auto mapList = infer({{i, k}, {k, j}, {i, j}});
-  auto matmulMatcher =
-      StructuredOpMatcher::make<linalg::GenericOp>()
-          .operation(NumDpsInits(EqualsTo(1)))
-          .operation(NumDpsInputs(EqualsTo(2)))
-          .operation(NumRegions(EqualsTo(1)))
-          .dim(MatchAll(), {mlir::utils::IteratorType::reduction,
-                            mlir::utils::IteratorType::parallel,
-                            mlir::utils::IteratorType::parallel})
-          .input(MatchOne(0), HasMap(EqualsTo(mapList[0])))
-          .input(MatchOne(1), HasMap(EqualsTo(mapList[1])))
-          .output(MatchOne(0), HasMap(EqualsTo(mapList[2])))
-          .region(MatchOne(0), WithMulAddBody(operands));
-  // TODO: we don't check buffer semantics. We never did and this tpp method
-  // leaks in other files. Will come back with a fix.
-  return matmulMatcher.match(linalgOp);
+  return linalgx::utils::isMatmulOp(linalgOp, operands);
 }
 
 // Return true if the linalg.generic can be mapped to a tpp.add.

--- a/lib/TPP/RewriteConvToMatmulImpl.cpp
+++ b/lib/TPP/RewriteConvToMatmulImpl.cpp
@@ -209,7 +209,7 @@ getSlicedConvOperands(OpBuilder &builder, ValueRange localIvs,
 // Check if the three innermost loop can be mapped to a matmul operation. Check
 // also the body and make sure it is a matmul-like.
 static bool checkMappingToMatmul(linalg::LinalgOp linalgOp) {
-  if (!tpp::utils::hasMulAddBody(linalgOp))
+  if (!linalgx::utils::hasMulAddBody(linalgOp))
     return false;
   SmallVector<utils::IteratorType> iteratorTypes =
       linalgOp.getIteratorTypesArray();

--- a/lib/TPP/RewriteToBatchReduceGemm.cpp
+++ b/lib/TPP/RewriteToBatchReduceGemm.cpp
@@ -162,7 +162,7 @@ static LogicalResult checkAccessPatterns(linalg::LinalgOp linalgOp) {
 
 // single region block with add, mul and linalg::yield.
 static LogicalResult checkBody(linalg::LinalgOp linalgOp) {
-  if (!tpp::utils::hasMulAddBody(linalgOp))
+  if (!linalgx::utils::hasMulAddBody(linalgOp))
     return failure();
   LLVM_DEBUG(llvm::dbgs() << __func__ << " OK\n");
   return success();

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "TPP/Dialect/Tpp/TppUtils.h"
 #include "TPP/Passes.h"
 #include "TPP/TransformUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -152,7 +151,7 @@ struct ConvertToForAll : public OpRewritePattern<scf::ForOp> {
 };
 
 static bool isMatmulLike(Operation *op) {
-  return linalgx::utils::isBlockedMatmul(op) || tpp::utils::isTppMatmul(op);
+  return linalgx::utils::isBlockedMatmul(op) || linalgx::utils::isMatmulOp(op);
 }
 
 static bool isConvolutionLike(Operation *op) {
@@ -570,7 +569,7 @@ static SmallVector<int64_t> getDefaultTileSizes(linalg::LinalgOp linalgOp) {
   if (linalgx::utils::isBlockedConvolution(linalgOp))
     return {1, 1, 1};
   // Matmuls are tiled and fused along i and j with 32.
-  if (tpp::utils::isTppMatmul(linalgOp))
+  if (linalgx::utils::isMatmulOp(linalgOp))
     return {32, 32};
   // Blocked matmuls are tiled and fused along the two outermost parallel loops
   // to expose a BRGEMM.

--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -397,7 +397,7 @@ bool isVNNIPacked(linalg::GenericOp matmulOp) {
 
 bool isMatmulOp(linalg::GenericOp matmulOp) {
   // TODO check structural and access pattern.
-  return tpp::utils::hasMulAddBody(matmulOp);
+  return linalgx::utils::hasMulAddBody(matmulOp);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp.mlir
@@ -541,3 +541,14 @@ func.func @broadcast_col_identity(%arg0: memref<8x32xf32>, %arg1: memref<8xf32>)
     }
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @matmul_on_tensor(
+func.func @matmul_on_tensor(%arg0: tensor<8x9xf32>,
+                            %arg1: tensor<9x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  // CHECK-NOT: tpp.matmul
+  %0 = linalg.matmul ins(%arg0, %arg1: tensor<8x9xf32>, tensor<9x8xf32>)
+                outs(%arg2: tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %0 : tensor<8x8xf32>
+}


### PR DESCRIPTION
`isTppMatmulOp` was abused in different parts of the code base to check if an operation was semantically equivalent to a linalg.matmul. It was also wrong for TPP as, currently, TPP works on memref only. Move the logic in linalgx utils and tight detection in `isTppMatmulOp`.