### PR TITLE
Move `tensor.pack` simplification in its own pass (NFC)

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -110,6 +110,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertForAllToParallelOpPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createHeapToStackPass(unsigned maxAllocSizeInBytes = 4096);
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSimplifyAndCanonicalizePackPass();
 
 void registerTestStructuralMatchers();
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -104,7 +104,6 @@ def CombineTppOps : Pass<"combine-tpp", "func::FuncOp"> {
   let dependentDialects = ["func::FuncDialect", "memref::MemRefDialect"];
 }
 
-
 def TransformDropSchedulePass : Pass<"transform-drop-schedule", "ModuleOp"> {
   let summary = "Drop the transform schedule";
   let constructor = "mlir::tpp::createTransformDropSchedulePass()";
@@ -257,10 +256,13 @@ def PropagatePackUnPack : Pass<"propagate-pack-and-unpack", "func::FuncOp"> {
   let constructor = "mlir::tpp::createPropagatePackUnPackPass()"; 
 }
 
-def SimplifyAndCanonicalizePack : Pass<"simplify-and-canonicalize-pack",
-                                       "func::FuncOp"> {
+def SimplifyAndCanonicalizePack : Pass<"simplify-pack", "func::FuncOp"> {
   let summary = "Simplify and canonicalize tensor.pack";
   let constructor = "mlir::tpp::createSimplifyAndCanonicalizePackPass()";
+  let description = [{
+    Apply `tensor.pack` and `tensor.unpack` canonicalization and simplification
+    patterns.
+  }];
 }
 
 def ConstantFoldPack : Pass<"constant-fold-pack", "ModuleOp"> {

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -257,6 +257,12 @@ def PropagatePackUnPack : Pass<"propagate-pack-and-unpack", "func::FuncOp"> {
   let constructor = "mlir::tpp::createPropagatePackUnPackPass()"; 
 }
 
+def SimplifyAndCanonicalizePack : Pass<"simplify-and-canonicalize-pack",
+                                       "func::FuncOp"> {
+  let summary = "Simplify and canonicalize tensor.pack";
+  let constructor = "mlir::tpp::createSimplifyAndCanonicalizePackPass()";
+}
+
 def ConstantFoldPack : Pass<"constant-fold-pack", "ModuleOp"> {
   let summary = "Constant fold tensor.pack";
   let description = [{

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -273,9 +273,8 @@ private:
     // mess up tensor producer-consumer chains used for analysis in the
     // following passes.
     pm.addPass(createPropagatePackUnPackPass());
-    pm.addPass(createCanonicalizerPass());
     pm.addPass(createConstantFoldPackPass());
-    pm.addPass(createCanonicalizerPass());
+    pm.addPass(createSimplifyAndCanonicalizePackPass());
 
     pm.addPass(createTileConsumerAndFuseProducersPass());
     pm.addPass(createCleanupPass());

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -490,9 +490,10 @@ fuseWithEltwise(RewriterBase &rewriter, TilingInterface consumer,
   scf::SCFTileAndFuseResult tileAndFuseResult;
   FailureOr<scf::SCFTilingResult> tilingResult =
       tileConsumer(rewriter, consumer, tileSizes);
-  if (failed(tilingResult))
+  if (failed(tilingResult)) {
     return rewriter.notifyMatchFailure(consumer,
                                        "failed to tile base operation");
+  }
   for (auto *tiledOp : tilingResult->tiledOps) {
     tileAndFuseResult.tiledAndFusedOps.insert(tiledOp);
     alreadyFusedOps.insert(tiledOp);

--- a/test/Passes/pack-unpack-propagation.mlir
+++ b/test/Passes/pack-unpack-propagation.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -propagate-pack-and-unpack -simplify-and-canonicalize-pack -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -propagate-pack-and-unpack -simplify-pack -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>

--- a/test/Passes/pack-unpack-propagation.mlir
+++ b/test/Passes/pack-unpack-propagation.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -propagate-pack-and-unpack -canonicalize -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -propagate-pack-and-unpack -simplify-and-canonicalize-pack -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>


### PR DESCRIPTION
Avoid entanglement. Also not all the patterns were running simplification.
Make simplification and canonicalization of tensor.pack a standalone pass.