### PR TITLE
Use custom printer and parser for unary/binary and ternary

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmEnum.td
+++ b/include/TPP/Dialect/Xsmm/XsmmEnum.td
@@ -59,9 +59,9 @@ def Xsmm_UnaryFlags : I64EnumAttr<
     "UnaryFlags", "see: libxsmm_meltw_unary_flags",
     [
       I64EnumAttrCase<"NONE", 0, "none">,
-      I64EnumAttrCase<"BCAST_ROW", 2, "row">,
-      I64EnumAttrCase<"BCAST_COL", 4, "col">,
-      I64EnumAttrCase<"BCAST_SCALAR", 8, "scalar">
+      I64EnumAttrCase<"BCAST_ROW", 2, "bcast_row">,
+      I64EnumAttrCase<"BCAST_COL", 4, "bcast_col">,
+      I64EnumAttrCase<"BCAST_SCALAR", 8, "bcast_scalar">
     ]> {
   let cppNamespace = "mlir::xsmm";
 }
@@ -76,6 +76,14 @@ def Xsmm_BinaryFlags : I64EnumAttr<
       I64EnumAttrCase<"BCAST_COL_IN_1", 8, "bcast_col_in1">,
       I64EnumAttrCase<"BCAST_SCALAR_IN_0", 16, "bcast_scalar_in0">,
       I64EnumAttrCase<"BCAST_SCALAR_IN_1", 32, "bcast_scalar_in1">
+    ]> {
+  let cppNamespace = "mlir::xsmm";
+}
+
+def Xsmm_TernaryFlags : I64EnumAttr<
+    "TernaryFlags", "see: libxsmm_meltw_ternary_flags",
+    [
+      I64EnumAttrCase<"NONE", 0, "none">
     ]> {
   let cppNamespace = "mlir::xsmm";
 }

--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -210,13 +210,11 @@ def Xsmm_TernaryDispatchOp : Xsmm_Op<"ternary.dispatch",[Pure]> {
     Xsmm_TernaryKind:$kind,
     ConfinedAttr<DenseI64ArrayAttr,
                 [DenseArrayNonNegative<DenseI64ArrayAttr>]>:$inputs,
+    TypedArrayAttrBase<Xsmm_TernaryFlags, "ternary flags">:$flags,
     Xsmm_DataType:$dataType);
   
   let results = (outs I64:$results);
-
-  let assemblyFormat = [{
-    $kind $inputs `(` `dataType` $dataType `)` attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let hasVerifier = 1;
 }
@@ -235,13 +233,11 @@ def Xsmm_BinaryDispatchOp : Xsmm_Op<"binary.dispatch",[Pure]> {
     Xsmm_BinaryKind:$kind,
     ConfinedAttr<DenseI64ArrayAttr,
                 [DenseArrayNonNegative<DenseI64ArrayAttr>]>:$inputs,
-    Xsmm_BinaryFlags:$flags, Xsmm_DataType:$dataType);
+    TypedArrayAttrBase<Xsmm_BinaryFlags, "binary flags">:$flags,
+    Xsmm_DataType:$dataType);
   
   let results = (outs I64:$results);
-
-  let assemblyFormat = [{
-    $kind $inputs `(` `broadcast` $flags `dataType` $dataType `)` attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let hasVerifier = 1;
 }
@@ -260,14 +256,12 @@ def Xsmm_UnaryDispatchOp : Xsmm_Op<"unary.dispatch",[Pure]> {
     Xsmm_UnaryKind:$kind, 
     ConfinedAttr<DenseI64ArrayAttr,
                 [DenseArrayNonNegative<DenseI64ArrayAttr>]>:$inputs,
-    Xsmm_UnaryFlags:$flags, Xsmm_DataType:$dataType);
+    TypedArrayAttrBase<Xsmm_UnaryFlags, "unary flags">:$flags, 
+    Xsmm_DataType:$dataType);
   
   let results = (outs I64:$results);
-
-  let assemblyFormat = [{
-    $kind $inputs `(` `broadcast` $flags `dataType` $dataType `)` attr-dict
-  }];
-
+  let hasCustomAssemblyFormat = 1;
+  
   let hasVerifier = 1;
 }
 

