### PR TITLE
Increase benchmark iterations for stability

### DIFF
--- a/benchmarks/mlir/gemm-bf16-3layers-1024.mlir
+++ b/benchmarks/mlir/gemm-bf16-3layers-1024.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) x 3

--- a/benchmarks/mlir/gemm-bf16_dp2-3layers-1024.mlir
+++ b/benchmarks/mlir/gemm-bf16_dp2-3layers-1024.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -element-wise-fusion |
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) x 3

--- a/benchmarks/mlir/gemm-bf16_dp4-3layers-1024.mlir
+++ b/benchmarks/mlir/gemm-bf16_dp4-3layers-1024.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -element-wise-fusion |
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) x 3

--- a/benchmarks/mlir/gemm-fp32-3layers-1024-unpacked.mlir
+++ b/benchmarks/mlir/gemm-fp32-3layers-1024-unpacked.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3

--- a/benchmarks/mlir/gemm-fp32-3layers-1024.mlir
+++ b/benchmarks/mlir/gemm-fp32-3layers-1024.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) x 3

--- a/benchmarks/mlir/matmul_48x64x96.mlir
+++ b/benchmarks/mlir/matmul_48x64x96.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void -print \
 //
 // Total flops = O(2*n*k*m) = 2*48x96x64 = 589824

--- a/benchmarks/mlir/matmul_64x48x96.mlir
+++ b/benchmarks/mlir/matmul_64x48x96.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void -print \
 //
 // Total flops = O(2*n*k*m) = 2*64x96x48 = 589824

--- a/benchmarks/mlir/matmul_64x64x64.mlir
+++ b/benchmarks/mlir/matmul_64x64x64.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void -print \
 //
 // Total flops = O(2*n*k*m) = 2*64x64x64 = 524288

--- a/benchmarks/mlir/mlp-bf16-10layers-3584.mlir
+++ b/benchmarks/mlir/mlp-bf16-10layers-3584.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 10

--- a/benchmarks/mlir/mlp-bf16-3layers-1024-unpacked.mlir
+++ b/benchmarks/mlir/mlp-bf16-3layers-1024-unpacked.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3

--- a/benchmarks/mlir/mlp-bf16-3layers-1024.mlir
+++ b/benchmarks/mlir/mlp-bf16-3layers-1024.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3

--- a/benchmarks/mlir/mlp-bf16_dp2-3layers-1024.mlir
+++ b/benchmarks/mlir/mlp-bf16_dp2-3layers-1024.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -element-wise-fusion |
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3

--- a/benchmarks/mlir/mlp-bf16_dp4-3layers-1024.mlir
+++ b/benchmarks/mlir/mlp-bf16_dp4-3layers-1024.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -element-wise-fusion |
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3

--- a/benchmarks/mlir/mlp-fp32-1layer-512.mlir
+++ b/benchmarks/mlir/mlp-fp32-1layer-512.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void -print \
 //
 // Total flops = broadcast O(n*m) + matmul O(2*n*m*k) + ReLU (O(n*m)

--- a/benchmarks/mlir/mlp-fp32-3layers-1024.mlir
+++ b/benchmarks/mlir/mlp-fp32-3layers-1024.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s -n 1000 \
 // RUN:  -e entry -entry-point-result=void
 
 // Total flops = matmul O(2*n*m*k) + BiasAdd (n*m) + ReLU (O(n*m) x 3


### PR DESCRIPTION
Should have done this a long time ago. Isn't meant to fix anything, but we need to start running these benchmarks more seriously.

This will increase the benchmark job's time, but it's needed. We can clean up some benchmarks if that becomes a problem.