### PR TITLE
Add more GEMM benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if (NOT TPP_INSIDE_IREE)
     ${CONFIG_DIR}/matmul/256x1024x1024.json
     ${CONFIG_DIR}/matmul/256x1024x4096.json
     ${CONFIG_DIR}/matmul/256x4096x1024.json
+    ${CONFIG_DIR}/matmul/128x1024x4096.json
   )
   string(JOIN ',' PERF_CFGS_STR ${PERF_CFGS})
   add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ if (NOT TPP_INSIDE_IREE)
     ${CONFIG_DIR}/matmul/256x1024x4096.json
     ${CONFIG_DIR}/matmul/256x4096x1024.json
     ${CONFIG_DIR}/matmul/128x1024x4096.json
+    ${CONFIG_DIR}/matmul/128x4096x1024.json
   )
   string(JOIN ',' PERF_CFGS_STR ${PERF_CFGS})
   add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,13 @@ if (NOT TPP_INSIDE_IREE)
                     WORKING_DIRECTORY ${BENCHMARK_DIR}
                     COMMENT Run Quick Benchmarks)
 
+  # Run performance benchmarks with small iterations to test the benchmarks and run locally on small machines
+  add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
+    -c ${CONFIG_DIR}/matmul/256x1024x1024.json,${CONFIG_DIR}/matmul/256x1024x4096.json
+                    DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
+                    WORKING_DIRECTORY ${BENCHMARK_DIR}
+                    COMMENT Run Quick Performance Benchmarks)
+
   # Run baseline benchmarks with default iterations to track simple performance
   add_custom_target(benchmarks ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR}
     -c ${CONFIG_DIR}/base/base.json,${CONFIG_DIR}/omp/dnn-fp32.json,${CONFIG_DIR}/omp/dnn-bf16.json,${CONFIG_DIR}/omp/mlir-fp32.json,${CONFIG_DIR}/omp/mlir-bf16.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if (NOT TPP_INSIDE_IREE)
     ${CONFIG_DIR}/matmul/256x4096x1024.json
     ${CONFIG_DIR}/matmul/128x1024x4096.json
     ${CONFIG_DIR}/matmul/128x4096x1024.json
+    ${CONFIG_DIR}/matmul/128x1024x1024.json
   )
   string(JOIN ',' PERF_CFGS_STR ${PERF_CFGS})
   add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,16 @@ if (NOT TPP_INSIDE_IREE)
                     COMMENT Run Quick Performance Benchmarks)
 
   # Run baseline benchmarks with default iterations to track simple performance
+  set(BENCH_CFGS
+    ${CONFIG_DIR}/base/base.json
+    ${CONFIG_DIR}/omp/dnn-fp32.json
+    ${CONFIG_DIR}/omp/dnn-bf16.json
+    ${CONFIG_DIR}/omp/mlir-fp32.json
+    ${CONFIG_DIR}/omp/mlir-bf16.json
+  )
+  string(JOIN ',' BENCH_CFGS_STR ${BENCH_CFGS})
   add_custom_target(benchmarks ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR}
-    -c ${CONFIG_DIR}/base/base.json,${CONFIG_DIR}/omp/dnn-fp32.json,${CONFIG_DIR}/omp/dnn-bf16.json,${CONFIG_DIR}/omp/mlir-fp32.json,${CONFIG_DIR}/omp/mlir-bf16.json
+    -c ${BENCH_CFGS_STR}
                     DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
                     WORKING_DIRECTORY ${BENCHMARK_DIR}
                     COMMENT Run Benchmarks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if (NOT TPP_INSIDE_IREE)
 
   # Run performance benchmarks with small iterations to test the benchmarks and run locally on small machines
   add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
-    -c ${CONFIG_DIR}/matmul/256x1024x1024.json,${CONFIG_DIR}/matmul/256x1024x4096.json
+    -c ${CONFIG_DIR}/matmul/256x1024x1024.json,${CONFIG_DIR}/matmul/256x1024x4096.json,${CONFIG_DIR}/matmul/256x4096x1024.json
                     DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
                     WORKING_DIRECTORY ${BENCHMARK_DIR}
                     COMMENT Run Quick Performance Benchmarks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,14 @@ if (NOT TPP_INSIDE_IREE)
                     COMMENT Run Quick Benchmarks)
 
   # Run performance benchmarks with small iterations to test the benchmarks and run locally on small machines
+  set(PERF_CFGS
+    ${CONFIG_DIR}/matmul/256x1024x1024.json
+    ${CONFIG_DIR}/matmul/256x1024x4096.json
+    ${CONFIG_DIR}/matmul/256x4096x1024.json
+  )
+  string(JOIN ',' PERF_CFGS_STR ${PERF_CFGS})
   add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
-    -c ${CONFIG_DIR}/matmul/256x1024x1024.json,${CONFIG_DIR}/matmul/256x1024x4096.json,${CONFIG_DIR}/matmul/256x4096x1024.json
+    -c ${PERF_CFGS_STR}
                     DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
                     WORKING_DIRECTORY ${BENCHMARK_DIR}
                     COMMENT Run Quick Performance Benchmarks)

