### PR TITLE
Allow random behaviour without user seed

### DIFF
--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -138,6 +138,11 @@ MLIRBench::PrintStage parsePrintStage(StringRef stage) {
 // so we can modify the IR with the needed wrappers
 static LogicalResult prepareMLIRKernel(Operation *op,
                                        JitRunnerOptions &options) {
+  // Randon options need seed
+  if (!seed && (splatRandom || initType == "random" || initType == "normal")) {
+    seed = std::time(0);
+  }
+
   // Benchmark object
   MLIRBenchConfig config(seed, tppToLoops, linalgToLoops,
                          parseTensorInitType(initType));
@@ -264,14 +269,6 @@ LogicalResult emitError(StringRef msg) {
 
 // Input validation
 LogicalResult validateInput() {
-  // Randon options need seed
-  if (!seed) {
-    if (splatRandom)
-      return emitError("Cannot replace splats with random without seed");
-    if (initType == "random" || initType == "normal")
-      return emitError("Cannot init random tensors without seed");
-  }
-
   // Parse tensor init
   auto init = parseTensorInitType(initType);
   if (init == TensorInitType::Invalid)


### PR DESCRIPTION
Generates a new seed (with localtime) instead. This allows for easily running random benchmarks without having to worry about propagating the seed through the multiple harnesses.

Once the harness can handle seeds (and use the same for all different tools), it can just pass `-seed` and it will behave accordingly.