### PR TITLE
Preserve attribute when printing tpp ops

### DIFF
--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -117,6 +117,8 @@ static void printTppOp(OpAsmPrinter &printer, ValueRange operands,
     printCommaSeparatedList(printer, operands);
     printer << " -> (" << results << ")";
   }
+  printer.printOptionalAttrDict(op->getAttrs(),
+                                /*elidedAttrs=*/{"operand_segment_sizes"});
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Tpp/tpp-ops-memref.mlir
+++ b/test/Dialect/Tpp/tpp-ops-memref.mlir
@@ -4,7 +4,7 @@
 func.func @tpp_dialect(%arg0: memref<2x2xf32>,
                        %arg1: memref<2x2xf32>,
                        %arg2: memref<2x2xf32>, %arg3: f32, %arg4: f32,
-                       %arg5: memref<2xf32>, %arg6: memref<2xf32>) -> memref<2x2xf32> {
+                       %arg5: memref<2xf32>, %arg6: memref<2xf32>) {
   // CHECK: tpp.add
   tpp.add ins(%arg0: memref<2x2xf32>, %arg0: memref<2x2xf32>) outs(%arg2: memref<2x2xf32>)
 
@@ -30,7 +30,10 @@ func.func @tpp_dialect(%arg0: memref<2x2xf32>,
   // CHECK: tpp.zero
   tpp.zero ins(%arg1: memref<2x2xf32>) outs(%arg1: memref<2x2xf32>)
 
-  return %arg2: memref<2x2xf32>
+  // CHECK: tpp.zero {{.+}} {myAttr = "myattr"}
+  tpp.zero ins(%arg1: memref<2x2xf32>) outs(%arg1: memref<2x2xf32>) {myAttr = "myattr"} 
+
+  return
 }
 
 // CHECK-LABEL: func.func @identity_bcast_row

--- a/test/Dialect/Tpp/tpp-ops-tensor.mlir
+++ b/test/Dialect/Tpp/tpp-ops-tensor.mlir
@@ -18,6 +18,9 @@ func.func @tpp_dialect(%arg0: tensor<5x4xf32>, %arg1: tensor<4x5xf32>,
   
   // CHECK: tpp.zero
   %5 = tpp.zero (%4: tensor<5x5xf32>) -> tensor<5x5xf32> 
+  
+  // CHECK: tpp.zero {{.+}} {myAttr = "myattr"}
+  %6 = tpp.zero (%4: tensor<5x5xf32>) -> tensor<5x5xf32> {myAttr = "myattr"}
   return %5 : tensor<5x5xf32>
 }
 


### PR DESCRIPTION
Useful when debugging bufferization.