--- a/benchmarks/config/matmul/128x1024x1024.json
+++ b/benchmarks/config/matmul/128x1024x1024.json
@@ -1,0 +1,87 @@
+[
+  {
+  "matmul_128x1024x1024_fp32_dnn": {
+    "matmul_fp32_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x1024_bf16_dnn": {
+    "matmul_bf16_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x1024_fp32_mlir": {
+    "matmul_fp32_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-128x1024x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-128x1024x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x1024_bf16_dp2_mlir": {
+    "matmul_bf16_dp2_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-128x1024x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_dp2_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-128x1024x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x1024_bf16_dp4_mlir": {
+    "matmul_bf16_dp4_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-128x1024x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(svebf16)" ]
+    },
+    "matmul_bf16_dp4_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-128x1024x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(svebf16)" ]
+    }
+  }}
+]

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -1,0 +1,87 @@
+[
+  {
+  "matmul_128x1024x4096_fp32_dnn": {
+    "matmul_fp32_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x4096_bf16_dnn": {
+    "matmul_bf16_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x4096_fp32_mlir": {
+    "matmul_fp32_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-128x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-128x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x4096_bf16_dp2_mlir": {
+    "matmul_bf16_dp2_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-128x1024x4096.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_dp2_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-128x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x1024x4096_bf16_dp4_mlir": {
+    "matmul_bf16_dp4_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-128x1024x4096.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(svebf16)" ]
+    },
+    "matmul_bf16_dp4_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-128x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(svebf16)" ]
+    }
+  }}
+]

--- a/benchmarks/config/matmul/128x4096x1024.json
+++ b/benchmarks/config/matmul/128x4096x1024.json
@@ -1,0 +1,87 @@
+[
+  {
+  "matmul_128x4096x1024_fp32_dnn": {
+    "matmul_fp32_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x4096x1024_bf16_dnn": {
+    "matmul_bf16_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x4096x1024_fp32_mlir": {
+    "matmul_fp32_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-128x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-128x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x4096x1024_bf16_dp2_mlir": {
+    "matmul_bf16_dp2_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-128x4096x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_dp2_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-128x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_128x4096x1024_bf16_dp4_mlir": {
+    "matmul_bf16_dp4_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-128x4096x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(svebf16)" ]
+    },
+    "matmul_bf16_dp4_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-128x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(svebf16)" ]
+    }
+  }}
+]

--- a/benchmarks/config/matmul/256x1024x4096.json
+++ b/benchmarks/config/matmul/256x1024x4096.json
@@ -1,0 +1,87 @@
+[
+  {
+  "matmul_256x1024x4096_fp32_dnn": {
+    "matmul_fp32_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "4096", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "4096", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x1024x4096_bf16_dnn": {
+    "matmul_bf16_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "4096", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "4096", "1024" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x1024x4096_fp32_mlir": {
+    "matmul_fp32_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-256x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-256x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x1024x4096_bf16_dp2_mlir": {
+    "matmul_bf16_dp2_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-256x1024x4096.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_dp2_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-256x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x1024x4096_bf16_dp4_mlir": {
+    "matmul_bf16_dp4_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-256x1024x4096.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(svebf16)" ]
+    },
+    "matmul_bf16_dp4_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-256x1024x4096.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(svebf16)" ]
+    }
+  }}
+]

