### PR TITLE
Check result of getPerfectlyNestedLoops

### DIFF
--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -62,6 +62,8 @@ struct ReplaceIterArgs : public OpRewritePattern<scf::ForOp> {
       return failure();
     SmallVector<scf::ForOp> nestedLoops;
     getPerfectlyNestedLoops(nestedLoops, forOp);
+    if (nestedLoops.size() == 0)
+      return failure();
     replaceIterArgs(rewriter, forOp, nestedLoops[nestedLoops.size() - 1]);
     return success();
   }
@@ -80,6 +82,8 @@ struct ConvertToForAll : public OpRewritePattern<scf::ForOp> {
       return failure();
     SmallVector<scf::ForOp> nestedLoops;
     getPerfectlyNestedLoops(nestedLoops, forOp);
+    if (nestedLoops.size() == 0)
+      return failure();
 
     SmallVector<Value> loopArgs;
     SmallVector<OpFoldResult> lbs, ubs, steps;


### PR DESCRIPTION
This may help #484, which was first reported in #454 and just after #408 was merged, which makes use of this function and replacing iterArgs with [size-1] array without making sure size > 0.

Either way, it's a safe code to add anyway.