### PR TITLE
Enable linalg to tpp conversion at tensor level - part 2

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -40,10 +40,6 @@ bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target);
 // Returns true if the linalg operation has copy semantics.
 bool hasCopySemantics(linalg::LinalgOp linalgOp);
 
-// Returns true if the linalg operation can convert to a tpp.matmul.
-bool isTppMatmul(linalg::LinalgOp linalgOp,
-                 SmallVectorImpl<Value> *capturedOperands = nullptr);
-
 // Returns true if the linalg operation can convert to a tpp.add.
 bool isTppAdd(linalg::GenericOp linalgOp,
               SmallVectorImpl<Value> *capturedOperands = nullptr);

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -66,8 +66,6 @@ struct ConvertGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
 
   LogicalResult matchAndRewrite(linalg::GenericOp linalgOp,
                                 PatternRewriter &rewriter) const override {
-    if (!linalgOp.hasBufferSemantics())
-      return rewriter.notifyMatchFailure(linalgOp, "Expect buffer semantics");
     if (!tpp::utils::hasStaticShape(linalgOp))
       return rewriter.notifyMatchFailure(
           linalgOp, "Expect static shape when mapping to tpp");

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -9,6 +9,7 @@
 #include "TPP/Dialect/Tpp/TppOps.h"
 #include "TPP/Dialect/Tpp/TppUtils.h"
 #include "TPP/Passes.h"
+#include "TPP/TransformUtils.h"
 #include "TPP/Transforms.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -53,7 +54,7 @@ struct ConvertGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
           linalgOp, ValueRange{operands[0], operands[1]}, operands[2]);
       return success();
     }
