### PR TITLE
Custom parser and printer for `MatmulLike` dispatch op

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -260,7 +260,6 @@ def Xsmm_UnaryDispatchOp : Xsmm_Op<"unary.dispatch",[Pure]> {
 // MatmulDispatchOp
 //===----------------------------------------------------------------------===//
 
-// TODO: all the `flags` should be a list.
 class Xsmm_MatmulLikeOp<string mnemonic, list<Trait> traits = []> :
   Xsmm_Op<mnemonic, !listconcat(traits, [Pure])> {
   let description = [{
@@ -276,11 +275,7 @@ class Xsmm_MatmulLikeOp<string mnemonic, list<Trait> traits = []> :
                        TypedArrayAttrBase<Xsmm_GemmFlags, "gemm flags">:$flags, 
                        Xsmm_DataType:$dataType);
   let results = (outs I64:$results);
-
-  let assemblyFormat = [{
-    $inputs `(` `flags` `=` $flags `,` 
-                `data_type` `=` $dataType `)` attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def Xsmm_MatmulDispatchOp : Xsmm_MatmulLikeOp<"matmul.dispatch"> {

--- a/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
@@ -16,3 +16,82 @@
 
 using namespace mlir;
 using namespace mlir::xsmm;
+
+template <typename EnumClass>
+static ParseResult parseEnum(EnumClass &value, OpAsmParser &parser) {
+  StringRef flag;
+  auto loc = parser.getCurrentLocation();
+  if (parser.parseKeyword(&flag))
+    return failure();
+  auto flagAttr = symbolizeEnum<EnumClass>(flag);
+  if (!flagAttr)
+    return parser.emitError(loc, "invalid enum") << flag;
+  value = *flagAttr;
+  return success();
+}
+
+static ParseResult parserImpl(OpAsmParser &parser, OperationState &result) {
+  auto &builder = parser.getBuilder();
+  // Parse the input
+  result.addAttribute("inputs", DenseI64ArrayAttr::parse(parser, Type{}));
+
+  if (parser.parseKeyword("flags") || parser.parseEqual() ||
+      parser.parseLParen())
+    return failure();
+
+  // Parse flags
+  SmallVector<Attribute, 4> flags;
+  auto parseFlags = [&]() -> ParseResult {
+    GemmFlags flag;
+    if (parseEnum(flag, parser))
+      return failure();
+    flags.push_back(builder.getI64IntegerAttr(static_cast<int64_t>(flag)));
+    return success();
+  };
+  if (parser.parseCommaSeparatedList(parseFlags) || parser.parseRParen())
+    return failure();
+  result.addAttribute("flags", builder.getArrayAttr(flags));
+
+  // Parse dataType
+  if (parser.parseKeyword("data_type") || parser.parseEqual())
+    return failure();
+  DataType dataType;
+  if (parseEnum(dataType, parser))
+    return failure();
+  result.addAttribute(
+      "dataType", builder.getI64IntegerAttr(static_cast<int64_t>(dataType)));
+  result.addTypes(builder.getIntegerType(64));
+  return success();
+}
+
+ParseResult MatmulDispatchOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
+  return parserImpl(parser, result);
+}
+
+ParseResult BrgemmDispatchOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
+  return parserImpl(parser, result);
+}
+
+template <typename OpTy>
+static void printerImpl(OpAsmPrinter &printer, OpTy op) {
+  printer << " [" << op.getInputs() << ']';
+  printer << " "
+          << " flags = (";
+  llvm::interleaveComma(op.getFlags(), printer, [&](auto &attr) {
+    auto flag = *symbolizeGemmFlags(attr.template cast<IntegerAttr>().getInt());
+    printer << xsmm::stringifyGemmFlags(flag);
+  });
+  printer << ") data_type = ";
+  auto dataType = op.getDataType();
+  printer << xsmm::stringifyDataType(dataType);
+}
+
+void MatmulDispatchOp::print(OpAsmPrinter &printer) {
+  printerImpl<MatmulDispatchOp>(printer, *this);
+}
+
+void BrgemmDispatchOp::print(OpAsmPrinter &printer) {
+  printerImpl<BrgemmDispatchOp>(printer, *this);
+}

--- a/test/BF16/Integration/xsmm-ternary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-ternary-bf16.mlir
@@ -5,7 +5,7 @@
 func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
                               %arg2: memref<4x4xbf16>) {
   %c64_i64 = arith.constant 64 : i64
-  %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4](flags = [4096], data_type = bf16)
+  %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4] flags = (vnni_b) data_type = bf16
   xsmm.brgemm(dataType bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
     : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
 

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
@@ -6,7 +6,7 @@
 func.func @brgemm_to_xsmm(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
                           %arg2: memref<5x5xf32>) -> memref<5x5xf32> {
   // CHECK: %[[BATCH:.+]] = arith.constant 3 : i64
-  // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5](flags = [0], data_type = f32)
+  // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.brgemm(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[BATCH]])
   tpp.brgemm ins(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>, %arg2: memref<5x5xf32>)
              outs(%arg2: memref<5x5xf32>)

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-gemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-gemm.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @matmul_to_xsmm(
 // CHECK-SAME: %[[ARG0:.*]]: memref<3x3xf32>, %[[ARG1:.*]]: memref<3x3xf32>, %[[ARG2:.*]]: memref<3x3xf32>)
 func.func @matmul_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) {
-  // CHECK: %[[DISPATCH:.*]] = xsmm.matmul.dispatch [3, 3, 3, 3, 3, 3](flags = [0], data_type = f32)
+  // CHECK: %[[DISPATCH:.*]] = xsmm.matmul.dispatch [3, 3, 3, 3, 3, 3] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.matmul(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]]) 
   tpp.matmul ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) 
              outs(%arg2: memref<3x3xf32>)

--- a/test/Conversion/XsmmToFunc/xsmm-to-func-using-meta.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func-using-meta.mlir
@@ -4,7 +4,7 @@
 // CHECK-DAG: func.func private @xsmm_brgemm_invoke(i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index, i64)
 func.func @dispatch_brgemm(%arg0: memref<2x5x4xf32>, %arg1: memref<2x4x5xf32>,
                            %arg2: memref<4x4xf32>) -> memref<4x4xf32> {
-  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] (flags = [0], data_type = f32)
+  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
   %c2_i64 = arith.constant 2 : i64
   xsmm.brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x5x4xf32>, memref<2x4x5xf32>, memref<4x4xf32>, i64) -> ()

--- a/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
@@ -16,7 +16,7 @@ func.func @dispatch_unary() -> i64 {
 
 // CHECK-LABEL: dispatch_brgemm
 func.func @dispatch_brgemm() -> i64 {
-  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] (flags = [0], data_type = f32)
+  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -30,7 +30,7 @@ func.func @dispatch_brgemm() -> i64 {
 
 // CHECK-LABEL: dispatch_gemm
 func.func @dispatch_gemm(%arg0: memref<3x3xf32>) -> i64 {
-  %0 = xsmm.matmul.dispatch [1, 2, 3, 4, 5, 6] (flags = [0], data_type = f32)
+  %0 = xsmm.matmul.dispatch [1, 2, 3, 4, 5, 6] flags = (none) data_type = f32
   return %0 : i64
 }
 

--- a/test/Dialect/Xsmm/xsmm-ops.mlir
+++ b/test/Dialect/Xsmm/xsmm-ops.mlir
@@ -23,7 +23,7 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
     : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
 
   // CHECK: xsmm.matmul.dispatch
-  xsmm.matmul.dispatch [3, 2, 1] (flags = [0, 4096], data_type = f32)
+  xsmm.matmul.dispatch [3, 2, 1] flags = (none, vnni_b) data_type = f32
 
   return %arg2: memref<2x2xf32>
 }

--- a/test/Dialect/Xsmm/xsmm-ops.mlir
+++ b/test/Dialect/Xsmm/xsmm-ops.mlir
@@ -25,5 +25,8 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
   // CHECK: xsmm.matmul.dispatch
   xsmm.matmul.dispatch [3, 2, 1] flags = (none, vnni_b) data_type = f32
 
+  // CHECK: xsmm.matmul.dispatch {{.*}} {myAttr = "myattr"}
+  xsmm.matmul.dispatch [3, 2, 1] flags = (none, vnni_b) data_type = f32 {myAttr = "myattr"}
+
   return %arg2: memref<2x2xf32>
 }

--- a/test/Integration/xsmm-ternary.mlir
+++ b/test/Integration/xsmm-ternary.mlir
@@ -4,7 +4,7 @@
 
 func.func @entry(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
   %c2_i64 = arith.constant 2 : i64
-  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3](flags = [0], data_type = f32)
+  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3] flags = (none) data_type = f32
   xsmm.brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 

--- a/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
+++ b/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
@@ -57,7 +57,7 @@ func.func @perf_dialect(%A: tensor<4x8xf32>,
 
 func.func @xsmm_dialect(%arg0: memref<32x256xf32>, %arg1: memref<1x8x32x32xf32>) -> i64 {
   %0 = xsmm.unary.dispatch identity [5, 6, 5, 6](broadcast row dataType f32)
-  %1 = xsmm.matmul.dispatch [3, 3, 3, 3, 3, 3] (flags = [0], data_type = f32)
+  %1 = xsmm.matmul.dispatch [3, 3, 3, 3, 3, 3] flags = (none) data_type = f32
   %2 = arith.addi %0, %1 : i64
   return %2: i64
 }

--- a/test/Passes/DefaultPipeline/xsmm.mlir
+++ b/test/Passes/DefaultPipeline/xsmm.mlir
@@ -152,7 +152,7 @@ func.func @brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: mem
   // CHECK: %[[cast2:.*]] = memref.cast %[[ARG2]]
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   %c2_i64 = arith.constant 2 : i64
-  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3](flags = [0], data_type = f32)
+  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3] flags = (none) data_type = f32
   xsmm.brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 
@@ -173,7 +173,7 @@ func.func @brgemm_bf16(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
   // CHECK: %[[cast2:.*]] = memref.cast %[[ARG2]]
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   %c64_i64 = arith.constant 64 : i64
-  %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4](flags = [4096], data_type = bf16)
+  %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4] flags = (vnni_b) data_type = bf16
   xsmm.brgemm(dataType bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
     : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
 
@@ -193,7 +193,7 @@ func.func @matmul(%A: memref<4x8xf32>,
   // CHECK: %[[cast1:.*]] = memref.cast %[[ARG1]]
   // CHECK: %[[cast2:.*]] = memref.cast %[[ARG2]]
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
-  %0 = xsmm.matmul.dispatch [4, 4, 8, 8, 4, 4](flags = [0], data_type = f32)
+  %0 = xsmm.matmul.dispatch [4, 4, 8, 8, 4, 4] flags = (none) data_type = f32
   xsmm.matmul(dataType f32, %0, %A, %B, %C) : (i64, memref<4x8xf32>, memref<8x4xf32>, memref<4x4xf32>) -> ()
 
   return
@@ -212,7 +212,7 @@ func.func @matmul_bf16(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>,
   // CHECK: %[[cast1:.*]] = memref.cast %[[ARG1]]
   // CHECK: %[[cast2:.*]] = memref.cast %[[ARG2]]
   // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
-  %0 = xsmm.matmul.dispatch [6, 6, 10, 10, 6, 6](flags = [4096], data_type = bf16)
+  %0 = xsmm.matmul.dispatch [6, 6, 10, 10, 6, 6] flags = (vnni_b) data_type = bf16
   xsmm.matmul(dataType bf16, %0, %arg0, %arg1, %arg2) : (i64, memref<6x10xbf16>, memref<5x6x2xbf16>, memref<6x6xbf16>) -> ()
 
   return
@@ -240,7 +240,7 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
     %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : memref<4x16x32x32xf32> to memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>
     %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : memref<8x16x32x32xf32> to memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>
     %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x8x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
-    %0 = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32](flags = [0], data_type = f32)
+    %0 = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32] flags = (none) data_type = f32
     xsmm.brgemm(dataType f32, %0, %subview, %subview_0, %subview_1, %c16_i64) 
       : (i64, memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>, 
          memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>,
@@ -276,7 +276,7 @@ func.func @conv2d_1x1(%arg0: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
   scf.for %arg1 = %c0 to %c7 step %c1 {
     %subview = memref.subview %arg0[0, %arg1, 0, 0] [1, 1, 7, 2048] [1, 1, 1, 1] : memref<1x7x7x2048xf32> to memref<7x2048xf32, strided<[2048, 1], offset: ?>>
     %subview_0 = memref.subview %alloc[0, %arg1, 0, 0] [1, 1, 7, 512] [1, 1, 1, 1] : memref<1x7x7x512xf32> to memref<7x512xf32, strided<[512, 1], offset: ?>>
-    %1 = xsmm.matmul.dispatch [7, 512, 2048, 2048, 512, 512](flags = [0], data_type = f32)
+    %1 = xsmm.matmul.dispatch [7, 512, 2048, 2048, 512, 512] flags = (none) data_type = f32
     xsmm.matmul(dataType f32, %1, %subview, %0, %subview_0) : (i64, memref<7x2048xf32, strided<[2048, 1], offset: ?>>, memref<2048x512xf32>, memref<7x512xf32, strided<[512, 1], offset: ?>>) -> ()
   }
 
@@ -314,7 +314,7 @@ module @predict_function {
     // CHECK: %[[cast1:.*]] = memref.cast %[[ARG0]]
     // CHECK: %[[cast2:.*]] = memref.cast %[[ARG1]]
     // CHECK: call @xsmm_matmul_invoke({{.*}}%[[cast1]], %[[cast2]], %[[cast0]]
-    %1 = xsmm.matmul.dispatch [128, 512, 256, 256, 512, 512](flags = [0], data_type = f32)
+    %1 = xsmm.matmul.dispatch [128, 512, 256, 256, 512, 512] flags = (none) data_type = f32
     xsmm.matmul(dataType f32, %1, %arg0, %arg1, %arg3) : (i64, memref<128x256xf32>, memref<256x512xf32>, memref<128x512xf32>) -> ()
 
     // Relu


### PR DESCRIPTION
Implement a custom parser and printer for `xsmm.matmul.dispatch` and `xsmm.brgemm.dispatch` ops. Currently only for matmul and brgemm but all the dispatch ops will follow. The custom parser and printer is necessary to preserver the pretty printing of the enum, which otherwise would get printed as integer. I did not find a way to get the same result using a custom assembly form.