### PR TITLE
Fix bf16_dp4 maps

### DIFF
--- a/benchmarks/mlir/gemm-bf16_dp4-3layers-1024.mlir
+++ b/benchmarks/mlir/gemm-bf16_dp4-3layers-1024.mlir
@@ -7,28 +7,34 @@
 // BENCH_TOTAL_FLOPS: 1610612736
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
-#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
 func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg3: tensor<8x32x32x32xbf16>, %arg6: tensor<8x32x32x32xbf16>, %arg9: tensor<8x32x32x32xbf16> ) -> tensor<8x32x32x32xbf16> {
   %arg1 = arith.constant dense<0.01> : tensor<32x32x8x32x4xbf16>
   %arg4 = arith.constant dense<0.02> : tensor<32x32x8x32x4xbf16>
   %arg7 = arith.constant dense<0.03> : tensor<32x32x8x32x4xbf16>
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
+  outs(%arg3 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
 
-  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%0, %arg4 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>) outs(%arg6 : tensor<8x32x32x32xbf16>) {
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%0, %arg4 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
+  outs(%arg6 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
 
-  %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%4, %arg7 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>) outs(%arg9 : tensor<8x32x32x32xbf16>) {
+  %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%4, %arg7 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
+  outs(%arg9 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16

--- a/benchmarks/mlir/mlp-bf16_dp4-3layers-1024.mlir
+++ b/benchmarks/mlir/mlp-bf16_dp4-3layers-1024.mlir
@@ -7,7 +7,7 @@
 // BENCH_TOTAL_FLOPS: 1072168960
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
-#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
@@ -21,7 +21,9 @@ func.func @entry(%arg0: tensor<8x32x32x32xbf16>,
                   %arg7: tensor<32x32x8x32x4xbf16>,
                   %arg8: tensor<1024xbf16> ) -> tensor<8x32x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
+  outs(%arg3 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
@@ -29,7 +31,8 @@ func.func @entry(%arg0: tensor<8x32x32x32xbf16>,
   } -> tensor<8x32x32x32xbf16>
   %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<1024xbf16> into tensor<32x32xbf16>
   %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-  ins(%0, %expanded : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
+  ins(%0, %expanded : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>)
+  outs(%arg3 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
@@ -43,39 +46,51 @@ func.func @entry(%arg0: tensor<8x32x32x32xbf16>,
 
   %arg6_buf = tensor.empty(): tensor<8x32x32x32xbf16>
   %arg6 = linalg.fill ins(%cst:bf16) outs(%arg6_buf:tensor<8x32x32x32xbf16>)->tensor<8x32x32x32xbf16>
-  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%3, %arg4 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>) outs(%arg6 : tensor<8x32x32x32xbf16>) {
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%3, %arg4 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
+  outs(%arg6 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
   %expanded2 = tensor.expand_shape %arg5 [[0, 1]] : tensor<1024xbf16> into tensor<32x32xbf16>
-  %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4, %expanded2 : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>) outs(%arg6 : tensor<8x32x32x32xbf16>) {
+  %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%4, %expanded2 : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>)
+  outs(%arg6 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
-  %7 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%6 : tensor<8x32x32x32xbf16>) outs(%arg6 : tensor<8x32x32x32xbf16>) {
+  %7 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%6 : tensor<8x32x32x32xbf16>)
+  outs(%arg6 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
   } -> tensor<8x32x32x32xbf16>
 
   %arg9_buf = tensor.empty(): tensor<8x32x32x32xbf16>
-  %arg9 = linalg.fill ins(%cst:bf16) outs(%arg9_buf:tensor<8x32x32x32xbf16>)->tensor<8x32x32x32xbf16>
-  %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%7, %arg7 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>) outs(%arg9 : tensor<8x32x32x32xbf16>) {
+  %arg9 = linalg.fill ins(%cst:bf16)outs(%arg9_buf:tensor<8x32x32x32xbf16>)->tensor<8x32x32x32xbf16>
+  %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%7, %arg7 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
+  outs(%arg9 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
   %expanded3 = tensor.expand_shape %arg8 [[0, 1]] : tensor<1024xbf16> into tensor<32x32xbf16>
-  %10 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%8, %expanded3 : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>) outs(%arg9 : tensor<8x32x32x32xbf16>) {
+  %10 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%8, %expanded3 : tensor<8x32x32x32xbf16>, tensor<32x32xbf16>)
+  outs(%arg9 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<8x32x32x32xbf16>
-  %11 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%10 : tensor<8x32x32x32xbf16>) outs(%arg9 : tensor<8x32x32x32xbf16>) {
+  %11 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  ins(%10 : tensor<8x32x32x32xbf16>)
+  outs(%arg9 : tensor<8x32x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16


### PR DESCRIPTION
Fixes incorrect dimension size in maps of bf16_dp4 benchmarks.
Plus a small refactor to make IR more readable.