### PR TITLE
Skip default builder for tpp

### DIFF
--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -85,7 +85,8 @@ class Tpp_UnaryOp<string mnemonic, list<Trait> traits = []> :
                        Variadic<TppOutputOperand>:$outputs);
   let results = (outs Variadic<TppTensor>:$results);
 
-  let hasCustomAssemblyFormat = 1; 
+  let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1; 
 
   let builders = [
     // Memref builder.

--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -192,6 +192,7 @@ class Tpp_BinaryOp<string mnemonic, list<Trait> traits = []> :
   let results = (outs Variadic<TppTensor>:$results);
 
   let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
 
   let builders = [
     // Memref builder.
@@ -255,6 +256,7 @@ class Tpp_TernaryOp<string mnemonic, list<Trait> traits = []> :
   let results = (outs Variadic<TppBrgemmOperand>:$results);
 
   let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
 
   let builders = [
     // Memref builder.

--- a/include/TPP/Dialect/Tpp/TppTraits.h
+++ b/include/TPP/Dialect/Tpp/TppTraits.h
@@ -14,7 +14,7 @@ LogicalResult verifyUnitStrideInnerLoop(Operation *op,
 
 LogicalResult checkBroadcastableShape(Operation *op);
 LogicalResult checkUnitStrideInnerLoop(Operation *op);
-LogicalResult verifyArity(Operation *op, unsigned numInput, unsigned numOutput);
+LogicalResult verifyArity(Operation *op, unsigned numInput);
 
 template <typename ConcreteType>
 struct BroadcastableShape
@@ -34,23 +34,17 @@ struct UnitStrideInnerLoop
 
 template <typename ConcreteType>
 struct UnaryOp : public OpTrait::TraitBase<ConcreteType, UnaryOp> {
-  static LogicalResult verifyTrait(Operation *op) {
-    return verifyArity(op, 1, 1);
-  }
+  static LogicalResult verifyTrait(Operation *op) { return verifyArity(op, 1); }
 };
 
 template <typename ConcreteType>
 struct BinaryOp : public OpTrait::TraitBase<ConcreteType, BinaryOp> {
-  static LogicalResult verifyTrait(Operation *op) {
-    return verifyArity(op, 2, 1);
-  }
+  static LogicalResult verifyTrait(Operation *op) { return verifyArity(op, 2); }
 };
 
 template <typename ConcreteType>
 struct TernaryOp : public OpTrait::TraitBase<ConcreteType, TernaryOp> {
-  static LogicalResult verifyTrait(Operation *op) {
-    return verifyArity(op, 3, 1);
-  }
+  static LogicalResult verifyTrait(Operation *op) { return verifyArity(op, 3); }
 };
 
 } // namespace tpp

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -130,7 +130,8 @@ static void tppOpBuilder(OpBuilder &builder, OperationState &state,
     state.addTypes(outputs.getTypes());
     state.addAttribute(
         "operand_segment_sizes",
-        builder.getDenseI32ArrayAttr({static_cast<int>(inputs.size()), 0}));
+        builder.getDenseI32ArrayAttr(
+            {static_cast<int>(inputs.size()), /*numOutputs=*/0}));
   } else {
     state.addOperands(outputs);
     state.addAttribute(

--- a/lib/TPP/Dialect/Tpp/TppTraits.cpp
+++ b/lib/TPP/Dialect/Tpp/TppTraits.cpp
@@ -148,8 +148,6 @@ LogicalResult mlir::OpTrait::tpp::checkUnitStrideInnerLoop(Operation *op) {
 
 static LogicalResult verifyArityImpl(Operation *op, unsigned numInput,
                                      unsigned numOutput) {
-  assert(op->template hasTrait<OpTrait::AttrSizedOperandSegments>());
-  assert(isa<mlir::tpp::TppOp>(op) && "expect a tpp operation");
   auto attrName =
       OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr();
   ArrayRef<int> sizeAttr =

--- a/lib/TPP/Dialect/Tpp/TppTraits.cpp
+++ b/lib/TPP/Dialect/Tpp/TppTraits.cpp
@@ -146,10 +146,10 @@ LogicalResult mlir::OpTrait::tpp::checkUnitStrideInnerLoop(Operation *op) {
   return verifyUnitStrideInnerLoop(op, /*emitDiagnostic=*/false);
 }
 
-// TODO: verify operand segement size on output.
-LogicalResult mlir::OpTrait::tpp::verifyArity(Operation *op, unsigned numInput,
-                                              unsigned numOutput) {
+static LogicalResult verifyArityImpl(Operation *op, unsigned numInput,
+                                     unsigned numOutput) {
   assert(op->template hasTrait<OpTrait::AttrSizedOperandSegments>());
+  assert(isa<mlir::tpp::TppOp>(op) && "expect a tpp operation");
   auto attrName =
       OpTrait::AttrSizedOperandSegments<void>::getOperandSegmentSizeAttr();
   ArrayRef<int> sizeAttr =
@@ -160,5 +160,19 @@ LogicalResult mlir::OpTrait::tpp::verifyArity(Operation *op, unsigned numInput,
     return op->emitError() << "expect " << numInput
                            << " input operands, but got: " << sizeAttr[0];
   }
+  if (sizeAttr[1] != static_cast<int>(numOutput)) {
+    return op->emitError() << "expect " << numOutput
+                           << " output operands, but got: " << sizeAttr[1];
+  }
   return success();
+}
+
+LogicalResult mlir::OpTrait::tpp::verifyArity(Operation *op,
+                                              unsigned numInput) {
+  assert(op->template hasTrait<OpTrait::AttrSizedOperandSegments>());
+  assert(isa<mlir::tpp::TppOp>(op) && "expect a tpp operation");
+  auto tppOp = cast<mlir::tpp::TppOp>(op);
+  if (tppOp.hasTensorSemantics())
+    return verifyArityImpl(tppOp, numInput, /*numberOfOutput=*/0);
+  return verifyArityImpl(tppOp, numInput, /*numberOfOutput=*/1);
 }

--- a/test/Dialect/Tpp/tpp-invalid.mlir
+++ b/test/Dialect/Tpp/tpp-invalid.mlir
@@ -310,8 +310,24 @@ func.func @tpp_relu_invalid_number_of_operands(%arg0: tensor<2x2xf32>) -> tensor
 
 // -----
 
-func.func @tpp_matmul_invalid_number_of_operands(%arg0: tensor<2x2xf32>) {
+func.func @tpp_matmul_invalid_number_of_operands(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32> {
   // expected-error @below {{expect 3 input operands, but got: 2}}
   %0 = tpp.matmul (%arg0: tensor<2x2xf32>, %arg0: tensor<2x2xf32>) -> tensor<2x2xf32>
   return %0: tensor<2x2xf32>
+}
+
+// -----
+
+func.func @tpp_segement_size(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  // expected-error @below {{expect 0 output operands, but got: 1}}
+  %0 = tpp.zero(%arg0: tensor<2x2xf32>, %arg0: tensor<2x2xf32>) -> tensor<2x2xf32> {operand_segment_sizes = array<i32: 1, 1>}
+  return %0 : tensor<2x2xf32>
+}
+
+// -----
+
+func.func @unary_invalid_operands(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  // expected-error @below {{expect 1 input operands, but got: 2}}
+  %0 = tpp.zero(%arg0: tensor<2x2xf32>, %arg0: tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
 }


### PR DESCRIPTION
We cannot call default builder as we need to set operand segement sizes in different way if we are in tensor or memref land.