### PR TITLE
Update GEMM benchmarks blocking factors

### DIFF
--- a/benchmarks/config/matmul/128x1024x1024.json
+++ b/benchmarks/config/matmul/128x1024x1024.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "1024" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "1024" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "1024" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "1024" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/config/matmul/128x4096x1024.json
+++ b/benchmarks/config/matmul/128x4096x1024.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "128", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "flags": [ "100", "128", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/config/matmul/256x1024x1024.json
+++ b/benchmarks/config/matmul/256x1024x1024.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/config/matmul/256x1024x4096.json
+++ b/benchmarks/config/matmul/256x1024x4096.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "4096", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "4096", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "4096", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "4096", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "4096", "1024" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/config/matmul/256x4096x1024.json
+++ b/benchmarks/config/matmul/256x4096x1024.json
@@ -5,14 +5,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "4096" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},
@@ -22,14 +22,14 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "4096" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "4096" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<4x32x32x32xbf16>
-!B = tensor<32x32x16x32x2xbf16>
-!C = tensor<4x32x32x32xbf16>
+!A = tensor<2x16x64x64xbf16>
+!B = tensor<16x16x32x64x2xbf16>
+!C = tensor<2x16x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-128x1024x4096.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<4x128x32x32xbf16>
-!B = tensor<32x128x16x32x2xbf16>
-!C = tensor<4x32x32x32xbf16>
+!A = tensor<2x64x64x64xbf16>
+!B = tensor<16x64x32x64x2xbf16>
+!C = tensor<2x16x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-128x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-128x4096x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<4x32x32x32xbf16>
-!B = tensor<128x32x16x32x2xbf16>
-!C = tensor<4x128x32x32xbf16>
+!A = tensor<2x16x64x64xbf16>
+!B = tensor<64x16x32x64x2xbf16>
+!C = tensor<2x64x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-256x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-256x1024x1024.mlir
@@ -9,15 +9,20 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-// GEMM 256 x 1024 x 1024 packed into 8x32 (256) x 32x32 (1024)
-func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x16x32x2xbf16>, %output: tensor<8x32x32x32xbf16>) -> tensor<8x32x32x32xbf16> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x16x32x2xbf16>) outs(%output : tensor<8x32x32x32xbf16>) {
+!A = tensor<4x16x64x64xbf16>
+!B = tensor<16x16x32x64x2xbf16>
+!C = tensor<4x16x64x64xbf16>
+
+// GEMM packed with tile size: 64, 64, 64
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
-  } -> tensor<8x32x32x32xbf16>
+  } -> !C
 
-  return %0 : tensor<8x32x32x32xbf16>
+  return %0 : !C
 }
-

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-256x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-256x1024x4096.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<8x128x32x32xbf16>
-!B = tensor<32x128x16x32x2xbf16>
-!C = tensor<8x32x32x32xbf16>
+!A = tensor<4x64x64x64xbf16>
+!B = tensor<16x64x32x64x2xbf16>
+!C = tensor<4x16x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)
@@ -26,4 +26,3 @@ func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
 
   return %0 : !C
 }
-

--- a/benchmarks/mlir/matmul/matmul-bf16-dp2-256x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp2-256x4096x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<8x32x32x32xbf16>
-!B = tensor<128x32x16x32x2xbf16>
-!C = tensor<8x128x32x32xbf16>
+!A = tensor<4x16x64x64xbf16>
+!B = tensor<64x16x32x64x2xbf16>
+!C = tensor<4x64x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<4x32x32x32xbf16>
-!B = tensor<32x32x8x32x4xbf16>
-!C = tensor<4x32x32x32xbf16>
+!A = tensor<2x16x64x64xbf16>
+!B = tensor<16x16x16x64x4xbf16>
+!C = tensor<2x16x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-128x1024x4096.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<4x128x32x32xbf16>
-!B = tensor<32x128x8x32x4xbf16>
-!C = tensor<4x32x32x32xbf16>
+!A = tensor<2x64x64x64xbf16>
+!B = tensor<16x64x16x64x4xbf16>
+!C = tensor<2x16x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-128x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-128x4096x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<4x32x32x32xbf16>
-!B = tensor<128x32x8x32x4xbf16>
-!C = tensor<4x128x32x32xbf16>
+!A = tensor<2x16x64x64xbf16>
+!B = tensor<64x16x16x64x4xbf16>
+!C = tensor<2x64x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-256x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-256x1024x1024.mlir
@@ -1,25 +1,28 @@
-// RUN: tpp-opt %s -element-wise-fusion |
 // RUN: tpp-run %s -n 10 \
 // RUN:  -e entry -entry-point-result=void
 
-// Total flops = matmul O(2*n*m*k) x 3
-// 2*256x1024x1024 (536870912) x 3 = 1,610,612,736
-// BENCH_TOTAL_FLOPS: 1610612736
+// Total flops = matmul O(2*n*m*k)
+// 2*256x1024x1024 = 536870912
+// BENCH_TOTAL_FLOPS: 536870912
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-func.func @entry(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x8x32x4xbf16>, %output: tensor<8x32x32x32xbf16>) -> tensor<8x32x32x32xbf16> {
+!A = tensor<4x16x64x64xbf16>
+!B = tensor<16x16x16x64x4xbf16>
+!C = tensor<4x16x64x64xbf16>
+
+// GEMM packed with tile size: 64, 64, 64
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
-  ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x8x32x4xbf16>)
-  outs(%arg3 : tensor<8x32x32x32xbf16>) {
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
-  } -> tensor<8x32x32x32xbf16>
+  } -> !C
 
