### PR TITLE
Enable linalg to tpp conversion at tensor level

### DIFF
--- a/lib/TPP/ConvertForAllToParallelOp.cpp
+++ b/lib/TPP/ConvertForAllToParallelOp.cpp
@@ -24,6 +24,7 @@ struct ConvertForAllToParallelOpImpl : public OpRewritePattern<scf::ForallOp> {
 
   LogicalResult matchAndRewrite(scf::ForallOp forallOp,
                                 PatternRewriter &rewriter) const override {
+    // Bail-out if we are not at memref.
     if (forallOp->getNumResults() != 0)
       return failure();
     Location loc = forallOp.getLoc();

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -82,9 +82,6 @@ struct ConvertBrgemmToTpp
 
   LogicalResult matchAndRewrite(linalg::BatchReduceMatmulOp brMatmulOp,
                                 PatternRewriter &rewriter) const override {
-    if (!brMatmulOp.hasBufferSemantics())
-      return rewriter.notifyMatchFailure(
-          brMatmulOp, "Expect buffer semantics when mapping to tpp");
     if (!tpp::utils::hasStaticShape(brMatmulOp))
       return rewriter.notifyMatchFailure(
           brMatmulOp, "Expect static shape when mapping to tpp");
@@ -102,9 +99,6 @@ struct ConvertMatmulToTpp : public OpRewritePattern<linalg::MatmulOp> {
 
   LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
                                 PatternRewriter &rewriter) const override {
-    if (!matmulOp.hasBufferSemantics())
-      return rewriter.notifyMatchFailure(
-          matmulOp, "Expect buffer semantics when mapping to tpp");
     if (!tpp::utils::hasStaticShape(matmulOp))
       return rewriter.notifyMatchFailure(
           matmulOp, "Expect static shape when mapping to tpp");

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -207,6 +207,13 @@ LogicalResult MatmulOp::verify() {
 
 void MatmulOp::build(OpBuilder &builder, OperationState &state,
                      ValueRange inputs, Value output) {
+  if (auto rankedOutput =
+          output.getType().dyn_cast_or_null<RankedTensorType>()) {
+    MatmulOp::build(builder, state, TypeRange{rankedOutput}, inputs,
+                    ValueRange{output});
+    return;
+  }
+  assert(output.getType().isa<MemRefType>() && "expect memref semantics");
   MatmulOp::build(builder, state, /*TypeRange=*/{}, inputs, ValueRange{output});
 }
 
@@ -248,6 +255,12 @@ LogicalResult BrgemmOp::verify() {
 
 void BrgemmOp::build(OpBuilder &builder, OperationState &state,
                      ValueRange inputs, Value output) {
+  if (auto rankedOutput =
+          output.getType().dyn_cast_or_null<RankedTensorType>()) {
+    BrgemmOp::build(builder, state, TypeRange{rankedOutput}, inputs, ValueRange{output});
+    return;
+  }
+  assert(output.getType().isa<MemRefType>() && "expect memref semantics");
   BrgemmOp::build(builder, state, /*TypeRange=*/{}, inputs, ValueRange{output});
 }
 

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -209,9 +209,8 @@ void MatmulOp::build(OpBuilder &builder, OperationState &state,
                      ValueRange inputs, Value output) {
   if (auto rankedOutput =
           output.getType().dyn_cast_or_null<RankedTensorType>()) {
-    MatmulOp::build(builder, state, TypeRange{rankedOutput}, inputs,
-                    ValueRange{output});
-    return;
+    return MatmulOp::build(builder, state, TypeRange{rankedOutput}, inputs,
+                           ValueRange{output});
   }
   assert(output.getType().isa<MemRefType>() && "expect memref semantics");
   MatmulOp::build(builder, state, /*TypeRange=*/{}, inputs, ValueRange{output});
@@ -257,8 +256,8 @@ void BrgemmOp::build(OpBuilder &builder, OperationState &state,
                      ValueRange inputs, Value output) {
   if (auto rankedOutput =
           output.getType().dyn_cast_or_null<RankedTensorType>()) {
-    BrgemmOp::build(builder, state, TypeRange{rankedOutput}, inputs, ValueRange{output});
-    return;
+    return BrgemmOp::build(builder, state, TypeRange{rankedOutput}, inputs,
+                           ValueRange{output});
   }
   assert(output.getType().isa<MemRefType>() && "expect memref semantics");
   BrgemmOp::build(builder, state, /*TypeRange=*/{}, inputs, ValueRange{output});

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-memref.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-memref.mlir
@@ -541,14 +541,3 @@ func.func @broadcast_col_identity(%arg0: memref<8x32xf32>, %arg1: memref<8xf32>)
     }
   return
 }
-
-// -----
-
-// CHECK-LABEL: func.func @matmul_on_tensor(
-func.func @matmul_on_tensor(%arg0: tensor<8x9xf32>,
-                            %arg1: tensor<9x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
-  // CHECK-NOT: tpp.matmul
-  %0 = linalg.matmul ins(%arg0, %arg1: tensor<8x9xf32>, tensor<9x8xf32>)
-                outs(%arg2: tensor<8x8xf32>) -> tensor<8x8xf32>
-  return %0 : tensor<8x8xf32>
-}

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -1,0 +1,29 @@
+// RUN: tpp-opt %s -split-input-file -convert-linalg-to-tpp | FileCheck %s
+
+func.func @brgemm_lowering(%arg0: tensor<3x5x4xf32>, %arg1: tensor<3x4x5xf32>,
+                          %arg2: tensor<5x5xf32>) -> tensor<5x5xf32> {
+  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1: tensor<3x5x4xf32>, tensor<3x4x5xf32>)
+                                  outs(%arg2: tensor<5x5xf32>) -> tensor<5x5xf32>
+  return %0 : tensor<5x5xf32>
+}
+
+// CHECK-LABEL: brgemm_lowering
+// CHECK-SAME: %[[ARG0:.+]]: tensor<3x5x4xf32>, %[[ARG1:.+]]: tensor<3x4x5xf32>, %[[ARG2:.+]]: tensor<5x5xf32>
+// CHECK: %{{.+}} = tpp.brgemm 
+// CHECK-SAME:  (%[[ARG0]] : tensor<3x5x4xf32>, %[[ARG1]] : tensor<3x4x5xf32>, %[[ARG2]] : tensor<5x5xf32>) 
+// CHECK-SAME:  -> (tensor<5x5xf32>)
+
+// -----
+
+func.func @matmul_lowering(%arg0: tensor<8x9xf32>,
+                           %arg1: tensor<9x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1: tensor<8x9xf32>, tensor<9x8xf32>)
+                     outs(%arg2: tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %0 : tensor<8x8xf32>
+}
+
+// CHECK-LABEL: matmul_lowering
+// CHECK-SAME: %[[ARG0:.+]]: tensor<8x9xf32>, %[[ARG1:.+]]: tensor<9x8xf32>, %[[ARG2:.+]]: tensor<8x8xf32>
+// CHECK: %{{.+}} = tpp.matmul
+// CHECK-SAME: (%[[ARG0]] : tensor<8x9xf32>, %[[ARG1]] : tensor<9x8xf32>, %[[ARG2]] : tensor<8x8xf32>) 
+// CHECK-SAME:  -> (tensor<8x8xf32>)

--- a/test/Passes/DefaultPipeline/tpp-conversion.mlir
+++ b/test/Passes/DefaultPipeline/tpp-conversion.mlir
@@ -46,27 +46,3 @@ func.func @vnni_dialect(%arg0: memref<4x256x512xbf16>,
 // CHECK: tpp.vnni_brgemm
 // CHECK-NOT: vnni.matmul
 // CHECK: tpp.vnni_matmul
-
-// -----
-
-func.func @matmul_lowering(%arg0: tensor<8x9xf32>,
-                           %arg1: tensor<9x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
-  %0 = linalg.matmul ins(%arg0, %arg1: tensor<8x9xf32>, tensor<9x8xf32>)
-                     outs(%arg2: tensor<8x8xf32>) -> tensor<8x8xf32>
-  return %0 : tensor<8x8xf32>
-}
-
-// CHECK-LABEL: matmul_lowering
-// CHECK: tpp.matmul
-
-// -----
-
-func.func @brgemm_lowering(%arg0: tensor<3x5x4xf32>, %arg1: tensor<3x4x5xf32>,
-                          %arg2: tensor<5x5xf32>) -> tensor<5x5xf32> {
-  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1: tensor<3x5x4xf32>, tensor<3x4x5xf32>)
-                                  outs(%arg2: tensor<5x5xf32>) -> tensor<5x5xf32>
-  return %0 : tensor<5x5xf32>
-}
-
-// CHECK-LABEL: brgemm_lowering
-// CHECK: tpp.brgemm

--- a/test/Passes/DefaultPipeline/tpp-conversion.mlir
+++ b/test/Passes/DefaultPipeline/tpp-conversion.mlir
@@ -1,27 +1,5 @@
 // RUN: tpp-opt %s -tpp-conversion -split-input-file | FileCheck %s
 
-#map0 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
-#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
-#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
-
-// Rewriting to brgemm is done after bufferization which is why it is not part of 'tpp-mapping'.
-// See the default pipeline in 'DefaultTppPasses' for more details.
-func.func @generic_to_brgemm(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor<8x16x32x32xf32>, %arg2: tensor<4x8x32x32xf32>) -> tensor<4x8x32x32xf32> {
-  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x16x32x32xf32>, tensor<8x16x32x32xf32>) outs(%arg2 : tensor<4x8x32x32xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
-      %8 = arith.mulf %arg3, %arg4 : f32
-      %9 = arith.addf %arg5, %8 : f32
-      linalg.yield %9 : f32
-    } -> tensor<4x8x32x32xf32>
-  return %1 :  tensor<4x8x32x32xf32>
-}
-
-// CHECK-LABEL: func.func @generic_to_brgemm(
-// CHECK-NOT: linalg.generic
-// CHECK: linalg.batch_reduce_matmul
-
-// -----
-
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 func.func @linalg_dialect(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
@@ -68,3 +46,27 @@ func.func @vnni_dialect(%arg0: memref<4x256x512xbf16>,
 // CHECK: tpp.vnni_brgemm
 // CHECK-NOT: vnni.matmul
 // CHECK: tpp.vnni_matmul
+
+// -----
+
+func.func @matmul_lowering(%arg0: tensor<8x9xf32>,
+                           %arg1: tensor<9x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1: tensor<8x9xf32>, tensor<9x8xf32>)
+                     outs(%arg2: tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %0 : tensor<8x8xf32>
+}
+
+// CHECK-LABEL: matmul_lowering
+// CHECK: tpp.matmul
+
+// -----
+
+func.func @brgemm_lowering(%arg0: tensor<3x5x4xf32>, %arg1: tensor<3x4x5xf32>,
+                          %arg2: tensor<5x5xf32>) -> tensor<5x5xf32> {
+  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1: tensor<3x5x4xf32>, tensor<3x4x5xf32>)
+                                  outs(%arg2: tensor<5x5xf32>) -> tensor<5x5xf32>
+  return %0 : tensor<5x5xf32>
+}
+
+// CHECK-LABEL: brgemm_lowering
+// CHECK: tpp.brgemm


### PR DESCRIPTION
Currently, only for Brgemm and Gemm (named). Also, changed behaviour for `TppLoweringPass`. It should only deal with linalg to tpp conversion and not pull in passes like `createConvertForAllToParallelOpPass` or `createRewriteToBatchReduceGemmPass`. These passes need to run after bufferization to preserve parallelism, while we may want to run `TppLoweringPass` at the tensor level to check the conversion.