### PR TITLE
Writable benchmark tensor arguments

### DIFF
--- a/benchmarks/mlir/mlp-bf16-10layers-3584.mlir
+++ b/benchmarks/mlir/mlp-bf16-10layers-3584.mlir
@@ -11,184 +11,259 @@
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
 
-func.func @entry(%arg0: tensor<8x112x32x32xbf16>, %arg1: tensor<112x112x32x32xbf16>, %arg2: tensor<3584xbf16>, %arg3: tensor<8x112x32x32xbf16>, %arg4: tensor<112x112x32x32xbf16>, %arg5: tensor<3584xbf16>, %arg6: tensor<8x112x32x32xbf16>, %arg7: tensor<112x112x32x32xbf16>, %arg8: tensor<3584xbf16>, %arg9: tensor<8x112x32x32xbf16> , %arg10: tensor<112x112x32x32xbf16>, %arg11: tensor<3584xbf16>, %arg12: tensor<8x112x32x32xbf16> , %arg13: tensor<112x112x32x32xbf16>, %arg14: tensor<3584xbf16>, %arg15: tensor<8x112x32x32xbf16> , %arg16: tensor<112x112x32x32xbf16>, %arg17: tensor<3584xbf16>, %arg18: tensor<8x112x32x32xbf16>, %arg19: tensor<112x112x32x32xbf16>, %arg20: tensor<3584xbf16>, %arg21: tensor<8x112x32x32xbf16>  , %arg22: tensor<112x112x32x32xbf16>, %arg23: tensor<3584xbf16>, %arg24: tensor<8x112x32x32xbf16>  , %arg25: tensor<112x112x32x32xbf16>, %arg26: tensor<3584xbf16>, %arg27: tensor<8x112x32x32xbf16> , %arg28: tensor<112x112x32x32xbf16>, %arg29: tensor<3584xbf16>, %arg30: tensor<8x112x32x32xbf16>  ) -> tensor<8x112x32x32xbf16> {
+func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg3 : tensor<8x112x32x32xbf16>) {
+
+  // Zero initialized output buffer for GEMMs
+  %zero = arith.constant 0.000000e+00 : bf16
+  %init_shape = tensor.empty() : tensor<8x112x32x32xbf16>
+  %zero_init = linalg.fill ins(%zero : bf16) outs(%init_shape : tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> 
+
+  // Use the same weights and biases for all the layers due to the extremely high memory
+  // usage of MLIR dense constants
+  // TODO: replace with different constants for each layer when memory issues are fixed
+  %weights = arith.constant dense<0.01> : tensor<112x112x32x32xbf16>
+  %bias = arith.constant dense<0.02> : tensor<3584xbf16>
+
+  // Empty tensor to indicate shape of the output buffer
+  %out_shape = tensor.empty() : tensor<8x112x32x32xbf16>
+
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %expanded : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg3 : tensor<8x112x32x32xbf16>) {
+  %expanded = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%0, %expanded : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<8x112x32x32xbf16>) outs(%arg3 : tensor<8x112x32x32xbf16>) {
+  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%2 : tensor<8x112x32x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%3, %arg4 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg6 : tensor<8x112x32x32xbf16>) {
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%3, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded2 = tensor.expand_shape %arg5 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4, %expanded2 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg6 : tensor<8x112x32x32xbf16>) {
+  %expanded2 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%4, %expanded2 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %7 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%6 : tensor<8x112x32x32xbf16>) outs(%arg6 : tensor<8x112x32x32xbf16>) {
+  %7 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%6 : tensor<8x112x32x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-  %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%7, %arg7 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg9 : tensor<8x112x32x32xbf16>) {
+  %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%7, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded3 = tensor.expand_shape %arg8 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %10 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%8, %expanded3 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg9 : tensor<8x112x32x32xbf16>) {
+  %expanded3 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %10 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%8, %expanded3 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %11 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10 : tensor<8x112x32x32xbf16>) outs(%arg9 : tensor<8x112x32x32xbf16>) {
+  %11 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%10 : tensor<8x112x32x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-   %12 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%11, %arg10 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg12 : tensor<8x112x32x32xbf16>) {
+   %12 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%11, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded4 = tensor.expand_shape %arg11 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %14 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%12, %expanded4 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg12 : tensor<8x112x32x32xbf16>) {
+  %expanded4 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %14 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%12, %expanded4 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %15 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%14 : tensor<8x112x32x32xbf16>) outs(%arg12 : tensor<8x112x32x32xbf16>) {
+  %15 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%14 : tensor<8x112x32x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-  %16 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%15, %arg13 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg15 : tensor<8x112x32x32xbf16>) {
+  %16 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%15, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded5 = tensor.expand_shape %arg14 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %18 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%16, %expanded5 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg15 : tensor<8x112x32x32xbf16>) {
+  %expanded5 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %18 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%16, %expanded5 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %19 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%18 : tensor<8x112x32x32xbf16>) outs(%arg15 : tensor<8x112x32x32xbf16>) {
+  %19 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%18 : tensor<8x112x32x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-   %20 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%19, %arg16 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg18 : tensor<8x112x32x32xbf16>) {
+   %20 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%19, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded6 = tensor.expand_shape %arg17 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %22 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%20, %expanded6 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg18 : tensor<8x112x32x32xbf16>) {
+  %expanded6 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %22 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%20, %expanded6 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %23 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%22 : tensor<8x112x32x32xbf16>) outs(%arg18 : tensor<8x112x32x32xbf16>) {
+  %23 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%22 : tensor<8x112x32x32xbf16>)
+    outs(%out_shape : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-  %24 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%23, %arg19 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg21 : tensor<8x112x32x32xbf16>) {
+  %24 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%23, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded7 = tensor.expand_shape %arg20 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %26 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%24, %expanded7 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg21 : tensor<8x112x32x32xbf16>) {
+  %expanded7 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %26 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%24, %expanded7 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %27 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%26 : tensor<8x112x32x32xbf16>) outs(%arg21 : tensor<8x112x32x32xbf16>) {
+  %27 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%26 : tensor<8x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
 
-  %28 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%27, %arg22 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg24 : tensor<8x112x32x32xbf16>) {
+  %28 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%27, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded8 = tensor.expand_shape %arg23 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %30 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%28, %expanded8 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg24 : tensor<8x112x32x32xbf16>) {
+  %expanded8 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %30 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%28, %expanded8 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %31 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%30 : tensor<8x112x32x32xbf16>) outs(%arg24 : tensor<8x112x32x32xbf16>) {
+  %31 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%30 : tensor<8x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-  %32 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%31, %arg25 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg27 : tensor<8x112x32x32xbf16>) {
+  %32 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%31, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded9 = tensor.expand_shape %arg26 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %34 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%32, %expanded9 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg27 : tensor<8x112x32x32xbf16>) {
+  %expanded9 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %34 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%32, %expanded9 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %35 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%34 : tensor<8x112x32x32xbf16>) outs(%arg27 : tensor<8x112x32x32xbf16>) {
+  %35 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%34 : tensor<8x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x112x32x32xbf16>
 
-  %36 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%35, %arg28 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>) outs(%arg30 : tensor<8x112x32x32xbf16>) {
+  %36 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+    ins(%35, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded10 = tensor.expand_shape %arg29 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
-  %38 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%36, %expanded10 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>) outs(%arg30 : tensor<8x112x32x32xbf16>) {
+  %expanded10 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %38 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%36, %expanded10 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %39 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%38 : tensor<8x112x32x32xbf16>) outs(%arg30 : tensor<8x112x32x32xbf16>) {
+  %39 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%38 : tensor<8x112x32x32xbf16>)
+    outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16

--- a/include/TPP/BuilderUtils.h
+++ b/include/TPP/BuilderUtils.h
@@ -5,8 +5,8 @@
 #ifndef TPP_BUILDER_UTILS_H
 #define TPP_BUILDER_UTILS_H
 
-#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 
 #include "TPP/TensorInit.h"
 
@@ -32,7 +32,8 @@ func::FuncOp createFunction(OpBuilder &builder, ModuleOp module,
                             TypeRange ret);
 
 // Create a local dense tensor
-Value createDenseTensor(OpBuilder &, TensorInitType, TensorType, int);
+Value createDenseTensor(OpBuilder &, TensorInitType, TensorType, int,
+                        std::optional<ModuleOp> module = std::nullopt);
 
 // Create a global dense memref
 Value createDenseMemref(OpBuilder &, ModuleOp, TensorInitType, MemRefType, int);

--- a/include/TPP/BuilderUtils.h
+++ b/include/TPP/BuilderUtils.h
@@ -31,7 +31,8 @@ func::FuncOp createFunction(OpBuilder &builder, ModuleOp module,
                             llvm::StringRef name, TypeRange args,
                             TypeRange ret);
 
-// Create a local dense tensor
+// Create a local constant dense tensor
+// When a module is passed, create a writable global dense tensor instead
 Value createDenseTensor(OpBuilder &, TensorInitType, TensorType, int,
                         std::optional<ModuleOp> module = std::nullopt);
 

--- a/include/TPP/BuilderUtils.h
+++ b/include/TPP/BuilderUtils.h
@@ -32,9 +32,7 @@ func::FuncOp createFunction(OpBuilder &builder, ModuleOp module,
                             TypeRange ret);
 
 // Create a local constant dense tensor
-// When a module is passed, create a writable global dense tensor instead
-Value createDenseTensor(OpBuilder &, TensorInitType, TensorType, int,
-                        std::optional<ModuleOp> module = std::nullopt);
+Value createDenseTensor(OpBuilder &, TensorInitType, TensorType, int);
 
 // Create a global dense memref
 Value createDenseMemref(OpBuilder &, ModuleOp, TensorInitType, MemRefType, int);

--- a/lib/TPP/BuilderUtils.cpp
+++ b/lib/TPP/BuilderUtils.cpp
@@ -1,4 +1,5 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -6,6 +7,8 @@
 #include "mlir/IR/BuiltinOps.h"
 
 #include "TPP/BuilderUtils.h"
+
+#include <optional>
 
 namespace mlir {
 
@@ -27,8 +30,7 @@ arith::ConstantOp getConstant(OpBuilder &builder, Type type, ValueT value) {
 func::FuncOp createFunction(OpBuilder &builder, ModuleOp module, StringRef name,
                             TypeRange args, TypeRange ret) {
   auto unkLoc = builder.getUnknownLoc();
-  auto funcType =
-      FunctionType::get(builder.getContext(), args, ret);
+  auto funcType = FunctionType::get(builder.getContext(), args, ret);
   auto func = func::FuncOp::create(unkLoc, name, funcType);
   func.setVisibility(SymbolTable::Visibility::Public);
   auto *entryBlock = func.addEntryBlock();
@@ -40,25 +42,25 @@ func::FuncOp createFunction(OpBuilder &builder, ModuleOp module, StringRef name,
 
 Value getConstInt(OpBuilder &builder, int value, int width) {
   switch (width) {
-    case 32:
-      return getConstant(builder, builder.getI32Type(), value);
-    case 64:
-      return getConstant(builder, builder.getI64Type(), value);
-    default:
-      assert(false && "Invalid constant integer size");
+  case 32:
+    return getConstant(builder, builder.getI32Type(), value);
+  case 64:
+    return getConstant(builder, builder.getI64Type(), value);
+  default:
+    assert(false && "Invalid constant integer size");
   }
 }
 
 Value getConstFloat(OpBuilder &builder, float value, int width) {
   switch (width) {
-    case 16:
-      return getConstant(builder, builder.getBF16Type(), value);
-    case 32:
-      return getConstant(builder, builder.getF32Type(), value);
-    case 64:
-      return getConstant(builder, builder.getF64Type(), value);
-    default:
-      assert(false && "Invalid constant float size");
+  case 16:
+    return getConstant(builder, builder.getBF16Type(), value);
+  case 32:
+    return getConstant(builder, builder.getF32Type(), value);
+  case 64:
+    return getConstant(builder, builder.getF64Type(), value);
+  default:
+    assert(false && "Invalid constant float size");
   }
 }
 
@@ -67,11 +69,24 @@ Value getConstIndex(OpBuilder &builder, int value) {
 }
 
 Value createDenseTensor(OpBuilder &builder, TensorInitType initType,
-                        TensorType type, int seed) {
+                        TensorType type, int seed,
+                        std::optional<ModuleOp> module) {
   auto unkLoc = builder.getUnknownLoc();
+
+  if (module) {
+    auto memrefType = MemRefType::get(type.getShape(), type.getElementType());
+    auto data = createDenseMemref(builder, *module, initType, memrefType, seed);
+    return builder.create<bufferization::ToTensorOp>(
+        unkLoc, data, /*restrict=*/true, /*writable=*/true);
+  }
+
   auto init = getTensorInit(initType, type.getElementType(), seed);
   auto floatInit = init->get(type);
-  return builder.create<arith::ConstantOp>(unkLoc, type, floatInit);
+  auto initVal = builder.create<arith::ConstantOp>(unkLoc, type, floatInit);
+  auto outBuf = builder.create<tensor::EmptyOp>(unkLoc, type, ValueRange{});
+  return builder
+      .create<linalg::CopyOp>(unkLoc, initVal.getResult(), outBuf.getResult())
+      .getResultTensors()[0];
 }
 
 Value createDenseMemref(OpBuilder &builder, ModuleOp module,
@@ -80,32 +95,31 @@ Value createDenseMemref(OpBuilder &builder, ModuleOp module,
   StringRef globalName;
   // First create the global
   {
-      OpBuilder::InsertionGuard guard(builder);
-      builder.setInsertionPointToStart(&module->getRegions().front().front());
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(&module->getRegions().front().front());
 
-      // Simple auto increment
-      static unsigned order = 0;
+    // Simple auto increment
+    static unsigned order = 0;
 
-      // Create global dense memrefs (Module insertion point)
-      auto privAttr = builder.getStringAttr("private");
+    // Create global dense memrefs (Module insertion point)
+    auto privAttr = builder.getStringAttr("private");
 
-      // Auto incremental naming system
-      std::string name = "__wrapper_" + std::to_string(order++);
+    // Auto incremental naming system
+    std::string name = "__wrapper_" + std::to_string(order++);
 
-      auto alignment = builder.getIntegerAttr(builder.getI64Type(), 128);
-      auto init = getTensorInit(initType, type.getElementType(), seed);
-      auto floatInit = init->get(type);
+    auto alignment = builder.getIntegerAttr(builder.getI64Type(), 128);
+    auto init = getTensorInit(initType, type.getElementType(), seed);
+    auto floatInit = init->get(type);
 
-      // Create the global object in the Module's region
-      auto global = builder.create<memref::GlobalOp>(
-          unkLoc, StringRef(name), privAttr, type, floatInit,
-          /*constant=*/false, alignment);
-      globalName = global.getName();
+    // Create the global object in the Module's region
+    auto global = builder.create<memref::GlobalOp>(
+        unkLoc, StringRef(name), privAttr, type, floatInit,
+        /*constant=*/false, alignment);
+    globalName = global.getName();
   }
   // Get the created global value and use it
   // as an input to the kernel
   auto nameAttr = builder.getStringAttr(globalName);
-  return builder.create<memref::GetGlobalOp>(
-                         unkLoc, type, nameAttr);
+  return builder.create<memref::GetGlobalOp>(unkLoc, type, nameAttr);
 }
 } // namespace mlir

--- a/lib/TPP/BuilderUtils.cpp
+++ b/lib/TPP/BuilderUtils.cpp
@@ -82,11 +82,7 @@ Value createDenseTensor(OpBuilder &builder, TensorInitType initType,
 
   auto init = getTensorInit(initType, type.getElementType(), seed);
   auto floatInit = init->get(type);
-  auto initVal = builder.create<arith::ConstantOp>(unkLoc, type, floatInit);
-  auto outBuf = builder.create<tensor::EmptyOp>(unkLoc, type, ValueRange{});
-  return builder
-      .create<linalg::CopyOp>(unkLoc, initVal.getResult(), outBuf.getResult())
-      .getResultTensors()[0];
+  return builder.create<arith::ConstantOp>(unkLoc, type, floatInit);
 }
 
 Value createDenseMemref(OpBuilder &builder, ModuleOp module,

--- a/lib/TPP/BuilderUtils.cpp
+++ b/lib/TPP/BuilderUtils.cpp
@@ -1,5 +1,4 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -69,17 +68,8 @@ Value getConstIndex(OpBuilder &builder, int value) {
 }
 
 Value createDenseTensor(OpBuilder &builder, TensorInitType initType,
-                        TensorType type, int seed,
-                        std::optional<ModuleOp> module) {
+                        TensorType type, int seed) {
   auto unkLoc = builder.getUnknownLoc();
-
-  if (module) {
-    auto memrefType = MemRefType::get(type.getShape(), type.getElementType());
-    auto data = createDenseMemref(builder, *module, initType, memrefType, seed);
-    return builder.create<bufferization::ToTensorOp>(
-        unkLoc, data, /*restrict=*/true, /*writable=*/true);
-  }
-
   auto init = getTensorInit(initType, type.getElementType(), seed);
   auto floatInit = init->get(type);
   return builder.create<arith::ConstantOp>(unkLoc, type, floatInit);

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -27,6 +27,7 @@ func.func @entry(%input: tensor<4x2xf32>) {
   return
 }
 // Constants
+// SPLAT-DAG: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // SPLAT-LABEL: @_entry
 // SPLAT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // SPLAT: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
@@ -36,9 +37,10 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // SPLAT: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // SPLAT-LABEL: @entry
-// SPLAT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
+// SPLAT: memref.get_global @__wrapper_0
 
 // Constants
+// RANDOM-NOT: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // RANDOM-LABEL: @_entry
 // RANDOM: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
@@ -48,9 +50,10 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // RANDOM: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // RANDOM-LABEL: @entry
-// RANDOM-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
+// RANDOM: memref.get_global @__wrapper_0
 
 // Constants
+// RANDOM-SPLAT-NOT: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-LABEL: @_entry
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
@@ -60,7 +63,7 @@ func.func @entry(%input: tensor<4x2xf32>) {
 // RANDOM-SPLAT: arith.constant dense<0> : tensor<4x8xi32>
 // Input
 // RANDOM-SPLAT-LABEL: @entry
-// RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<4x2xf32>
+// RANDOM-SPLAT: memref.get_global @__wrapper_0
 
 // OPT-CONST-LABEL: @_entry
 // OPT-CONST: arith.constant dense<1.000000e+00> : tensor<2x16xf32>

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -168,19 +168,19 @@ LogicalResult MLIRBench::createKernelArgs() {
   builder.setInsertionPointToStart(&mainBody);
 
   for (auto &ty : kernel.getArgumentTypes()) {
-    auto arg =
-        TypeSwitch<Type, llvm::Optional<Value>>(ty)
-            .Case<MemRefType>([&](auto memRefTy) {
-              // Create a memref global
-              return createDenseMemref(builder, module, initType, memRefTy,
-                                       seed);
-            })
-            .Case<TensorType>([&](auto tensorTy) {
-              // Create a dense const tensor and use it directly
-              // as an input to the kernel
-              return createDenseTensor(builder, initType, tensorTy, seed);
-            })
-            .Default([&](auto t) { return std::nullopt; });
+    auto arg = TypeSwitch<Type, llvm::Optional<Value>>(ty)
+                   .Case<MemRefType>([&](auto memRefTy) {
+                     // Create a memref global
+                     return createDenseMemref(builder, module, initType,
+                                              memRefTy, seed);
+                   })
+                   .Case<TensorType>([&](auto tensorTy) {
+                     // Create a dense const tensor and use it directly
+                     // as an input to the kernel
+                     return createDenseTensor(builder, initType, tensorTy, seed,
+                                              module);
+                   })
+                   .Default([&](auto t) { return std::nullopt; });
 
     if (!arg)
       return failure();


### PR DESCRIPTION
Generated tensors used for benchmark kernel function arguments are now writable.
This enables use of destination passing for benchmark kernels and the benchmarking framework behavior consistent for both memrefs and tensors. Making tensor globals writable avoids creation of allocs and copies for arguments which are written into by a kernel function.

Additionally, 10 layer MLP benchmark is refactored to minimize number of passed kernel arguments due to high runtime memory consumption (see issue #409).

Work towards #488 
