### PR TITLE
Naive tpp bufferization

### DIFF
--- a/include/TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.h
+++ b/include/TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.h
@@ -1,0 +1,22 @@
+//===- BufferizableOpInterfaceImpl.h - Impl. of BufferizableOpInterface ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_TPP_BUFFERIZABLEOPINTERFACEIMPL_H
+#define MLIR_DIALECT_TPP_BUFFERIZABLEOPINTERFACEIMPL_H
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir {
+namespace tpp {
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry);
+} // namespace tpp
+} // namespace mlir
+
+#endif // MLIR_DIALECT_TPP_BUFFERIZABLEOPINTERFACEIMPL_H

--- a/lib/TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.cpp
@@ -1,0 +1,366 @@
+//===- BufferizableOpInterfaceImpl.cpp - Impl. of BufferizableOpInterface -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Tpp/TppDialect.h"
+#include "TPP/Dialect/Tpp/TppOps.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/IR/Operation.h"
+
+using namespace mlir;
+using namespace mlir::bufferization;
+
+namespace mlir {
+namespace tpp {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Unary
+//===----------------------------------------------------------------------===//
+
+// Helper function to bufferize unary operations.
+template <typename OpTy>
+static LogicalResult bufferizeUnaryOp(Operation *op, RewriterBase &rewriter,
+                                      const BufferizationOptions &options) {
+  auto unaryOp = cast<OpTy>(op);
+  auto loc = unaryOp.getLoc();
+  FailureOr<Value> buffer =
+      getBuffer(rewriter, unaryOp.getInputs()[0], options);
+  if (failed(buffer))
+    return failure();
+  // Out-of-place bufferization.
+  if (unaryOp.getInputs()[0].getType() != op->getResult(0).getType()) {
+    FailureOr<Value> alloc =
+        allocateTensorForShapedValue(rewriter, loc, op->getResult(0),
+                                     /*escape=*/true, options, /*copy=*/false);
+    if (failed(alloc))
+      return failure();
+    FailureOr<Value> allocBuffer = getBuffer(rewriter, *alloc, options);
+    if (failed(allocBuffer))
+      return failure();
+    rewriter.create<OpTy>(loc, *buffer, *allocBuffer);
+    replaceOpWithBufferizedValues(rewriter, op, *allocBuffer);
+    return success();
+  }
+  // In-place bufferization.
+  rewriter.create<OpTy>(loc, *buffer, *buffer);
+  replaceOpWithBufferizedValues(rewriter, op, *buffer);
+  return success();
+}
+
+// Helper function to bufferize unary operation.
+// All the operands bufferize to memory reads.
+static bool bufferizesToMemoryReadUnaryImpl(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) {
+  return true;
+}
+
+// Helper function to bufferize unary operation.
+// The operand bufferize to memory write only if we can bufferize in place.
+static bool bufferizesToMemoryWriteUnaryImpl(Operation *op,
+                                             OpOperand &opOperand,
+                                             const AnalysisState &state) {
+  return opOperand.get().getType() == op->getResult(0).getType();
+}
+
+static AliasingOpResultList
+getAliasingOpResultsUnaryImpl(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) {
+  // The result alias with the opOperand only if we can bufferize in place.
+  if (opOperand.get().getType() == op->getResult(0).getType())
+    return {{op->getOpResult(0), BufferRelation::Equivalent,
+             /*isDefinite=*/true}};
+  return {};
+}
+
+struct ReluBufferizationInterface
+    : public BufferizableOpInterface::ExternalModel<ReluBufferizationInterface,
+                                                    tpp::ReluOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return bufferizesToMemoryReadUnaryImpl(op, opOperand, state);
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return bufferizesToMemoryWriteUnaryImpl(op, opOperand, state);
+  }
+
+  AliasingOpResultList getAliasingOpResults(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) const {
+    return getAliasingOpResultsUnaryImpl(op, opOperand, state);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    return bufferizeUnaryOp<tpp::ReluOp>(op, rewriter, options);
+  }
+};
+
+struct IdentityBufferizationInterface
+    : public BufferizableOpInterface::ExternalModel<
+          IdentityBufferizationInterface, tpp::IdentityOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return bufferizesToMemoryReadUnaryImpl(op, opOperand, state);
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return bufferizesToMemoryWriteUnaryImpl(op, opOperand, state);
+  }
+
+  AliasingOpResultList getAliasingOpResults(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) const {
+    return getAliasingOpResultsUnaryImpl(op, opOperand, state);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    return bufferizeUnaryOp<tpp::IdentityOp>(op, rewriter, options);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Binary
+//===----------------------------------------------------------------------===//
+
+// Helper function to bufferize a binary op.
+template <typename OpTy>
+static LogicalResult bufferizeBinaryOp(Operation *op, RewriterBase &rewriter,
+                                       const BufferizationOptions &options) {
+  auto binaryOp = cast<OpTy>(op);
+  auto loc = binaryOp.getLoc();
+  FailureOr<Value> lhsBuffer =
+      getBuffer(rewriter, binaryOp.getInputs()[0], options);
+  if (failed(lhsBuffer))
+    return failure();
+  FailureOr<Value> rhsBuffer =
+      getBuffer(rewriter, binaryOp.getInputs()[1], options);
+  if (failed(rhsBuffer))
+    return failure();
+  // Out-of-place bufferization.
+  auto outType = binaryOp->getResult(0).getType();
+  auto lhsType = binaryOp.getInputs()[0].getType();
+  auto rhsType = binaryOp.getInputs()[1].getType();
+  if ((outType != lhsType) && (outType != rhsType)) {
+    FailureOr<Value> alloc =
+        allocateTensorForShapedValue(rewriter, loc, binaryOp->getResult(0),
+                                     /*escape=*/true, options, /*copy=*/false);
+    if (failed(alloc))
+      return failure();
+    FailureOr<Value> allocBuffer = getBuffer(rewriter, *alloc, options);
+    if (failed(allocBuffer))
+      return failure();
+    rewriter.create<OpTy>(loc, ValueRange{*lhsBuffer, *rhsBuffer},
+                          *allocBuffer);
+    replaceOpWithBufferizedValues(rewriter, op, *allocBuffer);
+    return success();
+  }
+  // In-place bufferization on rhs.
+  if (outType == rhsType) {
+    rewriter.create<OpTy>(loc, ValueRange{*lhsBuffer, *rhsBuffer}, *rhsBuffer);
+    replaceOpWithBufferizedValues(rewriter, op, *rhsBuffer);
+    return success();
+  }
+  // In-place bufferization on lhs.
+  rewriter.create<OpTy>(loc, ValueRange{*lhsBuffer, *rhsBuffer}, *lhsBuffer);
+  replaceOpWithBufferizedValues(rewriter, op, *lhsBuffer);
+  return success();
+}
+
+// Helper function to bufferize a binary op.
+// Both operands bufferize to memory reads.
+static bool bufferizesToMemoryReadBinaryImpl(Operation *op,
+                                             OpOperand &opOperand,
+                                             const AnalysisState &state) {
+  return true;
+}
+
+static bool bufferizesToMemoryWriteBinaryImpl(Operation *op,
+                                              OpOperand &opOperand,
+                                              const AnalysisState &state) {
+  // If the rhs can bufferize in place with the result return true.
+  if (opOperand.getOperandNumber() == 1 &&
+      opOperand.get().getType() == op->getResult(0).getType())
+    return true;
+  // If the lhs can bufferize in place with the result return true. Note that
+  // if both can bufferize with the result we select the rhs first.
+  if (opOperand.getOperandNumber() == 0) {
+    if (op->getOpOperand(1).get().getType() == op->getResult(0).getType())
+      return false;
+    if (opOperand.get().getType() == op->getResult(0).getType())
+      return true;
+  }
+  return false;
+}
+
+static AliasingOpResultList
+getAliasingOpResultsBinaryImpl(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) {
+  // If the rhs can bufferize in place with the result return the rhs.
+  if (opOperand.getOperandNumber() == 1 &&
+      opOperand.get().getType() == op->getResult(0).getType())
+    return {{op->getOpResult(0), BufferRelation::Equivalent,
+             /*isDefinite=*/true}};
+  // If the lhs can bufferize in place with the result return the lhs. Note
+  // that if both can bufferize with the result we select the rhs first.
+  if (opOperand.getOperandNumber() == 0) {
+    if (op->getOpOperand(1).get().getType() == op->getResult(0).getType())
+      return {};
+    if (opOperand.get().getType() == op->getResult(0).getType())
+      return {{op->getOpResult(0), BufferRelation::Equivalent,
+               /*isDefinite=*/true}};
+  }
+  return {};
+}
+
+struct AddBufferizationInterface
+    : public BufferizableOpInterface::ExternalModel<AddBufferizationInterface,
+                                                    tpp::AddOp> {
+
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return bufferizesToMemoryReadBinaryImpl(op, opOperand, state);
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return bufferizesToMemoryWriteBinaryImpl(op, opOperand, state);
+  }
+
+  AliasingOpResultList getAliasingOpResults(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) const {
+    return getAliasingOpResultsBinaryImpl(op, opOperand, state);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    return bufferizeBinaryOp<tpp::AddOp>(op, rewriter, options);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Ternary
+//===----------------------------------------------------------------------===//
+
+// Helper function to bufferize ternary operations.
+template <typename OpTy>
+static LogicalResult bufferizeTernaryOp(Operation *op, RewriterBase &rewriter,
+                                        const BufferizationOptions &options) {
+  auto ternaryOp = cast<OpTy>(op);
+  FailureOr<Value> bufferA =
+      getBuffer(rewriter, ternaryOp.getInputs()[0], options);
+  if (failed(bufferA))
+    return failure();
+  FailureOr<Value> bufferB =
+      getBuffer(rewriter, ternaryOp.getInputs()[1], options);
+  if (failed(bufferB))
+    return failure();
+  FailureOr<Value> bufferC =
+      getBuffer(rewriter, ternaryOp.getInputs()[2], options);
+  if (failed(bufferC))
+    return failure();
+  rewriter.create<OpTy>(ternaryOp.getLoc(),
+                        ValueRange{*bufferA, *bufferB, *bufferC}, *bufferC);
+  replaceOpWithBufferizedValues(rewriter, op, *bufferC);
+  return success();
+}
+
+// Helper function to bufferize ternay operations.
+// All operands bufferize to memory reads.
+static bool bufferizesToMemoryReadTernaryImpl(Operation *op,
+                                              OpOperand &opOperand,
+                                              const AnalysisState &state) {
+  return true;
+}
+
+// Helper function to bufferize ternay operations.
+// The third operand has write (and read) semantics, thus it bufferize
+// to a memory write.
+static bool bufferizesToMemoryWriteTernaryImpl(Operation *op,
+                                               OpOperand &opOperand,
+                                               const AnalysisState &state) {
+  return opOperand.getOperandNumber() == 2;
+}
+
+// Helper function to bufferize ternay operations.
+// The third operand alias with the result.
+static AliasingOpResultList
+getAliasingOpResultsTernaryImpl(Operation *op, OpOperand &opOperand,
+                                const AnalysisState &state) {
+  if (opOperand.getOperandNumber() == 2)
+    return {{op->getOpResult(0), BufferRelation::Equivalent,
+             /*isDefinite=*/true}};
+  return {};
+}
+
+struct MatmulBufferizationInterface
+    : public BufferizableOpInterface::ExternalModel<
+          MatmulBufferizationInterface, tpp::MatmulOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return bufferizesToMemoryReadTernaryImpl(op, opOperand, state);
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return bufferizesToMemoryWriteTernaryImpl(op, opOperand, state);
+  }
+
+  AliasingOpResultList getAliasingOpResults(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) const {
+    return getAliasingOpResultsTernaryImpl(op, opOperand, state);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    return bufferizeTernaryOp<tpp::MatmulOp>(op, rewriter, options);
+  }
+};
+
+struct BrgemmBufferizationInterface
+    : public BufferizableOpInterface::ExternalModel<
+          BrgemmBufferizationInterface, tpp::BrgemmOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return bufferizesToMemoryReadTernaryImpl(op, opOperand, state);
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return bufferizesToMemoryWriteTernaryImpl(op, opOperand, state);
+  }
+
+  AliasingOpResultList getAliasingOpResults(Operation *op, OpOperand &opOperand,
+                                            const AnalysisState &state) const {
+    return getAliasingOpResultsTernaryImpl(op, opOperand, state);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    return bufferizeTernaryOp<tpp::BrgemmOp>(op, rewriter, options);
+  }
+};
+
+} // namespace
+} // namespace tpp
+} // namespace mlir
+
+namespace mlir {
+namespace tpp {
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, tpp::TppDialect *dialect) {
+    AddOp::attachInterface<tpp::AddBufferizationInterface>(*ctx);
+    IdentityOp::attachInterface<tpp::IdentityBufferizationInterface>(*ctx);
+    ReluOp::attachInterface<tpp::ReluBufferizationInterface>(*ctx);
+    MatmulOp::attachInterface<tpp::MatmulBufferizationInterface>(*ctx);
+    BrgemmOp::attachInterface<tpp::BrgemmBufferizationInterface>(*ctx);
+  });
+}
+} // namespace tpp
+} // namespace mlir