-    if (tpp::utils::isTppMatmul(linalgOp, &operands)) {
+    if (linalgx::utils::isMatmulOp(linalgOp, &operands)) {
       assert(operands.size() == 3 && "Expect three operands");
       rewriter.replaceOpWithNewOp<tpp::MatmulOp>(
           linalgOp, ValueRange{operands[0], operands[1], operands[2]},

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -125,7 +125,13 @@ static void printTppOp(OpAsmPrinter &printer, ValueRange operands,
 
 void IdentityOp::build(OpBuilder &builder, OperationState &result, Value input,
                        Value output) {
-  return IdentityOp::build(builder, result, /*TypeRange=*/{}, input, output);
+  if (auto rankedOutput =
+          output.getType().dyn_cast_or_null<RankedTensorType>()) {
+    return IdentityOp::build(builder, result, TypeRange{rankedOutput}, input,
+                             output);
+  }
+  assert(output.getType().isa<MemRefType>() && "expect memref semantics");
+  IdentityOp::build(builder, result, /*TypeRange=*/{}, input, output);
 }
 
 void IdentityOp::print(OpAsmPrinter &printer) {
@@ -142,7 +148,13 @@ ParseResult IdentityOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void ReluOp::build(OpBuilder &builder, OperationState &result, Value input,
                    Value output) {
-  return ReluOp::build(builder, result, /*TypeRange=*/{}, input, output);
+  if (auto rankedOutput =
+          output.getType().dyn_cast_or_null<RankedTensorType>()) {
+    return ReluOp::build(builder, result, TypeRange{rankedOutput}, input,
+                         output);
+  }
+  assert(output.getType().isa<MemRefType>() && "expect memref semantics");
+  ReluOp::build(builder, result, /*TypeRange=*/{}, input, output);
 }
 
 void ReluOp::print(OpAsmPrinter &printer) {
@@ -175,9 +187,14 @@ ParseResult ZeroOp::parse(OpAsmParser &parser, OperationState &result) {
 //===----------------------------------------------------------------------===//
 
 void AddOp::build(OpBuilder &builder, OperationState &result, ValueRange inputs,
-                  Value out) {
-  return AddOp::build(builder, result, /*TypeRange=*/{}, inputs,
-                      ValueRange{out});
+                  Value output) {
+  if (auto rankedOutput =
+          output.getType().dyn_cast_or_null<RankedTensorType>()) {
+    return AddOp::build(builder, result, TypeRange{rankedOutput}, inputs,
+                        ValueRange{output});
+  }
+  assert(output.getType().isa<MemRefType>() && "expect memref semantics");
+  AddOp::build(builder, result, /*TypeRange=*/{}, inputs, ValueRange{output});
 }
 
 void AddOp::print(OpAsmPrinter &printer) {

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -10,7 +10,6 @@
 #include "TPP/Dialect/Tpp/TppOps.h"
 #include "TPP/Dialect/Tpp/TppTraits.h"
 #include "TPP/IR/StructuredOpMatcher.h"
-#include "TPP/TransformUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -171,12 +170,6 @@ static bool isTppUnaryOp(linalg::GenericOp linalgOp) {
           .input(MatchAll(), HasMap(ProjectedPermutation()))
           .operation(VerifyInterface(OpTrait::tpp::checkBroadcastableShape));
   return isTppOp(linalgOp) && unaryMatcher.match(linalgOp);
-}
-
-// Returns true if the linalg.generic maps to a tpp.gemm.
-// TODO: we may want to remove now.
-bool isTppMatmul(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
-  return linalgx::utils::isMatmulOp(linalgOp, operands);
 }
 
 // Return true if the linalg.generic can be mapped to a tpp.add.

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -139,7 +139,6 @@ static bool isTppOp(linalg::GenericOp linalgOp) {
   using namespace tpp::structured_match;
   auto tppMatcher =
       StructuredOpMatcher::make<linalg::GenericOp>()
-          .operation(HasBufferSemantics())
           .output(MatchAll(), HasStaticShape())
           .input(MatchAll(), HasStaticShape())
           .operation(VerifyInterface(OpTrait::tpp::checkUnitStrideInnerLoop));
@@ -175,9 +174,8 @@ static bool isTppUnaryOp(linalg::GenericOp linalgOp) {
 }
 
 // Returns true if the linalg.generic maps to a tpp.gemm.
+// TODO: we may want to remove now.
 bool isTppMatmul(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
-  if (linalgOp.hasTensorSemantics())
-    return false;
   return linalgx::utils::isMatmulOp(linalgOp, operands);
 }
 

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-memref.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-memref.mlir
@@ -65,7 +65,7 @@ func.func @add_mapping_scalar(%arg0: memref<f32>, %arg1: memref<f32>) {
 
 // -----
 
-// We don't support broadcast for tpp.add. All operands must have the same type.
+// Output affine map is not an identity.
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (0, d1)>
 func.func @add_mapping_brcst(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) {
@@ -101,7 +101,7 @@ func.func @add_mapping(%arg0: memref<4x4xf32>, %arg1: memref<4x4xf32>) {
 
 // -----
 
-// All dimension get collapsed to a rank zero memref and we do not convert rank 0 memref to tpp.
+// tpp have 2d rank.
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 func.func @add_mapping(%arg0: memref<1x1x1xf32>, %arg1: memref<1x1x1xf32>) {
   // CHECK-NOT: tpp.add
@@ -307,7 +307,10 @@ func.func @matmul_mapping() -> memref<28x32xf32> {
   %alloc_1 = memref.alloc() : memref<28x32xf32>
   
   // CHECK-NOT: tpp.matmul
-  linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%alloc, %alloc_0 : memref<28x55xf32>, memref<55x32xf32>) outs(%alloc_1 : memref<28x32xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "reduction"]} 
+    ins(%alloc, %alloc_0 : memref<28x55xf32>, memref<55x32xf32>) outs(%alloc_1 : memref<28x32xf32>) {
     ^bb0(%in: f32, %in_2: f32, %out: f32):
       %0 = arith.mulf %in, %in_2 : f32
       %1 = arith.addf %out, %0 : f32
@@ -455,7 +458,7 @@ func.func @transpose_no_output_identity(%arg0: memref<8x32xf32>, %arg1: memref<3
 
 // CHECK-LABEL: func.func @empty_map_identity
 // CHECK-SAME: %[[ARG0:.+]]: f32, %[[ARG1:.+]]: memref<8x32xf32>
-func.func @empty_map_identity(%arg0 : f32, %arg1: memref<8x32xf32>) {
+func.func @empty_map_identity(%arg0: f32, %arg1: memref<8x32xf32>) {
   // CHECK: tpp.identity ins(%[[ARG0]] : f32) outs(%[[ARG1]] : memref<8x32xf32>)
   linalg.generic {
     indexing_maps = [#map, #map1],

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -27,3 +27,125 @@ func.func @matmul_lowering(%arg0: tensor<8x9xf32>,
 // CHECK: %{{.+}} = tpp.matmul
 // CHECK-SAME: (%[[ARG0]] : tensor<8x9xf32>, %[[ARG1]] : tensor<9x8xf32>, %[[ARG2]] : tensor<8x8xf32>) 
 // CHECK-SAME:  -> (tensor<8x8xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @add_mapping(%arg0: tensor<5x5xf32>, %arg1: tensor<5x5xf32>) -> tensor<5x5xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0: tensor<5x5xf32>) outs(%arg1: tensor<5x5xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %0 = arith.addf %in, %out : f32
+        linalg.yield %0 : f32
+  } -> tensor<5x5xf32>
+  return %0 : tensor<5x5xf32>
+}
+
+// CHECK-LABEL: add_mapping
+// CHECK-SAME: %[[ARG0:.+]]: tensor<5x5xf32>, %[[ARG1:.+]]: tensor<5x5xf32>
+// CHECK: %{{.+}} = tpp.add (%[[ARG0]] : tensor<5x5xf32>, %[[ARG1]] : tensor<5x5xf32>) -> (tensor<5x5xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @relu_mapping_inplace(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = linalg.generic {
+    indexing_maps = [#map],
+    iterator_types = ["parallel", "parallel"]}
+    outs(%arg0: tensor<10x10xf32>) {
+      ^bb0(%out : f32):
+        %0 = arith.maxf %out, %c0 : f32
+        linalg.yield %0 : f32
+  } -> tensor<10x10xf32>
+  return %0 : tensor<10x10xf32>
+}
+
+// CHECK-LABEL: relu_mapping_inplace
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<10x10xf32>
+// CHECK: %{{.+}} = tpp.relu (%[[ARG0]] : tensor<10x10xf32>) -> (tensor<10x10xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @relu_mapping_outofplace(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg1: tensor<10x10xf32>) outs(%arg0: tensor<10x10xf32>) {
+      ^bb0(%in : f32, %out : f32):
+        %0 = arith.maxf %in, %c0 : f32
+        linalg.yield %0 : f32
+  } -> tensor<10x10xf32>
+  return %0 : tensor<10x10xf32>
+}
+
+// CHECK-LABEL: relu_mapping_outofplace
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<10x10xf32>, %[[ARG1:.+]]: tensor<10x10xf32>
+// CHECK: %{{.+}} = tpp.relu (%[[ARG1]] : tensor<10x10xf32>) -> (tensor<10x10xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> ()>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @scalar_identity(%arg0: f32, %arg1: tensor<8x32xf32>) -> tensor<8x32xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map1],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0 : f32) outs(%arg1: tensor<8x32xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        linalg.yield %in : f32
+  } -> tensor<8x32xf32>
+  return %0 : tensor<8x32xf32>
+}
+
+// CHECK-LABEL: scalar_identity
+// CHECK-SAME: %[[ARG0:.+]]: f32, %[[ARG1:.+]]: tensor<8x32xf32>
+// CHECK: %{{.+}} = tpp.identity (%[[ARG0]] : f32) -> (tensor<8x32xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (0, d1)>
+
+func.func @broadcast_row_identity(%arg0: tensor<8x32xf32>, %arg1: tensor<1x32xf32>) -> tensor<8x32xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map1, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg1: tensor<1x32xf32>) outs(%arg0: tensor<8x32xf32>) {
+      ^bb0(%in: f32, %out:f32):
+        linalg.yield %in : f32
+  } -> tensor<8x32xf32>
+  return %0 : tensor<8x32xf32>
+}
+
+// CHECK-LABEL: broadcast_row_identity
+// CHECK-SAME: %[[ARG0:.+]]: tensor<8x32xf32>, %[[ARG1]]: tensor<1x32xf32>
+// CHECK: %{{.+}} = tpp.identity (%[[ARG1]] : tensor<1x32xf32>) -> (tensor<8x32xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0, 0)>
+
+func.func @broadcast_col_identity(%arg0: tensor<8x32xf32>, %arg1: tensor<8x1xf32>) -> tensor<8x32xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map1, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg1: tensor<8x1xf32>) outs(%arg0: tensor<8x32xf32>) {
+      ^bb0(%in: f32, %out:f32):
+        linalg.yield %in : f32
+  } -> tensor<8x32xf32>
+  return %0 : tensor<8x32xf32>
+}
+
+// CHECK-LABEL: broadcast_col_identity
+// CHECK-SAME: %[[ARG0:.+]]: tensor<8x32xf32>, %[[ARG1]]: tensor<8x1xf32>
+// CHECK: %{{.+}} = tpp.identity (%[[ARG1]] : tensor<8x1xf32>) -> (tensor<8x32xf32>)


### PR DESCRIPTION
Enable all the rest. Relax constraint on the matchers and allow tensor semantics. Replicate some memref test in `linalg-to-tpp-tensor.mlir`.