### PR TITLE
Improve bufferization for binary and ternary ops

### DIFF
--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -152,6 +152,29 @@ def Tpp_ReluOp : Tpp_UnaryOp<"relu"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ZeroOp
+//===----------------------------------------------------------------------===//
+
+def Tpp_ZeroOp : Tpp_UnaryOp<"zero"> {
+  let summary = "Zero a tensor or memref.";
+  let description = [{
+    Zero initialize a tensor or memref value.
+    
+    Example:
+    
+    ```mlir
+    
+    // out-of-place - memref abstraction.
+    tpp.zero ins(%0: memref<2x2xf32>) outs(%1: memref<2x2xf32>)
+
+    // tensor abstraction.
+    %0 = tpp.zero (%0: tensor<4xf32>) -> tensor<4xf32>
+    
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Binary Operations
 //===----------------------------------------------------------------------===//
 

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -154,6 +154,23 @@ ParseResult ReluOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 //===----------------------------------------------------------------------===//
+// ZeroOp
+//===----------------------------------------------------------------------===//
+
+void ZeroOp::build(OpBuilder &builder, OperationState &result, Value input,
+                   Value output) {
+  return ZeroOp::build(builder, result, /*TypeRange=*/{}, input, output);
+}
+
+void ZeroOp::print(OpAsmPrinter &printer) {
+  printTppOp(printer, getInputs(), getOutputs(), getResultTypes(), *this);
+}
+
+ParseResult ZeroOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseTppOp(parser, result);
+}
+
+//===----------------------------------------------------------------------===//
 // AdddOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TPP/Dialect/Tpp/TppUtils.h"
+#include "TPP/Dialect/Tpp/TppOps.h"
 #include "TPP/Dialect/Tpp/TppTraits.h"
 #include "TPP/IR/StructuredOpMatcher.h"
 #include "TPP/TransformUtils.h"
@@ -107,11 +108,13 @@ static bool isZeroOp(Operation *defOp) {
   if (!defOp)
     return false;
 
+  if (isa_and_nonnull<tpp::ZeroOp>(defOp))
+    return true;
+
   return TypeSwitch<Operation *, bool>(defOp)
       .Case<arith::ConstantOp>([&](auto op) {
         // Dense attributes don't match APFloat.isZero()
         auto attr = op.getValue();
-        attr.dump();
         return isZeroAttr(attr);
       })
       .Case<linalg::FillOp, linalg::CopyOp>([&](auto op) {

--- a/test/Dialect/Tpp/tpp-bufferization.mlir
+++ b/test/Dialect/Tpp/tpp-bufferization.mlir
@@ -49,6 +49,7 @@ func.func @tpp_tensor_add_bufferize_outs_of_place(%arg0: tensor<1xf32>, %arg1: t
 // CHECK-LABEL: func.func @tpp_tensor_add_loop
 // CHECK-SAME: %[[ARG0:.+]]: memref<32x32xf32>, %[[ARG1:.+]]: memref<32x32xf32>
 func.func @tpp_tensor_add_loop(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK-NOT: memref.alloc
   %c0 = arith.constant 0 : index
   // CHECK: %[[C0:.+]] = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -92,6 +93,7 @@ func.func @tpp_tensor_relu_must_allocate(%arg0: tensor<32xf32>) -> tensor<32x32x
 // CHECK-LABEL: func.func @relu_tensor_loop
 // CHECK-SAME:  (%[[ARG0:.+]]: memref<32x32xf32>)
 func.func @relu_tensor_loop(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK-NOT: memref.alloc
   %c0 = arith.constant 0 : index
   // CHECK: %[[C0:.+]] = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -150,6 +152,7 @@ func.func @tpp_tensor_matmul(%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
 // CHECK-SAME:  %[[ARG2:.+]]: memref<32x32xf32>, %[[ARG3:.+]]: memref<32x32xf32>
 func.func @tpp_mixed(%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
                      %arg2: tensor<32x32xf32>, %arg3: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK-NOT: memref.alloc
   %0 = tpp.matmul (%arg0: tensor<32x64xf32>, %arg1: tensor<64x32xf32>,
                           %arg2: tensor<32x32xf32>) -> tensor<32x32xf32>
   // CHECK: tpp.matmul ins(%[[ARG0]] : memref<32x64xf32>, %[[ARG1]] : memref<64x32xf32>, %[[ARG2]] : memref<32x32xf32>) 
@@ -197,6 +200,7 @@ func.func @tpp_add_with_insert_slice(%arg0: tensor<1536xbf16>,
   return %0 : tensor<8x48x32x32xbf16>
 }
 
+// CHECK-NOT: memref.alloc
 // CHECK: %[[EXPAND:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]] : memref<1536xbf16> into memref<48x32xbf16>
 // CHECK: scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (8, 48)
 // CHECK-NEXT: %[[SUB:.+]] = memref.subview %expand_shape[%[[ARG3]], 0] [1, 32] [1, 1] 
@@ -235,6 +239,7 @@ func.func @sequence_of_adds_on_lhs(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32
 }
 
 // CHECK-LABEL: sequence_of_adds_on_lhs
+// CHECK-NOT: memref.alloc
 // CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>
 // CHECK: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ARG1]] : memref<3x3xf32>) 
 // CHECK-SAME:    outs(%[[ARG1]] : memref<3x3xf32>)

--- a/test/Dialect/Tpp/tpp-bufferization.mlir
+++ b/test/Dialect/Tpp/tpp-bufferization.mlir
@@ -374,9 +374,9 @@ func.func @test_mlp_bf16_3_layer_1024(%arg0: tensor<256x1024xbf16>,
   return %8 : tensor<256x1024xbf16>
 }
 
-// CHECK-NOT: memref.alloc
 // CHECK-LABEL: test_mlp_bf16_3_layer_1024(
 // CHECK-SAME: %[[ARG0:.+]]: memref<256x1024xbf16>, %[[ARG1:.+]]: memref<256x1024xbf16>)
+// CHECK-NOT: memref.alloc
 // CHECK: %[[GB:.+]] = memref.get_global @__constant_1024x1024xbf16 : memref<1024x1024xbf16>
 // CHECK: %[[GB1:.+]] = memref.get_global @__constant_256x1024xbf16 : memref<256x1024xbf16>
 // CHECK: tpp.zero ins(%[[ARG1]] : memref<256x1024xbf16>) outs(%[[ARG1]] : memref<256x1024xbf16>)

--- a/test/Dialect/Tpp/tpp-ops-tensor.mlir
+++ b/test/Dialect/Tpp/tpp-ops-tensor.mlir
@@ -14,8 +14,11 @@ func.func @tpp_dialect(%arg0: tensor<5x4xf32>, %arg1: tensor<4x5xf32>,
   %3 = tpp.brgemm (%arg3: tensor<8x5x5xf32>, %arg3: tensor<8x5x5xf32>, 
                    %2: tensor<5x5xf32>) -> tensor<5x5xf32>
   // CHECK: tpp.relu
-  %4 = tpp.relu (%3 : tensor<5x5xf32>) -> tensor<5x5xf32>
-  return %4 : tensor<5x5xf32>
+  %4 = tpp.relu (%3: tensor<5x5xf32>) -> tensor<5x5xf32>
+  
+  // CHECK: tpp.zero
+  %5 = tpp.zero (%4: tensor<5x5xf32>) -> tensor<5x5xf32> 
+  return %5 : tensor<5x5xf32>
 }
 
 // CHECK-LABEL: func.func @tpp_identity_tensor_bcast


### PR DESCRIPTION
- Binary: Avoid bufferize on constant-like operation. If an operand is detected to be constant we cannot write to it.

- Ternary: If C is zero filled we can add only a 'write' effect this allows to reuse C without introducing further copies.