--- a/lib/TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.cpp
@@ -33,9 +33,9 @@ static LogicalResult bufferizeUnaryOp(Operation *op, RewriterBase &rewriter,
   if (failed(buffer))
     return failure();
   // Out-of-place bufferization.
-  if (unaryOp.getInputs()[0].getType() != op->getResult(0).getType()) {
+  if (unaryOp.getInputs()[0].getType() != unaryOp.getResultType()) {
     FailureOr<Value> alloc =
-        allocateTensorForShapedValue(rewriter, loc, op->getResult(0),
+        allocateTensorForShapedValue(rewriter, loc, unaryOp.getResult(0),
                                      /*escape=*/true, options, /*copy=*/false);
     if (failed(alloc))
       return failure();
@@ -144,12 +144,12 @@ static LogicalResult bufferizeBinaryOp(Operation *op, RewriterBase &rewriter,
   if (failed(rhsBuffer))
     return failure();
   // Out-of-place bufferization.
-  auto outType = binaryOp->getResult(0).getType();
+  auto outType = binaryOp.getResultType();
   auto lhsType = binaryOp.getInputs()[0].getType();
   auto rhsType = binaryOp.getInputs()[1].getType();
   if ((outType != lhsType) && (outType != rhsType)) {
     FailureOr<Value> alloc =
-        allocateTensorForShapedValue(rewriter, loc, binaryOp->getResult(0),
+        allocateTensorForShapedValue(rewriter, loc, binaryOp.getResult(0),
                                      /*escape=*/true, options, /*copy=*/false);
     if (failed(alloc))
       return failure();

--- a/lib/TPP/Dialect/Tpp/CMakeLists.txt
+++ b/lib/TPP/Dialect/Tpp/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(TPPTppDialect
     TppAttr.cpp
     TppTraits.cpp
     TppInterface.cpp
+    BufferizableOpInterfaceImpl.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/test/Dialect/Tpp/tpp-bufferization.mlir
+++ b/test/Dialect/Tpp/tpp-bufferization.mlir
@@ -1,0 +1,289 @@
+// RUN: tpp-opt %s -bufferize -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @tpp_tensor_add
+// CHECK-SAME: %[[ARG0:.+]]: memref<32x32xf32>, %[[ARG1:.+]]: memref<32x32xf32>
+func.func @tpp_tensor_add(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %0 = tpp.add (%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: tpp.add ins(%[[ARG0]] : memref<32x32xf32>, %[[ARG1]] : memref<32x32xf32>)
+  // CHECK-SAME:    outs(%[[ARG1]] : memref<32x32xf32>)
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_add_bufferize_on_rhs
+// CHECK-SAME: %[[ARG0:.+]]: memref<32xf32>, %[[ARG1:.+]]: memref<32x32xf32>
+func.func @tpp_tensor_add_bufferize_on_rhs(%arg0: tensor<32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %0 = tpp.add (%arg0: tensor<32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: tpp.add ins(%[[ARG0]] : memref<32xf32>, %[[ARG1]] : memref<32x32xf32>) 
+  // CHECK-SAME:    outs(%[[ARG1]] : memref<32x32xf32>)
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_add_bufferize_on_lhs
+// CHECK-SAME: %[[ARG0:.+]]: memref<32x32xf32>, %[[ARG1:.+]]: memref<32xf32>
+func.func @tpp_tensor_add_bufferize_on_lhs(%arg0: tensor<32x32xf32>, %arg1: tensor<32xf32>) -> tensor<32x32xf32> {
+  %0 = tpp.add (%arg0: tensor<32x32xf32>, %arg1: tensor<32xf32>) -> tensor<32x32xf32>
+  // CHECK: tpp.add ins(%[[ARG0]] : memref<32x32xf32>, %[[ARG1]] : memref<32xf32>) 
+  // CHECK-SAME:    outs(%[[ARG0]] : memref<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_add_bufferize_outs_of_place
+// CHECK-SAME: %[[ARG0:.+]]: memref<1xf32>, %[[ARG1:.+]]: memref<32xf32>
+func.func @tpp_tensor_add_bufferize_outs_of_place(%arg0: tensor<1xf32>, %arg1: tensor<32xf32>) -> tensor<32x32xf32> {
+  %0 = tpp.add (%arg0: tensor<1xf32>, %arg1: tensor<32xf32>) -> tensor<32x32xf32>
+  // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+  // CHECK-NEXT: tpp.add ins(%[[ARG0]] : memref<1xf32>, %[[ARG1]] : memref<32xf32>) 
+  // CHECK-SAME:         outs(%[[ALLOC]] : memref<32x32xf32>)
+  // CHECK-NEXT: return %[[ALLOC]] : memref<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_add_loop
+// CHECK-SAME: %[[ARG0:.+]]: memref<32x32xf32>, %[[ARG1:.+]]: memref<32x32xf32>
+func.func @tpp_tensor_add_loop(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[C0:.+]] = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  // CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
+  %r = scf.for %i = %c0 to %c10 step %c1 iter_args(%iter_arg1 = %arg1) -> tensor<32x32xf32> {
+    %added = tpp.add (%arg0: tensor<32x32xf32>, %iter_arg1: tensor<32x32xf32>) -> tensor<32x32xf32>
+    scf.yield %added : tensor<32x32xf32>
+  }
+  // CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
+  // CHECK-NEXT: tpp.add ins(%[[ARG0]] : memref<32x32xf32>, %[[ARG1]] : memref<32x32xf32>) 
+  // CHECK-SAME:         outs(%[[ARG1]] : memref<32x32xf32>)
+  return %r : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_relu
+// CHECK-SAME:  %[[ARG0:.+]]: memref<32x32xf32>
+func.func @tpp_tensor_relu(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: tpp.relu ins(%[[ARG0]] : memref<32x32xf32>) outs(%[[ARG0]] : memref<32x32xf32>)
+  %0 = tpp.relu (%arg0: tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_relu_must_allocate
+// CHECK-SAME: (%[[ARG0:.+]]: memref<32xf32>) -> memref<32x32xf32>
+func.func @tpp_tensor_relu_must_allocate(%arg0: tensor<32xf32>) -> tensor<32x32xf32> {
+  // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+  // CHECK-NEXT: tpp.relu ins(%[[ARG0]] : memref<32xf32>) outs(%[[ALLOC]] : memref<32x32xf32>)
+  // CHECK-NEXT: return %[[ALLOC]] : memref<32x32xf32>
+  %0 = tpp.relu (%arg0: tensor<32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @relu_tensor_loop
+// CHECK-SAME:  (%[[ARG0:.+]]: memref<32x32xf32>)
+func.func @relu_tensor_loop(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %c0 = arith.constant 0 : index
+  // CHECK: %[[C0:.+]] = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  // CHECK-DAG: %[[C10:.+]] = arith.constant 10 : index
+  %r = scf.for %i = %c0 to %c10 step %c1 iter_args(%iter_arg0 = %arg0) -> tensor<32x32xf32> {
+    %relu = tpp.relu (%iter_arg0: tensor<32x32xf32>) -> tensor<32x32xf32>
+    scf.yield %relu : tensor<32x32xf32>
+  }
+  // CHECK: scf.for %[[I:.+]] = %[[C0]] to %[[C10]] step %[[C1]]
+  // CHECK-NEXT: tpp.relu ins(%[[ARG0]] : memref<32x32xf32>) outs(%[[ARG0]] : memref<32x32xf32>)
+  return %r : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_identity
+// CHECK-SAME:  %[[ARG0:.+]]: memref<32x32xf32>
+func.func @tpp_tensor_identity(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: tpp.identity ins(%[[ARG0]] : memref<32x32xf32>) outs(%[[ARG0]] : memref<32x32xf32>)
+  %0 = tpp.identity (%arg0: tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_identity_must_allocate
+// CHECK-SAME: (%[[ARG0:.+]]: memref<32xf32>) -> memref<32x32xf32>
+func.func @tpp_tensor_identity_must_allocate(%arg0: tensor<32xf32>) -> tensor<32x32xf32> {
+  // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+  // CHECK-NEXT: tpp.identity ins(%[[ARG0]] : memref<32xf32>) outs(%[[ALLOC]] : memref<32x32xf32>)
+  // CHECK-NEXT: return %[[ALLOC]] : memref<32x32xf32>
+  %0 = tpp.identity (%arg0: tensor<32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_matmul
+// CHECK-SAME:  %[[ARG0:.+]]: memref<32x64xf32>, %[[ARG1:.+]]: memref<64x32xf32>, 
+// CHECK-SAME:  %[[ARG2:.+]]: memref<32x32xf32>
+func.func @tpp_tensor_matmul(%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
+                             %arg2: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: tpp.matmul ins(%[[ARG0]] : memref<32x64xf32>, %[[ARG1]] : memref<64x32xf32>, %[[ARG2]] : memref<32x32xf32>)
+  // CHECK-SAME:       outs(%[[ARG2]] : memref<32x32xf32>)
+  %0 = tpp.matmul (%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
+                          %arg2: tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_mixed
+// CHECK-SAME:  %[[ARG0:.+]]: memref<32x64xf32>, %[[ARG1:.+]]: memref<64x32xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<32x32xf32>, %[[ARG3:.+]]: memref<32x32xf32>
+func.func @tpp_mixed(%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
+                     %arg2: tensor<32x32xf32>, %arg3: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %0 = tpp.matmul (%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
+                          %arg2: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: tpp.matmul ins(%[[ARG0]] : memref<32x64xf32>, %[[ARG1]] : memref<64x32xf32>, %[[ARG2]] : memref<32x32xf32>) 
+  // CHECK-SAME:       outs(%[[ARG2]] : memref<32x32xf32>)
+  %1 = tpp.add (%0: tensor<32x32xf32>, %arg3: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NEXT: tpp.add ins(%[[ARG2]] : memref<32x32xf32>, %[[ARG3]] : memref<32x32xf32>) 
+  // CHECK-SAME:         outs(%[[ARG3]] : memref<32x32xf32>)
+  %2 = tpp.relu (%1: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK-NEXT: tpp.relu ins(%[[ARG3]] : memref<32x32xf32>) 
+  // CHECK-SAME:          outs(%[[ARG3]] : memref<32x32xf32>)
+  return %2 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_tensor_brgemm
+// CHECK-SAME: %[[ARG0:.+]]: memref<4x32x32xf32>, %[[ARG1:.+]]: memref<4x32x32xf32>,
+// CHECK-SAME: %[[ARG2:.+]]: memref<32x32xf32>  
+func.func @tpp_tensor_brgemm(%arg0: tensor<4x32x32xf32>, %arg1: tensor<4x32x32xf32>, 
+                             %arg2: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %0 = tpp.brgemm (%arg0: tensor<4x32x32xf32>, %arg1: tensor<4x32x32xf32>,
+                          %arg2: tensor<32x32xf32>) -> tensor<32x32xf32>
+  // CHECK: tpp.brgemm ins(%[[ARG0]] : memref<4x32x32xf32>, %[[ARG1]] : memref<4x32x32xf32>, %[[ARG2]] : memref<32x32xf32>) 
+  // CHECK-SAME:       outs(%[[ARG2]] : memref<32x32xf32>)
+  return %0 : tensor<32x32xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tpp_add_with_insert_slice
+// CHECK-SAME: %[[ARG0:.+]]: memref<1536xbf16>, %[[ARG1:.+]]: memref<8x48x32x32xbf16>
+func.func @tpp_add_with_insert_slice(%arg0: tensor<1536xbf16>, 
+                                     %arg1: tensor<8x48x32x32xbf16>) -> tensor<8x48x32x32xbf16> {
+  %expanded = tensor.expand_shape %arg0 [[0, 1]] : tensor<1536xbf16> into tensor<48x32xbf16>
+  %c48 = arith.constant 48 : index
+  %c8 = arith.constant 8 : index
+  %0 = scf.forall (%arg2, %arg3) in (%c8, %c48) shared_outs(%arg4 = %arg1) -> (tensor<8x48x32x32xbf16>) {
+    %extracted_slice = tensor.extract_slice %expanded[%arg3, 0] [1, 32] [1, 1] : tensor<48x32xbf16> to tensor<32xbf16>
+    %extracted_slice_0 = tensor.extract_slice %arg4[%arg2, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<8x48x32x32xbf16> to tensor<32x32xbf16>
+    %1 = tpp.add(%extracted_slice_0 : tensor<32x32xbf16>, %extracted_slice : tensor<32xbf16>) -> tensor<32x32xbf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %1 into %arg4[%arg2, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xbf16> into tensor<8x48x32x32xbf16>
+    }
+  }
+  return %0 : tensor<8x48x32x32xbf16>
+}
+
+// CHECK: %[[EXPAND:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]] : memref<1536xbf16> into memref<48x32xbf16>
+// CHECK: scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (8, 48)
+// CHECK-NEXT: %[[SUB:.+]] = memref.subview %expand_shape[%[[ARG3]], 0] [1, 32] [1, 1] 
+// CHECK-SAME:  : memref<48x32xbf16> to memref<32xbf16, strided<[1], offset: ?>>
+// CHECK-NEXT: %[[SUB0:.+]] = memref.subview %[[ARG1]][%[[ARG2]], %[[ARG3]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] 
+// CHECK-SAME:  : memref<8x48x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
+// CHECK-NEXT: tpp.add ins(%[[SUB0]] : memref<32x32xbf16, strided<[32, 1], offset: ?>>, 
+// CHECK-SAME:             %[[SUB]] : memref<32xbf16, strided<[1], offset: ?>>) 
+// CHECK-SAME:         outs(%[[SUB0]] : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
+
+// -----
+
+func.func @sequence_of_adds_on_rhs(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %0 = tpp.add (%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>
+  %1 = tpp.add (%0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>
+  return %1 : tensor<3x3xf32>
+}
+
+// Our bufferization is not optimal here. We decide to bufferize on rhs and then introduce
+// copies. We should bufferize on lhs.
+// CHECK-LABEL: func.func @sequence_of_adds_on_rhs
+// CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>
+// CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
+// CHECK: memref.copy %[[ARG1]], %[[ALLOC]] : memref<3x3xf32> to memref<3x3xf32>
+// CHECK: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ALLOC]] : memref<3x3xf32>) 
+// CHECK-SAME:    outs(%[[ALLOC]] : memref<3x3xf32>)
+// CHECK: tpp.add ins(%[[ALLOC]] : memref<3x3xf32>, %[[ARG1]] : memref<3x3xf32>) 
+// CHECK-SAME:    outs(%[[ARG1]] : memref<3x3xf32>)
+
+// -----
+
+func.func @sequence_of_adds_on_lhs(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %0 = tpp.add (%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>
+  %1 = tpp.add (%0: tensor<3x3xf32>, %arg0: tensor<3x3xf32>) -> tensor<3x3xf32>
+  return %1 : tensor<3x3xf32>
+}
+
+// CHECK-LABEL: sequence_of_adds_on_lhs
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>
+// CHECK: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ARG1]] : memref<3x3xf32>) 
+// CHECK-SAME:    outs(%[[ARG1]] : memref<3x3xf32>)
+// CHECK: tpp.add ins(%[[ARG1]] : memref<3x3xf32>, %[[ARG0]] : memref<3x3xf32>) 
+// CHECK-SAME:    outs(%[[ARG0]] : memref<3x3xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @tpp_and_linalg(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %0 = tpp.add (%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32>
+  %1 = linalg.generic {
+    indexing_maps = [#map, #map, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%0, %arg0: tensor<3x3xf32>, tensor<3x3xf32>)
+    outs(%arg0: tensor<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %add = arith.addf %in, %in_1 : f32
+        linalg.yield %add : f32
+    } -> tensor<3x3xf32>
+  return %1 : tensor<3x3xf32>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL: func.func @tpp_and_linalg
+// CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>
+// CHECK: tpp.add ins(%[[ARG0:.+]] : memref<3x3xf32>, %[[ARG1:.+]] : memref<3x3xf32>) outs(%[[ARG1:.+]] : memref<3x3xf32>)
+// CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
+// CHECK: linalg.generic
+// CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]]
+// CHECK-SAME:  iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:  ins(%[[ARG1]], %[[ARG0]]
+// CHECK-SAME:  outs(%[[ALLOC]]
+
+// -----
+
+// This test only to show that we already have the alloc for the linalg
+// operation. Thus it does not come from our bufferization see above.
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @simple_linalg(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg1, %arg0: tensor<3x3xf32>, tensor<3x3xf32>)
+    outs(%arg0: tensor<3x3xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %add = arith.addf %in, %in_1 : f32
+        linalg.yield %add : f32
+    } -> tensor<3x3xf32>
+  return %0 : tensor<3x3xf32>
+}

--- a/tools/tpp-opt/tpp-opt.cpp
+++ b/tools/tpp-opt/tpp-opt.cpp
@@ -23,6 +23,7 @@
 #include "TPP/Dialect/Check/CheckDialect.h"
 #include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/Tpp/TppDialect.h"
 #include "TPP/Dialect/Transform/LinalgXTransformOps.h"
 #include "TPP/Dialect/VNNI/BufferizableOpInterfaceImpl.h"
@@ -44,6 +45,7 @@ int main(int argc, char **argv) {
   mlir::check::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::vnni::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::perf::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::tpp::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tpp::registerTestStructuralMatchers();
 
   // Add the following to include *all* MLIR Core dialects, or selectively


### PR DESCRIPTION
- Unary op: Attempt to bufferize in place if the input type matches with the output type, otheriwse bufferize out-of-place.

- Binary op: Attempt to bufferize in place if the output type matchers either the lhs input or the rhs input, otherwise bufferize out-of-place.

- Ternary op: bufferize on the rhs input operand.