--- a/benchmarks/config/matmul/256x4096x1024.json
+++ b/benchmarks/config/matmul/256x4096x1024.json
@@ -1,0 +1,87 @@
+[
+  {
+  "matmul_256x4096x1024_fp32_dnn": {
+    "matmul_fp32_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x4096x1024_bf16_dnn": {
+    "matmul_bf16_single_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_omp_16_dnn": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x4096x1024_fp32_mlir": {
+    "matmul_fp32_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-256x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "1" },
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_fp32_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-fp32-256x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x4096x1024_bf16_dp2_mlir": {
+    "matmul_bf16_dp2_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-256x4096x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "matmul_bf16_dp2_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp2-256x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "matmul_256x4096x1024_bf16_dp4_mlir": {
+    "matmul_bf16_dp4_single_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-256x4096x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(svebf16)" ]
+    },
+    "matmul_bf16_dp4_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "matmul/matmul-bf16-dp4-256x4096x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ "(svebf16)" ]
+    }
+  }}
+]

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x1024x1024 = 268435456
+// BENCH_TOTAL_FLOPS: 268435456
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<4x32x32x32xbf16>
+!B = tensor<32x32x16x32x2xbf16>
+!C = tensor<4x32x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x4096.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x1024x4096 = 1073741824
+// BENCH_TOTAL_FLOPS: 1073741824
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<4x128x32x32xbf16>
+!B = tensor<32x128x16x32x2xbf16>
+!C = tensor<4x32x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-128x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-128x4096x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x4096x1024 = 1073741824
+// BENCH_TOTAL_FLOPS: 1073741824
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<4x32x32x32xbf16>
+!B = tensor<128x32x16x32x2xbf16>
+!C = tensor<4x128x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-256x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-256x1024x4096.mlir
@@ -1,0 +1,29 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*256x1024x4096 = 2147483648
+// BENCH_TOTAL_FLOPS: 2147483648
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<8x128x32x32xbf16>
+!B = tensor<32x128x16x32x2xbf16>
+!C = tensor<8x32x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}
+

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-256x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-256x4096x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*256x4096x1024 = 2147483648
+// BENCH_TOTAL_FLOPS: 2147483648
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<8x32x32x32xbf16>
+!B = tensor<128x32x16x32x2xbf16>
+!C = tensor<8x128x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x1024x1024 = 268435456
+// BENCH_TOTAL_FLOPS: 268435456
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<4x32x32x32xbf16>
+!B = tensor<32x32x8x32x4xbf16>
+!C = tensor<4x32x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x4096.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x1024x4096 = 1073741824
+// BENCH_TOTAL_FLOPS: 1073741824
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<4x128x32x32xbf16>
+!B = tensor<32x128x8x32x4xbf16>
+!C = tensor<4x32x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-128x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-128x4096x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x4096x1024 = 1073741824
+// BENCH_TOTAL_FLOPS: 1073741824
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<4x32x32x32xbf16>
+!B = tensor<128x32x8x32x4xbf16>
+!C = tensor<4x128x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-256x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-256x1024x4096.mlir
@@ -1,0 +1,29 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*256x1024x4096 = 2147483648
+// BENCH_TOTAL_FLOPS: 2147483648
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<8x128x32x32xbf16>
+!B = tensor<32x128x8x32x4xbf16>
+!C = tensor<8x32x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}
+

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-256x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-256x4096x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*256x4096x1024 = 2147483648
+// BENCH_TOTAL_FLOPS: 2147483648
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+
+!A = tensor<8x32x32x32xbf16>
+!B = tensor<128x32x8x32x4xbf16>
+!C = tensor<8x128x32x32xbf16>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-fp32-128x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-128x1024x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x1024x1024 = 268435456
+// BENCH_TOTAL_FLOPS: 268435456
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+!A = tensor<4x32x32x32xf32>
+!B = tensor<32x32x32x32xf32>
+!C = tensor<4x32x32x32xf32>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %mul = arith.mulf %in, %in_0 : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-fp32-128x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-128x1024x4096.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x1024x4096 = 1073741824
+// BENCH_TOTAL_FLOPS: 1073741824
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+!A = tensor<4x128x32x32xf32>
+!B = tensor<32x128x32x32xf32>
+!C = tensor<4x32x32x32xf32>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %mul = arith.mulf %in, %in_0 : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-fp32-128x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-128x4096x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*128x4096x1024 = 1073741824
+// BENCH_TOTAL_FLOPS: 1073741824
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+!A = tensor<4x32x32x32xf32>
+!B = tensor<128x32x32x32xf32>
+!C = tensor<4x128x32x32xf32>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %mul = arith.mulf %in, %in_0 : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> !C
+
+  return %0 : !C
+}

--- a/benchmarks/mlir/matmul/matmul-fp32-256x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-256x1024x4096.mlir
@@ -1,0 +1,29 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*256x1024x4096 = 2147483648
+// BENCH_TOTAL_FLOPS: 2147483648
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+!A = tensor<8x128x32x32xf32>
+!B = tensor<32x128x32x32xf32>
+!C = tensor<8x32x32x32xf32>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %mul = arith.mulf %in, %in_0 : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> !C
+
+  return %0 : !C
+}
+

--- a/benchmarks/mlir/matmul/matmul-fp32-256x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-256x4096x1024.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// Total flops = matmul O(2*n*m*k)
+// 2*256x4096x1024 = 2147483648
+// BENCH_TOTAL_FLOPS: 2147483648
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+!A = tensor<8x32x32x32xf32>
+!B = tensor<128x32x32x32xf32>
+!C = tensor<8x128x32x32xf32>
+
+// GEMM packed with tile size: 32, 32, 32
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %mul = arith.mulf %in, %in_0 : f32
+      %add = arith.addf %out, %mul : f32
+      linalg.yield %add : f32
+  } -> !C
+
+  return %0 : !C
+}

--- a/scripts/buildkite/benchmark.sh
+++ b/scripts/buildkite/benchmark.sh
@@ -51,3 +51,8 @@ benchmark omp/mlir-bf16.json "OpenMP TPP-MLIR BF16"
 
 # Matmul Benchmarks
 benchmark matmul/256x1024x1024.json "Matmul 256x1024x1024"
+benchmark matmul/256x1024x4096.json "Matmul 256x1024x4096"
+benchmark matmul/256x4096x1024.json "Matmul 256x4096x1024"
+benchmark matmul/128x1024x4096.json "Matmul 128x1024x4096"
+benchmark matmul/128x4096x1024.json "Matmul 128x4096x1024"
+benchmark matmul/128x1024x1024.json "Matmul 128x1024x1024"


### PR DESCRIPTION
Adds `quick-perf` build target to quickly run performance benchmarks on local machine.
Adds more GEMM benchmarks of MxNxK shapes:
  * 256x1024x4096
  * 256x4096x1024
  * 128x1024x4096
  * 128x4096x1024
  * 128x1024x1024