--- a/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
@@ -126,7 +126,7 @@ static void printerImpl(OpAsmPrinter &printer, OpTy op) {
   auto dataType = op.getDataType();
   printer << xsmm::stringifyDataType(dataType);
   printer.printOptionalAttrDict(
-      op->getAttrs(), /*elidedAttrs=*/{"dataType", "flags", "inputs"});
+      op->getAttrs(), /*elidedAttrs=*/{"dataType", "flags", "inputs", "kind"});
 }
 
 void MatmulDispatchOp::print(OpAsmPrinter &printer) {

--- a/runtime/XsmmRunnerUtils.h
+++ b/runtime/XsmmRunnerUtils.h
@@ -29,13 +29,13 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_xsmm_matmul_dispatch(
     const libxsmm_datatype, int64_t, int64_t, int64_t, int64_t, int64_t,
     int64_t, const libxsmm_gemm_flags);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT int64_t
-_mlir_ciface_xsmm_unary_dispatch(const libxsmm_datatype, int64_t, int64_t,
-                                 int64_t, int64_t, int64_t, int64_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_xsmm_unary_dispatch(
+    const libxsmm_meltw_unary_type, const libxsmm_datatype, int64_t, int64_t,
+    int64_t, int64_t, const libxsmm_meltw_unary_flags);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT int64_t
-_mlir_ciface_xsmm_binary_dispatch(const libxsmm_datatype, int64_t, int64_t,
-                                  int64_t, int64_t, int64_t, int64_t, int64_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_xsmm_binary_dispatch(
+    const libxsmm_meltw_binary_type, const libxsmm_datatype, int64_t, int64_t,
+    int64_t, int64_t, int64_t, const libxsmm_meltw_binary_flags);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_xsmm_brgemm_dispatch(
     const libxsmm_datatype, int64_t, int64_t, int64_t, int64_t, int64_t,

--- a/test/BF16/Integration/xsmm-binary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-binary-bf16.mlir
@@ -6,7 +6,7 @@ memref.global "private" constant @__constant_bias : memref<3x3xbf16> = dense<1.0
 
 func.func @entry(%arg0: memref<3x3xbf16>, %arg1: memref<3x3xbf16>) {
   %0 = memref.get_global @__constant_bias : memref<3x3xbf16>
-  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3](broadcast none dataType bf16)
+  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = none data_type = bf16
   xsmm.binary add(dataType bf16, %1, %arg0, %0, %arg1) : (i64, memref<3x3xbf16>, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
 
   return

--- a/test/BF16/Integration/xsmm-binary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-binary-bf16.mlir
@@ -6,7 +6,7 @@ memref.global "private" constant @__constant_bias : memref<3x3xbf16> = dense<1.0
 
 func.func @entry(%arg0: memref<3x3xbf16>, %arg1: memref<3x3xbf16>) {
   %0 = memref.get_global @__constant_bias : memref<3x3xbf16>
-  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = none data_type = bf16
+  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = (none) data_type = bf16
   xsmm.binary add(dataType bf16, %1, %arg0, %0, %arg1) : (i64, memref<3x3xbf16>, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
 
   return

--- a/test/BF16/Integration/xsmm-unary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-unary-bf16.mlir
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s
 
 func.func @entry(%arg0: memref<3x3xbf16>) {
-  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType bf16)
+  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3] flags = (none) data_type = bf16
   xsmm.unary relu(dataType bf16, %0, %arg0, %arg0) : (i64, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
 
   return

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-add.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-add.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: func.func @add_to_xsmm_1d
 func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: memref<32xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 32, 32, 32](broadcast none dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 32, 32, 32] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<32xf32>, memref<32xf32>, memref<32xf32>) -> ()
   tpp.add ins(%arg0: memref<32xf32>, %arg1: memref<32xf32>) outs(%arg2: memref<32xf32>)
   return 
@@ -12,7 +12,7 @@ func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: m
 
 // CHECK-LABEL: add_to_xsmm_2d
 func.func @add_to_xsmm_2d(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>, %arg2: memref<3x4xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [3, 4, 4, 4, 4](broadcast none dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [3, 4, 4, 4, 4] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<3x4xf32>, memref<3x4xf32>, memref<3x4xf32>) -> ()
   tpp.add ins(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>) outs(%arg2: memref<3x4xf32>)
   return
@@ -24,9 +24,9 @@ func.func @add_to_xsmm_2d(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>, %arg2:
 func.func @add_to_xsmm_bcast_on_col(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf32>,
                                       %arg2: memref<5xf32>, %arg3: memref<1xf32>) {
   tpp.add ins(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf32>) outs(%arg1: memref<5x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 5, 5, 5](broadcast bcast_col_in0 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 5, 5, 5] flags = (bcast_col_in0) data_type = f32
   tpp.add ins(%arg1: memref<5x5xf32>, %arg0: memref<1x5xf32>) outs(%arg1: memref<5x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 5, 5, 5](broadcast bcast_col_in1 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 5, 5, 5] flags = (bcast_col_in1) data_type = f32
   return
 }
 
@@ -35,9 +35,9 @@ func.func @add_to_xsmm_bcast_on_col(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf3
 // CHECK-LABEL: func.func @add_to_xsmm_bcast_on_row
 func.func @add_to_xsmm_bcast_on_row(%arg0: memref<5x1xf32>, %arg1: memref<5x5xf32>) {
   tpp.add ins(%arg0: memref<5x1xf32>, %arg1: memref<5x5xf32>) outs(%arg1: memref<5x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 1, 5, 5](broadcast bcast_row_in0 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 1, 5, 5] flags = (bcast_row_in0) data_type = f32
   tpp.add ins(%arg1: memref<5x5xf32>, %arg0: memref<5x1xf32>) outs(%arg1: memref<5x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 5, 1, 5](broadcast bcast_row_in1 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 5, 1, 5] flags = (bcast_row_in1) data_type = f32
   return
 }
 
@@ -48,14 +48,14 @@ func.func @add_to_xsmm_bcast_on_scalar_or_none(
     %arg0: memref<1xf32>, %arg1: memref<5xf32>, 
     %arg2: memref<1x5xf32>, %arg3: memref<5x5xf32>) {
   tpp.add ins(%arg0: memref<1xf32>, %arg1: memref<5xf32>) outs(%arg1: memref<5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 1, 5, 5](broadcast bcast_scalar_in0 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 1, 5, 5] flags = (bcast_scalar_in0) data_type = f32
   tpp.add ins(%arg1: memref<5xf32>, %arg0: memref<1xf32>) outs(%arg1: memref<5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 5, 1, 5](broadcast bcast_scalar_in1 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 5, 1, 5] flags = (bcast_scalar_in1) data_type = f32
   tpp.add ins(%arg2: memref<1x5xf32>, %arg1: memref<5xf32>) outs(%arg2: memref<1x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 5, 5, 5](broadcast none dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 5, 5, 5] flags = (none) data_type = f32
   tpp.add ins(%arg0: memref<1xf32>, %arg3: memref<5x5xf32>) outs(%arg3: memref<5x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 1, 5, 5](broadcast bcast_scalar_in0 dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [5, 5, 1, 5, 5] flags = (bcast_scalar_in0) data_type = f32
   tpp.add ins(%arg1: memref<5xf32>, %arg2: memref<1x5xf32>) outs(%arg2: memref<1x5xf32>)
-  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 5, 5, 5](broadcast none dataType f32)
+  // CHECK: %{{.+}} = xsmm.binary.dispatch add [1, 5, 5, 5, 5] flags = (none) data_type = f32
   return
 } 

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-identity.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-identity.mlir
@@ -15,7 +15,7 @@ func.func @identity_to_xsmm(%arg0: memref<3x3xf32>) {
   // compute_type = 1 (F32)
   // b_cast = 3 (bcast scalar)
 
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [3, 3, 1, 3](broadcast scalar dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
   // CHECK: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[CST]], %[[ARG0]]) 
   tpp.identity ins(%cst: f32) outs(%arg0: memref<3x3xf32>)
   return
@@ -36,7 +36,7 @@ func.func @identity_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // compute_type = 1 (F32)
   // b_cast = 0 (bcast none)
 
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [3, 3, 3, 3](broadcast none dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [3, 3, 3, 3] flags = (none) data_type = f32
   // CHECK: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
   return
@@ -58,7 +58,7 @@ func.func @identity_to_xsmm(%arg0: memref<5x1xf32>, %arg1: memref<5x6xf32>) {
   // compute_type = 1 (F32)
   // b_cast = 1 (bcast row)
 
-  // CHECK: xsmm.unary.dispatch identity [5, 6, 1, 6](broadcast row dataType f32)
+  // CHECK: xsmm.unary.dispatch identity [5, 6, 1, 6] flags = (bcast_row) data_type = f32
   // CHECK: xsmm.unary identity
   tpp.identity ins(%arg0: memref<5x1xf32>) outs(%arg1: memref<5x6xf32>)
   return
@@ -80,7 +80,7 @@ func.func @identity_to_xsmm(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf32>) {
   // compute_type = 1 (F32)
   // b_cast = 2 (bcast col)
 
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 5, 5, 5](broadcast col dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 5, 5, 5] flags = (bcast_col) data_type = f32
   // CHECK-NEXT: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: memref<1x5xf32>) outs(%arg1: memref<5x5xf32>)
   return
@@ -93,7 +93,7 @@ func.func @identity_to_xsmm(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf32>) {
 // CHECK-SAME:  %[[ARG1:.+]]: memref<5x6xf32>)
 func.func @identity_to_xsmm(%arg0: f32, %arg1: memref<5x6xf32>) {
 
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 6, 1, 6](broadcast scalar dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 6, 1, 6] flags = (bcast_scalar) data_type = f32
   // CHECK-NEXT: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: f32) outs(%arg1: memref<5x6xf32>)
   return
@@ -104,7 +104,7 @@ func.func @identity_to_xsmm(%arg0: f32, %arg1: memref<5x6xf32>) {
 // CHECK-LABEL: @identity_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<1x1xf32>, %[[ARG1:.+]]: memref<5x6xf32>)
 func.func @identity_to_xsmm(%arg0: memref<1x1xf32>, %arg1: memref<5x6xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 6, 1, 6](broadcast scalar dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 6, 1, 6] flags = (bcast_scalar) data_type = f32
   // CHECK-NEXT: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: memref<1x1xf32>) outs(%arg1: memref<5x6xf32>)
   return

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-relu.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-relu.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<5x6xf32>)
 func.func @relu_to_xsmm(%arg0: memref<5x6xf32>) {
-  // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6](broadcast none dataType f32)
+  // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPACTH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<5x6xf32>) outs(%arg0: memref<5x6xf32>)
   return
@@ -14,7 +14,7 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>) {
 // CHECK-LABEL: @relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<5x6xf32>, %[[ARG1:.+]]: memref<5x6xf32>)
 func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
-  // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6](broadcast none dataType f32)
+  // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPACTH]], %[[ARG0]], %[[ARG1]])
   tpp.relu ins(%arg0: memref<5x6xf32>) outs(%arg1: memref<5x6xf32>)
   return
@@ -25,7 +25,7 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
 // CHECK-LABEL: func.func @relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>)
 func.func @relu_to_xsmm(%arg0: memref<32xf32>) {
-  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32](broadcast none dataType f32)
+  // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<32xf32>) outs(%arg0: memref<32xf32>)
   return

--- a/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: dispatch_unary
 func.func @dispatch_unary() -> i64 {
-  %0 = xsmm.unary.dispatch identity [5, 6, 5, 6](broadcast row dataType f32)
+  %0 = xsmm.unary.dispatch identity [5, 6, 5, 6] flags = (bcast_row) data_type = f32
   return %0: i64
 }
 
@@ -10,7 +10,7 @@ func.func @dispatch_unary() -> i64 {
 // CHECK-DAG: %[[C5:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[C6:.+]] = arith.constant 6 : i64
 // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i64
-// CHECK: call @xsmm_unary_dispatch(%[[C1]], %[[C5]], %[[C6]], %[[C5]], %[[C6]], %[[C1]], %[[C2]])
+// CHECK: call @xsmm_unary_dispatch(%[[C1]], %[[C1]], %[[C5]], %[[C6]], %[[C5]], %[[C6]], %[[C2]])
 
 // -----
 

--- a/test/Dialect/Xsmm/xsmm-invalid.mlir
+++ b/test/Dialect/Xsmm/xsmm-invalid.mlir
@@ -147,7 +147,7 @@ func.func @brgemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @unary_dispatch
 func.func @unary_dispatch() -> i64 {
   // expected-error@+1 {{failed to satisfy constraint: i64 dense array attribute whose value is non-negative}}
-  %0 = xsmm.unary.dispatch relu [3, 2, 1, -3] ( broadcast none dataType f32 )
+  %0 = xsmm.unary.dispatch relu [3, 2, 1, -3] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -156,7 +156,7 @@ func.func @unary_dispatch() -> i64 {
 // CHECK-LABEL: func.func @unary_dispatch
 func.func @unary_dispatch() -> i64 {
   // expected-error@+1 {{op expect 4 args but got: 3}}
-  %0 = xsmm.unary.dispatch relu [3, 2, 1] ( broadcast none dataType f32 )
+  %0 = xsmm.unary.dispatch relu [3, 2, 1] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -165,7 +165,7 @@ func.func @unary_dispatch() -> i64 {
 // CHECK-LABEL: func.func @binary_dispatch
 func.func @binary_dispatch() -> i64 {
   // expected-error@+1 {{failed to satisfy constraint: i64 dense array attribute whose value is non-negative}}
-  %0 = xsmm.binary.dispatch add [3, 2, 1, 3, -2] ( broadcast none dataType f32 )
+  %0 = xsmm.binary.dispatch add [3, 2, 1, 3, -2] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -174,7 +174,7 @@ func.func @binary_dispatch() -> i64 {
 // CHECK-LABEL: func.func @binary_dispatch
 func.func @binary_dispatch() -> i64 {
   // expected-error@+1 {{op expect 5 args but got: 3}}
-  %0 = xsmm.binary.dispatch add [3, 2, 1] ( broadcast none dataType f32 )
+  %0 = xsmm.binary.dispatch add [3, 2, 1] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -183,7 +183,7 @@ func.func @binary_dispatch() -> i64 {
 // CHECK-LABEL: func.func @ternary_dispatch
 func.func @ternary_dispatch() -> i64 {
   // expected-error@+1 {{failed to satisfy constraint: i64 dense array attribute whose value is non-negative}}
-  %0 = xsmm.ternary.dispatch none [3, 2, 1, 3, -2] ( dataType f32 )
+  %0 = xsmm.ternary.dispatch none [3, 2, 1, 3, -2] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -192,6 +192,6 @@ func.func @ternary_dispatch() -> i64 {
 // CHECK-LABEL: func.func @ternary_dispatch
 func.func @ternary_dispatch() -> i64 {
   // expected-error@+1 {{op expect 6 args but got: 3}}
-  %0 = xsmm.ternary.dispatch none [3, 2, 1] ( dataType f32 )
+  %0 = xsmm.ternary.dispatch none [3, 2, 1] flags = (none) data_type = f32
   return %0 : i64
 }

--- a/test/Dialect/Xsmm/xsmm-ops.mlir
+++ b/test/Dialect/Xsmm/xsmm-ops.mlir
@@ -13,10 +13,10 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
     : (memref<2x2xf32>) -> ()
 
   // CHECK: xsmm.binary.dispatch
-  %0 = xsmm.binary.dispatch add [3, 2, 1, 3, 2] (broadcast none dataType f32)
+  %0 = xsmm.binary.dispatch add [3, 2, 1, 3, 2] flags = (none) data_type = f32
 
   // CHECK: xsmm.unary.dispatch
-  %1 = xsmm.unary.dispatch identity [3, 2, 1, 3] (broadcast row dataType f32)
+  %1 = xsmm.unary.dispatch identity [3, 2, 1, 3] flags = (bcast_row) data_type = f32
 
   // CHECK: xsmm.matmul
   xsmm.matmul (dataType f32, %arg0, %arg1, %arg2) 

--- a/test/Integration/xsmm-binary.mlir
+++ b/test/Integration/xsmm-binary.mlir
@@ -6,7 +6,7 @@ memref.global "private" constant @__constant_bias : memref<3x3xf32> = dense<1.0>
 
 func.func @entry(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   %0 = memref.get_global @__constant_bias : memref<3x3xf32>
-  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3](broadcast none dataType f32)
+  %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = (none) data_type = f32
   xsmm.binary add(dataType f32, %1, %arg0, %0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return

--- a/test/Integration/xsmm-unary.mlir
+++ b/test/Integration/xsmm-unary.mlir
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s
 
 func.func @entry(%arg0: memref<3x3xf32>) {
-  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType f32)
+  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3] flags = (none) data_type = f32
   xsmm.unary relu(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return

--- a/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
+++ b/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
@@ -56,7 +56,7 @@ func.func @perf_dialect(%A: tensor<4x8xf32>,
 // -----
 
 func.func @xsmm_dialect(%arg0: memref<32x256xf32>, %arg1: memref<1x8x32x32xf32>) -> i64 {
-  %0 = xsmm.unary.dispatch identity [5, 6, 5, 6](broadcast row dataType f32)
+  %0 = xsmm.unary.dispatch identity [5, 6, 5, 6] flags = (bcast_row) data_type = f32
   %1 = xsmm.matmul.dispatch [3, 3, 3, 3, 3, 3] flags = (none) data_type = f32
   %2 = arith.addi %0, %1 : i64
   return %2: i64

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -37,7 +37,7 @@ module @predict_function  {
     // Relu
     // CHECK: call @xsmm_unary_dispatch
     // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
-    %2 = xsmm.unary.dispatch relu [128, 512, 512, 512](broadcast none dataType f32)
+    %2 = xsmm.unary.dispatch relu [128, 512, 512, 512] flags = (none) data_type = f32
     xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 
     return

--- a/test/Passes/DefaultPipeline/xsmm.mlir
+++ b/test/Passes/DefaultPipeline/xsmm.mlir
@@ -8,7 +8,7 @@ func.func @add(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
   // CHECK: %[[cast1:.*]] = memref.cast %[[ARG1]]
   // CHECK: call @xsmm_binary_invoke({{.*}}%[[cast0]], %[[cast1]]
-  %0 = xsmm.binary.dispatch add [3, 3, 3, 3, 3](broadcast none dataType f32)
+  %0 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = (none) data_type = f32
   xsmm.binary add(dataType f32, %0, %arg0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
@@ -28,7 +28,7 @@ func.func @add_mapping(%arg0: memref<1x10x10xf32>, %arg1: memref<1x10x10xf32>) {
   // CHECK: call @xsmm_binary_invoke({{.*}}%[[cast]], %[[cast1]]
     %subview = memref.subview %arg0[0, 0, 0] [1, 10, 10] [1, 1, 1] : memref<1x10x10xf32> to memref<10x10xf32>
     %subview_0 = memref.subview %arg1[0, 0, 0] [1, 10, 10] [1, 1, 1] : memref<1x10x10xf32> to memref<10x10xf32>
-    %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10](broadcast none dataType f32)
+    %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10] flags = (none) data_type = f32
     xsmm.binary add(dataType f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32>, memref<10x10xf32>) -> ()
 
   return
@@ -51,7 +51,7 @@ func.func @add_mapping_parallel(%arg0: memref<10x10x10xf32>, %arg1: memref<10x10
   scf.parallel (%arg2) = (%c0) to (%c10) step (%c1) {
     %subview = memref.subview %arg0[%arg2, 0, 0] [1, 10, 10] [1, 1, 1] : memref<10x10x10xf32> to memref<10x10xf32, #map>
     %subview_0 = memref.subview %arg1[%arg2, 0, 0] [1, 10, 10] [1, 1, 1] : memref<10x10x10xf32> to memref<10x10xf32, #map>
-    %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10](broadcast none dataType f32)
+    %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10] flags = (none) data_type = f32
     xsmm.binary add(dataType f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32, #map>, memref<10x10xf32, #map>) -> ()
     scf.yield
   }
@@ -69,7 +69,7 @@ func.func @identity(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG1]]
   // CHECK: %[[cast1:.*]] = memref.cast %[[ARG0]]
   // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast1]]
-  %0 = xsmm.unary.dispatch identity [3, 3, 1, 3](broadcast scalar dataType f32)
+  %0 = xsmm.unary.dispatch identity [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
   xsmm.unary identity(dataType f32, %0, %arg1, %arg0) : (i64, memref<1x1xf32>, memref<3x3xf32>) -> ()
 
   return
@@ -93,7 +93,7 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
   %alloc = memref.alloc() {alignment = 128 : i64} : memref<12x56x56x64xf32>
   scf.parallel (%arg1, %arg2) = (%c0, %c0) to (%c12, %c56) step (%c1, %c1) {
     %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 56, 64] [1, 1, 1, 1] : memref<12x56x56x64xf32> to memref<56x64xf32, #map>
-    %0 = xsmm.unary.dispatch identity [56, 64, 64, 64](broadcast col dataType f32)
+    %0 = xsmm.unary.dispatch identity [56, 64, 64, 64] flags = (bcast_col) data_type = f32
     xsmm.unary identity(dataType f32, %0, %arg0, %subview) : (i64, memref<64xf32>, memref<56x64xf32, #map>) -> ()
     scf.yield
   }
@@ -109,7 +109,7 @@ func.func @relu(%arg0: memref<3x3xf32>) {
   // CHECK: call @xsmm_unary_dispatch
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
   // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
-  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3](broadcast none dataType f32)
+  %0 = xsmm.unary.dispatch relu [3, 3, 3, 3] flags = (none) data_type = f32
   xsmm.unary relu(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
@@ -131,7 +131,7 @@ func.func @relu_3d(%arg0: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
   %c1 = arith.constant 1 : index
   scf.parallel (%arg1) = (%c0) to (%c64) step (%c1) {
     %subview = memref.subview %arg0[%arg1, 0, 0] [1, 32, 32] [1, 1, 1] : memref<64x32x32xf32> to memref<32x32xf32, #map>
-    %0 = xsmm.unary.dispatch relu [32, 32, 32, 32](broadcast none dataType f32)
+    %0 = xsmm.unary.dispatch relu [32, 32, 32, 32] flags = (none) data_type = f32
     xsmm.unary relu(dataType f32, %0, %subview, %subview) : (i64, memref<32x32xf32, #map>, memref<32x32xf32, #map>) -> ()
     scf.yield
   }
@@ -306,7 +306,7 @@ module @predict_function {
     // CHECK: %[[cast:.*]] = memref.cast %[[ARG2]]
     // CHECK: %[[cast0:.*]] = memref.cast %[[ARG3]]
     // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast0]]
-    %0 = xsmm.unary.dispatch identity [128, 512, 512, 512](broadcast col dataType f32)
+    %0 = xsmm.unary.dispatch identity [128, 512, 512, 512] flags = (bcast_col) data_type = f32
     xsmm.unary identity(dataType f32, %0, %arg2, %arg3) : (i64, memref<512xf32>, memref<128x512xf32>) -> ()
 
     // Matmul
@@ -320,7 +320,7 @@ module @predict_function {
     // Relu
     // CHECK: call @xsmm_unary_dispatch
     // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
-    %2 = xsmm.unary.dispatch relu [128, 512, 512, 512](broadcast none dataType f32)
+    %2 = xsmm.unary.dispatch relu [128, 512, 512, 512] flags = (none) data_type = f32
     xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 
     return


### PR DESCRIPTION
- Use custom printer and parser to align with matmul and brgemm op

- Simplify dispatch creation in conversion from Xsmm to Func. All the dispatch but Quaternary can share same conversion functions

Quaternary is the only one that is not updated. Will follow up if we need it.