### PR TITLE
Validate unary/binary and ternary dispatch

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -206,13 +206,19 @@ def Xsmm_TernaryDispatchOp : Xsmm_Op<"ternary.dispatch",[Pure]> {
     example, leading dimensions or sizes. Returns the pointer to call as I64.
   }];
 
-  let arguments = (ins Xsmm_TernaryKind:$kind, DenseI64ArrayAttr:$inputs,
-                       Xsmm_DataType:$dataType);
+  let arguments = (ins 
+    Xsmm_TernaryKind:$kind,
+    ConfinedAttr<DenseI64ArrayAttr,
+                [DenseArrayNonNegative<DenseI64ArrayAttr>]>:$inputs,
+    Xsmm_DataType:$dataType);
+  
   let results = (outs I64:$results);
 
   let assemblyFormat = [{
     $kind $inputs `(` `dataType` $dataType `)` attr-dict
   }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -225,13 +231,19 @@ def Xsmm_BinaryDispatchOp : Xsmm_Op<"binary.dispatch",[Pure]> {
     See 'ternary.dispatch'.
   }];
 
-  let arguments = (ins Xsmm_BinaryKind:$kind, DenseI64ArrayAttr:$inputs,
-                       Xsmm_BinaryFlags:$flags, Xsmm_DataType:$dataType);
+  let arguments = (ins 
+    Xsmm_BinaryKind:$kind,
+    ConfinedAttr<DenseI64ArrayAttr,
+                [DenseArrayNonNegative<DenseI64ArrayAttr>]>:$inputs,
+    Xsmm_BinaryFlags:$flags, Xsmm_DataType:$dataType);
+  
   let results = (outs I64:$results);
 
   let assemblyFormat = [{
     $kind $inputs `(` `broadcast` $flags `dataType` $dataType `)` attr-dict
   }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -244,13 +256,19 @@ def Xsmm_UnaryDispatchOp : Xsmm_Op<"unary.dispatch",[Pure]> {
     See 'ternary.dispatch'.
   }];
 
-  let arguments = (ins Xsmm_UnaryKind:$kind, DenseI64ArrayAttr:$inputs,
-                       Xsmm_UnaryFlags:$flags, Xsmm_DataType:$dataType);
+  let arguments = (ins 
+    Xsmm_UnaryKind:$kind, 
+    ConfinedAttr<DenseI64ArrayAttr,
+                [DenseArrayNonNegative<DenseI64ArrayAttr>]>:$inputs,
+    Xsmm_UnaryFlags:$flags, Xsmm_DataType:$dataType);
+  
   let results = (outs I64:$results);
 
   let assemblyFormat = [{
     $kind $inputs `(` `broadcast` $flags `dataType` $dataType `)` attr-dict
   }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Xsmm/xsmm-invalid.mlir
+++ b/test/Dialect/Xsmm/xsmm-invalid.mlir
@@ -141,3 +141,57 @@ func.func @brgemm_dispatch() -> i64 {
   %0 = xsmm.brgemm.dispatch [3, 2, -1, 3, 2] flags = (none) data_type = f32
   return %0 : i64
 }
+
+// -----
+
+// CHECK-LABEL: func.func @unary_dispatch
+func.func @unary_dispatch() -> i64 {
+  // expected-error@+1 {{failed to satisfy constraint: i64 dense array attribute whose value is non-negative}}
+  %0 = xsmm.unary.dispatch relu [3, 2, 1, -3] ( broadcast none dataType f32 )
+  return %0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: func.func @unary_dispatch
+func.func @unary_dispatch() -> i64 {
+  // expected-error@+1 {{op expect 4 args but got: 3}}
+  %0 = xsmm.unary.dispatch relu [3, 2, 1] ( broadcast none dataType f32 )
+  return %0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: func.func @binary_dispatch
+func.func @binary_dispatch() -> i64 {
+  // expected-error@+1 {{failed to satisfy constraint: i64 dense array attribute whose value is non-negative}}
+  %0 = xsmm.binary.dispatch add [3, 2, 1, 3, -2] ( broadcast none dataType f32 )
+  return %0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: func.func @binary_dispatch
+func.func @binary_dispatch() -> i64 {
+  // expected-error@+1 {{op expect 5 args but got: 3}}
+  %0 = xsmm.binary.dispatch add [3, 2, 1] ( broadcast none dataType f32 )
+  return %0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: func.func @ternary_dispatch
+func.func @ternary_dispatch() -> i64 {
+  // expected-error@+1 {{failed to satisfy constraint: i64 dense array attribute whose value is non-negative}}
+  %0 = xsmm.ternary.dispatch none [3, 2, 1, 3, -2] ( dataType f32 )
+  return %0 : i64
+}
+
+// -----
+
+// CHECK-LABEL: func.func @ternary_dispatch
+func.func @ternary_dispatch() -> i64 {
+  // expected-error@+1 {{op expect 6 args but got: 3}}
+  %0 = xsmm.ternary.dispatch none [3, 2, 1] ( dataType f32 )
+  return %0 : i64
+}

--- a/test/Dialect/Xsmm/xsmm-ops.mlir
+++ b/test/Dialect/Xsmm/xsmm-ops.mlir
@@ -13,10 +13,10 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
     : (memref<2x2xf32>) -> ()
 
   // CHECK: xsmm.binary.dispatch
-  %0 = xsmm.binary.dispatch add [3, 2, 1] (broadcast none dataType f32)
+  %0 = xsmm.binary.dispatch add [3, 2, 1, 3, 2] (broadcast none dataType f32)
 
   // CHECK: xsmm.unary.dispatch
-  %1 = xsmm.unary.dispatch identity [3, 2, 1] (broadcast row dataType f32)
+  %1 = xsmm.unary.dispatch identity [3, 2, 1, 3] (broadcast row dataType f32)
 
   // CHECK: xsmm.matmul
   xsmm.matmul (dataType f32, %arg0, %arg1, %arg2) 


### PR DESCRIPTION
Add verification for `input` argument. `input` are the leading dimensions and sizes passed to the library expect them to be positive and bounded to some value based on the op type.