-  return %0 : tensor<8x32x32x32xbf16>
+  return %0 : !C
 }
-

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-256x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-256x1024x4096.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<8x128x32x32xbf16>
-!B = tensor<32x128x8x32x4xbf16>
-!C = tensor<8x32x32x32xbf16>
+!A = tensor<4x64x64x64xbf16>
+!B = tensor<16x64x16x64x4xbf16>
+!C = tensor<4x16x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)
@@ -26,4 +26,3 @@ func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
 
   return %0 : !C
 }
-

--- a/benchmarks/mlir/matmul/matmul-bf16-dp4-256x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-bf16-dp4-256x4096x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 
-!A = tensor<8x32x32x32xbf16>
-!B = tensor<128x32x8x32x4xbf16>
-!C = tensor<8x128x32x32xbf16>
+!A = tensor<4x16x64x64xbf16>
+!B = tensor<64x16x16x64x4xbf16>
+!C = tensor<4x64x64x64xbf16>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-fp32-128x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-128x1024x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-!A = tensor<4x32x32x32xf32>
-!B = tensor<32x32x32x32xf32>
-!C = tensor<4x32x32x32xf32>
+!A = tensor<2x16x64x64xf32>
+!B = tensor<16x16x64x64xf32>
+!C = tensor<2x16x64x64xf32>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-fp32-128x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-128x1024x4096.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-!A = tensor<4x128x32x32xf32>
-!B = tensor<32x128x32x32xf32>
-!C = tensor<4x32x32x32xf32>
+!A = tensor<2x64x64x64xf32>
+!B = tensor<16x64x64x64xf32>
+!C = tensor<2x16x64x64xf32>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-fp32-128x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-128x4096x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-!A = tensor<4x32x32x32xf32>
-!B = tensor<128x32x32x32xf32>
-!C = tensor<4x128x32x32xf32>
+!A = tensor<2x16x64x64xf32>
+!B = tensor<64x16x64x64xf32>
+!C = tensor<2x64x64x64xf32>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)

--- a/benchmarks/mlir/matmul/matmul-fp32-256x1024x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-256x1024x1024.mlir
@@ -9,15 +9,20 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-// GEMM 256 x 1024 x 1024 packed into 8x32 (256) x 32x32 (1024)
-func.func @entry(%arg0: tensor<8x32x32x32xf32>, %arg1: tensor<32x32x32x32xf32>, %output: tensor<8x32x32x32xf32>) -> tensor<8x32x32x32xf32> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xf32>, tensor<32x32x32x32xf32>) outs(%output : tensor<8x32x32x32xf32>) {
+!A = tensor<4x16x64x64xf32>
+!B = tensor<16x16x64x64xf32>
+!C = tensor<4x16x64x64xf32>
+
+// GEMM packed with tile size: 64, 64, 64
+func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
+  ins(%arg0, %arg1 : !A, !B)
+  outs(%output : !C) {
     ^bb0(%in: f32, %in_0: f32, %out: f32):
       %mul = arith.mulf %in, %in_0 : f32
       %add = arith.addf %out, %mul : f32
       linalg.yield %add : f32
-  } -> tensor<8x32x32x32xf32>
+  } -> !C
 
-  return %0 : tensor<8x32x32x32xf32>
+  return %0 : !C
 }
-

--- a/benchmarks/mlir/matmul/matmul-fp32-256x1024x4096.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-256x1024x4096.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-!A = tensor<8x128x32x32xf32>
-!B = tensor<32x128x32x32xf32>
-!C = tensor<8x32x32x32xf32>
+!A = tensor<4x64x64x64xf32>
+!B = tensor<16x64x64x64xf32>
+!C = tensor<4x16x64x64xf32>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)
@@ -26,4 +26,3 @@ func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
 
   return %0 : !C
 }
-

--- a/benchmarks/mlir/matmul/matmul-fp32-256x4096x1024.mlir
+++ b/benchmarks/mlir/matmul/matmul-fp32-256x4096x1024.mlir
@@ -9,11 +9,11 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-!A = tensor<8x32x32x32xf32>
-!B = tensor<128x32x32x32xf32>
-!C = tensor<8x128x32x32xf32>
+!A = tensor<4x16x64x64xf32>
+!B = tensor<64x16x64x64xf32>
+!C = tensor<4x64x64x64xf32>
 
-// GEMM packed with tile size: 32, 32, 32
+// GEMM packed with tile size: 64, 64, 64
 func.func @entry(%arg0: !A, %arg1: !B, %output: !C) -> !C {
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
   ins(%arg0, %arg1 : !A, !B)


### PR DESCRIPTION
Blocks existing GEMM performance benchmarks with factors from PARLOOPER.
Also, fixes DNN sizes for GEMM 128x1024x4096.