### PR TITLE
[XSMM] Align priting for invoke and dispatch (NFC)

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -38,7 +38,7 @@ def Xsmm_QuarternaryOp : Xsmm_Op<"quarternary", []> {
                        Variadic<XsmmMemRef>:$inputs);
 
   let assemblyFormat = [{
-    $callee `(` `dataType` $dataType `,` $inputs `)` 
+    $callee `(` `data_type` `=` $dataType `,` $inputs `)` 
     attr-dict `:` functional-type($inputs, results)
   }];
 
@@ -74,7 +74,7 @@ def Xsmm_TernaryOp : Xsmm_Op<"ternary", []> {
                        Variadic<XsmmMemRef>:$inputs);
 
   let assemblyFormat = [{
-    $callee `(` `dataType` $dataType `,` $inputs `)` 
+    $callee `(` `data_type` `=` $dataType `,` $inputs `)` 
     attr-dict `:` functional-type($inputs, results)
   }];
 
@@ -105,7 +105,7 @@ def Xsmm_BinaryOp : Xsmm_Op<"binary", []> {
                        Variadic<XsmmMemRef>:$inputs);
 
   let assemblyFormat = [{
-    $callee `(` `dataType` $dataType `,` $inputs `)` 
+    $callee `(` `data_type` `=` $dataType `,` $inputs `)` 
     attr-dict `:` functional-type($inputs, results)
   }];
 }
@@ -125,7 +125,7 @@ def Xsmm_UnaryOp : Xsmm_Op<"unary", []> {
                        Variadic<XsmmMemRef>:$inputs);
 
   let assemblyFormat = [{
-    $callee `(` `dataType` $dataType `,` $inputs `)` 
+    $callee `(` `data_type` `=` $dataType `,` $inputs `)` 
     attr-dict `:` functional-type($inputs, results)
   }];
 
@@ -150,7 +150,7 @@ def Xsmm_GemmOp : Xsmm_Op<"gemm"> {
   let arguments = (ins Xsmm_DataType:$dataType, Variadic<XsmmMemRef>:$inputs);
   
   let assemblyFormat = [{
-    `(` `dataType` $dataType `,` $inputs `)`
+    `(` `data_type` `=` $dataType `,` $inputs `)`
     attr-dict `:` functional-type($inputs, results)
   }];
 }
@@ -164,7 +164,7 @@ def Xsmm_BrgemmOp : Xsmm_Op<"brgemm"> {
   let arguments = (ins Xsmm_DataType:$dataType, Variadic<XsmmMemRef>:$inputs);
 
   let assemblyFormat = [{
-    `(` `dataType` $dataType `,` $inputs `)`
+    `(` `data_type` `=` $dataType `,` $inputs `)`
     attr-dict `:` functional-type($inputs, results)
   }];
 }

--- a/test/BF16/Integration/xsmm-binary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-binary-bf16.mlir
@@ -7,7 +7,7 @@ memref.global "private" constant @__constant_bias : memref<3x3xbf16> = dense<1.0
 func.func @entry(%arg0: memref<3x3xbf16>, %arg1: memref<3x3xbf16>) {
   %0 = memref.get_global @__constant_bias : memref<3x3xbf16>
   %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = (none) data_type = bf16
-  xsmm.binary add(dataType bf16, %1, %arg0, %0, %arg1) : (i64, memref<3x3xbf16>, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
+  xsmm.binary add(data_type = bf16, %1, %arg0, %0, %arg1) : (i64, memref<3x3xbf16>, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
 
   return
 }

--- a/test/BF16/Integration/xsmm-quarternary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-quarternary-bf16.mlir
@@ -5,7 +5,7 @@
 func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>, %arg2: memref<4xbf16>, %arg3: memref<4x4xbf16>) {
   %c16_i64 = arith.constant 16 : i64
   %func = xsmm.quarternary.dispatch fused_brgemm [4, 4, 4, 4, 4, 4](dataType bf16, isVNNI true)
-  xsmm.quarternary fused_brgemm(dataType bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4xbf16>, memref<4x4xbf16>, i64) -> ()
+  xsmm.quarternary fused_brgemm(data_type = bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4xbf16>, memref<4x4xbf16>, i64) -> ()
 
   return
 }

--- a/test/BF16/Integration/xsmm-ternary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-ternary-bf16.mlir
@@ -6,7 +6,7 @@ func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
                               %arg2: memref<4x4xbf16>) {
   %c64_i64 = arith.constant 64 : i64
   %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4] flags = (vnni_b) data_type = bf16
-  xsmm.brgemm(dataType bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
+  xsmm.brgemm(data_type = bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
     : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
 
   return

--- a/test/BF16/Integration/xsmm-unary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-unary-bf16.mlir
@@ -4,7 +4,7 @@
 
 func.func @entry(%arg0: memref<3x3xbf16>) {
   %0 = xsmm.unary.dispatch relu [3, 3, 3, 3] flags = (none) data_type = bf16
-  xsmm.unary relu(dataType bf16, %0, %arg0, %arg0) : (i64, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
+  xsmm.unary relu(data_type = bf16, %0, %arg0, %arg0) : (i64, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
 
   return
 }

--- a/test/BF16/Integration/xsmm-zero-bf16.mlir
+++ b/test/BF16/Integration/xsmm-zero-bf16.mlir
@@ -6,7 +6,7 @@ func.func @entry(%arg0: memref<3x3xbf16>) {
   %cst = arith.constant 5.0 : bf16
   linalg.fill ins(%cst : bf16) outs(%arg0 : memref<3x3xbf16>)
   %0 = xsmm.unary.dispatch zero [3, 3, 3, 3] flags = (none) data_type = bf16
-  xsmm.unary zero(dataType bf16, %0, %arg0, %arg0) : (i64, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
+  xsmm.unary zero(data_type = bf16, %0, %arg0, %arg0) : (i64, memref<3x3xbf16>, memref<3x3xbf16>) -> ()
 
   return
 }

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-add.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-add.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: func.func @add_to_xsmm_1d
 func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: memref<32xf32>) {
   // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [1, 32, 32, 32, 32] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<32xf32>, memref<32xf32>, memref<32xf32>) -> ()
+  // CHECK-NEXT: xsmm.binary add(data_type = f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<32xf32>, memref<32xf32>, memref<32xf32>) -> ()
   tpp.add ins(%arg0: memref<32xf32>, %arg1: memref<32xf32>) outs(%arg2: memref<32xf32>)
   return 
 }
@@ -13,7 +13,7 @@ func.func @add_to_xsmm_1d(%arg0: memref<32xf32>, %arg1: memref<32xf32>, %arg2: m
 // CHECK-LABEL: add_to_xsmm_2d
 func.func @add_to_xsmm_2d(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>, %arg2: memref<3x4xf32>) {
   // CHECK: %[[DISPATCH:.+]] = xsmm.binary.dispatch add [3, 4, 4, 4, 4] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.binary add(dataType f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<3x4xf32>, memref<3x4xf32>, memref<3x4xf32>) -> ()
+  // CHECK-NEXT: xsmm.binary add(data_type = f32, %[[DISPATCH]], %{{.+}}, %{{.+}}, %{{.+}}) : (i64, memref<3x4xf32>, memref<3x4xf32>, memref<3x4xf32>) -> ()
   tpp.add ins(%arg0: memref<3x4xf32>, %arg1: memref<3x4xf32>) outs(%arg2: memref<3x4xf32>)
   return
 }

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
@@ -7,7 +7,7 @@ func.func @brgemm_to_xsmm(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
                           %arg2: memref<5x5xf32>) -> memref<5x5xf32> {
   // CHECK: %[[BATCH:.+]] = arith.constant 3 : i64
   // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.brgemm(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[BATCH]])
+  // CHECK-NEXT: xsmm.brgemm(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[BATCH]])
   tpp.brgemm ins(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>, %arg2: memref<5x5xf32>)
              outs(%arg2: memref<5x5xf32>)
   return %arg2: memref<5x5xf32>

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-gemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-gemm.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME: %[[ARG0:.*]]: memref<3x3xf32>, %[[ARG1:.*]]: memref<3x3xf32>, %[[ARG2:.*]]: memref<3x3xf32>)
 func.func @gemm_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) {
   // CHECK: %[[DISPATCH:.*]] = xsmm.gemm.dispatch [3, 3, 3, 3, 3, 3] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.gemm(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]]) 
+  // CHECK-NEXT: xsmm.gemm(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]]) 
   tpp.gemm ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) 
            outs(%arg2: memref<3x3xf32>)
   return

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-identity.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-identity.mlir
@@ -16,7 +16,7 @@ func.func @identity_to_xsmm(%arg0: memref<3x3xf32>) {
   // b_cast = 3 (bcast scalar)
 
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
-  // CHECK: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[CST]], %[[ARG0]]) 
+  // CHECK: xsmm.unary identity(data_type = f32, %[[DISPATCH]], %[[CST]], %[[ARG0]]) 
   tpp.identity ins(%cst: f32) outs(%arg0: memref<3x3xf32>)
   return
 }
@@ -37,7 +37,7 @@ func.func @identity_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // b_cast = 0 (bcast none)
 
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [3, 3, 3, 3] flags = (none) data_type = f32
-  // CHECK: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
+  // CHECK: xsmm.unary identity(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
   return
 }
@@ -81,7 +81,7 @@ func.func @identity_to_xsmm(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf32>) {
   // b_cast = 2 (bcast col)
 
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 5, 5, 5] flags = (bcast_col) data_type = f32
-  // CHECK-NEXT: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
+  // CHECK-NEXT: xsmm.unary identity(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: memref<1x5xf32>) outs(%arg1: memref<5x5xf32>)
   return
 }
@@ -94,7 +94,7 @@ func.func @identity_to_xsmm(%arg0: memref<1x5xf32>, %arg1: memref<5x5xf32>) {
 func.func @identity_to_xsmm(%arg0: f32, %arg1: memref<5x6xf32>) {
 
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 6, 1, 6] flags = (bcast_scalar) data_type = f32
-  // CHECK-NEXT: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
+  // CHECK-NEXT: xsmm.unary identity(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: f32) outs(%arg1: memref<5x6xf32>)
   return
 }
@@ -105,7 +105,7 @@ func.func @identity_to_xsmm(%arg0: f32, %arg1: memref<5x6xf32>) {
 // CHECK-SAME:  %[[ARG0:.+]]: memref<1x1xf32>, %[[ARG1:.+]]: memref<5x6xf32>)
 func.func @identity_to_xsmm(%arg0: memref<1x1xf32>, %arg1: memref<5x6xf32>) {
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [5, 6, 1, 6] flags = (bcast_scalar) data_type = f32
-  // CHECK-NEXT: xsmm.unary identity(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
+  // CHECK-NEXT: xsmm.unary identity(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]]) 
   tpp.identity ins(%arg0: memref<1x1xf32>) outs(%arg1: memref<5x6xf32>)
   return
 }

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-quarternary.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-quarternary.mlir
@@ -14,7 +14,7 @@ module {
       %cast = memref.cast %alloc_3 : memref<32x32xbf16> to memref<32x32xbf16, strided<[32, 1]>>
       
       //CHECK:  {{.*}} = xsmm.quarternary.dispatch fused_brgemm [32, 32, 32, 32, 32, 32](dataType bf16, isVNNI true)
-      //CHECK:  xsmm.quarternary fused_brgemm(dataType bf16, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (i64, memref<16x32x32xbf16, strided<[1024, 32, 1], offset: ?>>, memref<16x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, memref<32xbf16, strided<[1], offset: ?>>, memref<32x32xbf16, strided<[32, 1], offset: ?>>, i64) -> ()
+      //CHECK:  xsmm.quarternary fused_brgemm(data_type = bf16, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (i64, memref<16x32x32xbf16, strided<[1024, 32, 1], offset: ?>>, memref<16x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>, memref<32xbf16, strided<[1], offset: ?>>, memref<32x32xbf16, strided<[32, 1], offset: ?>>, i64) -> ()
       tpp.vnni_brgemm ins(%subview_0 : memref<16x32x32xbf16, strided<[1024, 32, 1], offset: ?>>, %subview_1 : memref<16x16x32x2xbf16, strided<[1024, 64, 2, 1], offset: ?>>) outs(%cast : memref<32x32xbf16, strided<[32, 1]>>)
       %subview_4 = memref.subview %expand_shape[%arg5, 0] [1, 32] [1, 1] : memref<16x32xbf16> to memref<32xbf16, strided<[1], offset: ?>>
       %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<32x32xbf16>

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-relu.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-relu.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME:  %[[ARG0:.+]]: memref<5x6xf32>)
 func.func @relu_to_xsmm(%arg0: memref<5x6xf32>) {
   // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPACTH]], %[[ARG0]], %[[ARG0]])
+  // CHECK-NEXT: xsmm.unary relu(data_type = f32, %[[DISPACTH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<5x6xf32>) outs(%arg0: memref<5x6xf32>)
   return
 }
@@ -15,7 +15,7 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>) {
 // CHECK-SAME:  %[[ARG0:.+]]: memref<5x6xf32>, %[[ARG1:.+]]: memref<5x6xf32>)
 func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
   // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPACTH]], %[[ARG0]], %[[ARG1]])
+  // CHECK-NEXT: xsmm.unary relu(data_type = f32, %[[DISPACTH]], %[[ARG0]], %[[ARG1]])
   tpp.relu ins(%arg0: memref<5x6xf32>) outs(%arg1: memref<5x6xf32>)
   return
 }
@@ -26,7 +26,7 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
 // CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>)
 func.func @relu_to_xsmm(%arg0: memref<32xf32>) {
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.unary relu(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
+  // CHECK-NEXT: xsmm.unary relu(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<32xf32>) outs(%arg0: memref<32xf32>)
   return
 }

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-zero.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-zero.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME:  %[[ARG0:.+]]: memref<5x6xf32>)
 func.func @zero_to_xsmm(%arg0: memref<5x6xf32>) {
   // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch zero [5, 6, 6, 6] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.unary zero(dataType f32, %[[DISPACTH]], %[[ARG0]], %[[ARG0]])
+  // CHECK-NEXT: xsmm.unary zero(data_type = f32, %[[DISPACTH]], %[[ARG0]], %[[ARG0]])
   tpp.zero ins(%arg0: memref<5x6xf32>) outs(%arg0: memref<5x6xf32>)
   return
 }
@@ -15,7 +15,7 @@ func.func @zero_to_xsmm(%arg0: memref<5x6xf32>) {
 // CHECK-SAME:  %[[ARG0:.+]]: memref<32xf32>)
 func.func @zero_to_xsmm(%arg0: memref<32xf32>) {
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch zero [1, 32, 32, 32] flags = (none) data_type = f32
-  // CHECK-NEXT: xsmm.unary zero(dataType f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
+  // CHECK-NEXT: xsmm.unary zero(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
   tpp.zero ins(%arg0: memref<32xf32>) outs(%arg0: memref<32xf32>)
   return
 }

--- a/test/Conversion/XsmmToFunc/xsmm-to-func-using-meta.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func-using-meta.mlir
@@ -6,7 +6,7 @@ func.func @dispatch_brgemm(%arg0: memref<2x5x4xf32>, %arg1: memref<2x4x5xf32>,
                            %arg2: memref<4x4xf32>) -> memref<4x4xf32> {
   %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
   %c2_i64 = arith.constant 2 : i64
-  xsmm.brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
+  xsmm.brgemm(data_type = f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x5x4xf32>, memref<2x4x5xf32>, memref<4x4xf32>, i64) -> ()
   return %arg2 : memref<4x4xf32>
 }

--- a/test/Dialect/Xsmm/xsmm-ops.mlir
+++ b/test/Dialect/Xsmm/xsmm-ops.mlir
@@ -5,11 +5,11 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
                         %arg1: memref<2x2xf32>, %arg2: memref<2x2xf32>) {
 
   // CHECK: xsmm.binary
-  xsmm.binary add(dataType f32, %arg0, %arg1)
+  xsmm.binary add(data_type = f32, %arg0, %arg1)
     : (memref<2x2xf32>, memref<2x2xf32>) -> ()
 
   // CHECK: xsmm.unary
-  xsmm.unary relu(dataType f32, %arg0)
+  xsmm.unary relu(data_type = f32, %arg0)
     : (memref<2x2xf32>) -> ()
 
   // CHECK: xsmm.binary.dispatch
@@ -19,7 +19,7 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
   %1 = xsmm.unary.dispatch identity [3, 2, 1, 3] flags = (bcast_row) data_type = f32
 
   // CHECK: xsmm.gemm
-  xsmm.gemm (dataType f32, %arg0, %arg1, %arg2) 
+  xsmm.gemm (data_type = f32, %arg0, %arg1, %arg2) 
     : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
 
   // CHECK: xsmm.gemm.dispatch
@@ -44,7 +44,7 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
   // CHECK: xsmm.unary.dispatch zero
   %11 = xsmm.unary.dispatch zero [2, 2, 2, 2] flags = (none) data_type = f32
   // CHECK: xsmm.unary zero
-  xsmm.unary zero(dataType f32, %11, %arg0, %arg0) : (i64, memref<2x2xf32>, memref<2x2xf32>) -> ()
+  xsmm.unary zero(data_type = f32, %11, %arg0, %arg0) : (i64, memref<2x2xf32>, memref<2x2xf32>) -> ()
 
   return
 }

--- a/test/Integration/xsmm-binary.mlir
+++ b/test/Integration/xsmm-binary.mlir
@@ -7,7 +7,7 @@ memref.global "private" constant @__constant_bias : memref<3x3xf32> = dense<1.0>
 func.func @entry(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   %0 = memref.get_global @__constant_bias : memref<3x3xf32>
   %1 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = (none) data_type = f32
-  xsmm.binary add(dataType f32, %1, %arg0, %0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>, memref<3x3xf32>) -> ()
+  xsmm.binary add(data_type = f32, %1, %arg0, %0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }

--- a/test/Integration/xsmm-quarternary.mlir
+++ b/test/Integration/xsmm-quarternary.mlir
@@ -5,7 +5,7 @@
 func.func @entry(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3xbf16>, %arg3: memref<3x3xf32>) {
   %c16_i64 = arith.constant 16 : i64
   %func = xsmm.quarternary.dispatch fused_brgemm [3, 3, 4, 4, 3, 3](dataType f32, isVNNI false)
-  xsmm.quarternary fused_brgemm(dataType bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3xbf16>, memref<3x3xf32>, i64) -> ()
+  xsmm.quarternary fused_brgemm(data_type = bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3xbf16>, memref<3x3xf32>, i64) -> ()
 
   return
 }

--- a/test/Integration/xsmm-ternary.mlir
+++ b/test/Integration/xsmm-ternary.mlir
@@ -5,7 +5,7 @@
 func.func @entry(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
   %c2_i64 = arith.constant 2 : i64
   %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3] flags = (none) data_type = f32
-  xsmm.brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
+  xsmm.brgemm(data_type = f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 
   return

--- a/test/Integration/xsmm-unary.mlir
+++ b/test/Integration/xsmm-unary.mlir
@@ -4,7 +4,7 @@
 
 func.func @entry(%arg0: memref<3x3xf32>) {
   %0 = xsmm.unary.dispatch relu [3, 3, 3, 3] flags = (none) data_type = f32
-  xsmm.unary relu(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
+  xsmm.unary relu(data_type = f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }

--- a/test/Integration/xsmm-zero.mlir
+++ b/test/Integration/xsmm-zero.mlir
@@ -6,7 +6,7 @@ func.func @entry(%arg0: memref<3x3xf32>) {
   %cst = arith.constant 5.0 : f32
   linalg.fill ins(%cst : f32) outs(%arg0 : memref<3x3xf32>)
   %0 = xsmm.unary.dispatch zero [3, 3, 3, 3] flags = (none) data_type = f32
-  xsmm.unary zero(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
+  xsmm.unary zero(data_type = f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -38,7 +38,7 @@ module @predict_function  {
     // CHECK: call @xsmm_unary_dispatch
     // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
     %2 = xsmm.unary.dispatch relu [128, 512, 512, 512] flags = (none) data_type = f32
-    xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
+    xsmm.unary relu(data_type = f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 
     return
   }

--- a/test/Passes/DefaultPipeline/xsmm.mlir
+++ b/test/Passes/DefaultPipeline/xsmm.mlir
@@ -9,7 +9,7 @@ func.func @add(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // CHECK: %[[cast1:.*]] = memref.cast %[[ARG1]]
   // CHECK: call @xsmm_binary_invoke({{.*}}%[[cast0]], %[[cast1]]
   %0 = xsmm.binary.dispatch add [3, 3, 3, 3, 3] flags = (none) data_type = f32
-  xsmm.binary add(dataType f32, %0, %arg0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
+  xsmm.binary add(data_type = f32, %0, %arg0, %arg1) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }
@@ -29,7 +29,7 @@ func.func @add_mapping(%arg0: memref<1x10x10xf32>, %arg1: memref<1x10x10xf32>) {
     %subview = memref.subview %arg0[0, 0, 0] [1, 10, 10] [1, 1, 1] : memref<1x10x10xf32> to memref<10x10xf32>
     %subview_0 = memref.subview %arg1[0, 0, 0] [1, 10, 10] [1, 1, 1] : memref<1x10x10xf32> to memref<10x10xf32>
     %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10] flags = (none) data_type = f32
-    xsmm.binary add(dataType f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32>, memref<10x10xf32>) -> ()
+    xsmm.binary add(data_type = f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32>, memref<10x10xf32>) -> ()
 
   return
 }
@@ -52,7 +52,7 @@ func.func @add_mapping_parallel(%arg0: memref<10x10x10xf32>, %arg1: memref<10x10
     %subview = memref.subview %arg0[%arg2, 0, 0] [1, 10, 10] [1, 1, 1] : memref<10x10x10xf32> to memref<10x10xf32, #map>
     %subview_0 = memref.subview %arg1[%arg2, 0, 0] [1, 10, 10] [1, 1, 1] : memref<10x10x10xf32> to memref<10x10xf32, #map>
     %0 = xsmm.binary.dispatch add [10, 10, 10, 10, 10] flags = (none) data_type = f32
-    xsmm.binary add(dataType f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32, #map>, memref<10x10xf32, #map>) -> ()
+    xsmm.binary add(data_type = f32, %0, %subview, %subview_0) : (i64, memref<10x10xf32, #map>, memref<10x10xf32, #map>) -> ()
     scf.yield
   }
 
@@ -70,7 +70,7 @@ func.func @identity(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
   // CHECK: %[[cast1:.*]] = memref.cast %[[ARG0]]
   // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast1]]
   %0 = xsmm.unary.dispatch identity [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
-  xsmm.unary identity(dataType f32, %0, %arg1, %arg0) : (i64, memref<1x1xf32>, memref<3x3xf32>) -> ()
+  xsmm.unary identity(data_type = f32, %0, %arg1, %arg0) : (i64, memref<1x1xf32>, memref<3x3xf32>) -> ()
 
   return
 }
@@ -94,7 +94,7 @@ func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
   scf.parallel (%arg1, %arg2) = (%c0, %c0) to (%c12, %c56) step (%c1, %c1) {
     %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 56, 64] [1, 1, 1, 1] : memref<12x56x56x64xf32> to memref<56x64xf32, #map>
     %0 = xsmm.unary.dispatch identity [56, 64, 64, 64] flags = (bcast_col) data_type = f32
-    xsmm.unary identity(dataType f32, %0, %arg0, %subview) : (i64, memref<64xf32>, memref<56x64xf32, #map>) -> ()
+    xsmm.unary identity(data_type = f32, %0, %arg0, %subview) : (i64, memref<64xf32>, memref<56x64xf32, #map>) -> ()
     scf.yield
   }
 
@@ -110,7 +110,7 @@ func.func @zero(%arg0: memref<3x3xf32>) {
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
   // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
   %0 = xsmm.unary.dispatch zero [3, 3, 3, 3] flags = (none) data_type = f32
-  xsmm.unary zero(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
+  xsmm.unary zero(data_type = f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }
@@ -124,7 +124,7 @@ func.func @relu(%arg0: memref<3x3xf32>) {
   // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
   // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
   %0 = xsmm.unary.dispatch relu [3, 3, 3, 3] flags = (none) data_type = f32
-  xsmm.unary relu(dataType f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
+  xsmm.unary relu(data_type = f32, %0, %arg0, %arg0) : (i64, memref<3x3xf32>, memref<3x3xf32>) -> ()
 
   return
 }
@@ -146,7 +146,7 @@ func.func @relu_3d(%arg0: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
   scf.parallel (%arg1) = (%c0) to (%c64) step (%c1) {
     %subview = memref.subview %arg0[%arg1, 0, 0] [1, 32, 32] [1, 1, 1] : memref<64x32x32xf32> to memref<32x32xf32, #map>
     %0 = xsmm.unary.dispatch relu [32, 32, 32, 32] flags = (none) data_type = f32
-    xsmm.unary relu(dataType f32, %0, %subview, %subview) : (i64, memref<32x32xf32, #map>, memref<32x32xf32, #map>) -> ()
+    xsmm.unary relu(data_type = f32, %0, %subview, %subview) : (i64, memref<32x32xf32, #map>, memref<32x32xf32, #map>) -> ()
     scf.yield
   }
 
@@ -167,7 +167,7 @@ func.func @brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: mem
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   %c2_i64 = arith.constant 2 : i64
   %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3] flags = (none) data_type = f32
-  xsmm.brgemm(dataType f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
+  xsmm.brgemm(data_type = f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 
   return
@@ -188,7 +188,7 @@ func.func @brgemm_bf16(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   %c64_i64 = arith.constant 64 : i64
   %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4] flags = (vnni_b) data_type = bf16
-  xsmm.brgemm(dataType bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
+  xsmm.brgemm(data_type = bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
     : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
 
   return
@@ -208,7 +208,7 @@ func.func @gemm(%A: memref<4x8xf32>,
   // CHECK: %[[cast2:.*]] = memref.cast %[[ARG2]]
   // CHECK: call @xsmm_gemm_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
   %0 = xsmm.gemm.dispatch [4, 4, 8, 8, 4, 4] flags = (none) data_type = f32
-  xsmm.gemm(dataType f32, %0, %A, %B, %C) : (i64, memref<4x8xf32>, memref<8x4xf32>, memref<4x4xf32>) -> ()
+  xsmm.gemm(data_type = f32, %0, %A, %B, %C) : (i64, memref<4x8xf32>, memref<8x4xf32>, memref<4x4xf32>) -> ()
 
   return
 }
@@ -227,7 +227,7 @@ func.func @gemm_bf16(%arg0: memref<6x10xbf16>, %arg1: memref<5x6x2xbf16>,
   // CHECK: %[[cast2:.*]] = memref.cast %[[ARG2]]
   // CHECK: call @xsmm_gemm_invoke({{.*}}%[[cast]], %[[cast1]], %[[cast2]]
   %0 = xsmm.gemm.dispatch [6, 6, 10, 10, 6, 6] flags = (vnni_b) data_type = bf16
-  xsmm.gemm(dataType bf16, %0, %arg0, %arg1, %arg2) : (i64, memref<6x10xbf16>, memref<5x6x2xbf16>, memref<6x6xbf16>) -> ()
+  xsmm.gemm(data_type = bf16, %0, %arg0, %arg1, %arg2) : (i64, memref<6x10xbf16>, memref<5x6x2xbf16>, memref<6x6xbf16>) -> ()
 
   return
 }
@@ -255,7 +255,7 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
     %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : memref<8x16x32x32xf32> to memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>
     %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x8x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
     %0 = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32] flags = (none) data_type = f32
-    xsmm.brgemm(dataType f32, %0, %subview, %subview_0, %subview_1, %c16_i64) 
+    xsmm.brgemm(data_type = f32, %0, %subview, %subview_0, %subview_1, %c16_i64) 
       : (i64, memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>, 
          memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>,
          memref<32x32xf32, strided<[32, 1], offset: ?>>, i64) -> ()
@@ -291,7 +291,7 @@ func.func @conv2d_1x1(%arg0: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
     %subview = memref.subview %arg0[0, %arg1, 0, 0] [1, 1, 7, 2048] [1, 1, 1, 1] : memref<1x7x7x2048xf32> to memref<7x2048xf32, strided<[2048, 1], offset: ?>>
     %subview_0 = memref.subview %alloc[0, %arg1, 0, 0] [1, 1, 7, 512] [1, 1, 1, 1] : memref<1x7x7x512xf32> to memref<7x512xf32, strided<[512, 1], offset: ?>>
     %1 = xsmm.gemm.dispatch [7, 512, 2048, 2048, 512, 512] flags = (none) data_type = f32
-    xsmm.gemm(dataType f32, %1, %subview, %0, %subview_0) : (i64, memref<7x2048xf32, strided<[2048, 1], offset: ?>>, memref<2048x512xf32>, memref<7x512xf32, strided<[512, 1], offset: ?>>) -> ()
+    xsmm.gemm(data_type = f32, %1, %subview, %0, %subview_0) : (i64, memref<7x2048xf32, strided<[2048, 1], offset: ?>>, memref<2048x512xf32>, memref<7x512xf32, strided<[512, 1], offset: ?>>) -> ()
   }
 
   // CHECK: return {{.*}} : memref<1x7x7x512xf32>
@@ -321,7 +321,7 @@ module @predict_function {
     // CHECK: %[[cast0:.*]] = memref.cast %[[ARG3]]
     // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast]], %[[cast0]]
     %0 = xsmm.unary.dispatch identity [128, 512, 512, 512] flags = (bcast_col) data_type = f32
-    xsmm.unary identity(dataType f32, %0, %arg2, %arg3) : (i64, memref<512xf32>, memref<128x512xf32>) -> ()
+    xsmm.unary identity(data_type = f32, %0, %arg2, %arg3) : (i64, memref<512xf32>, memref<128x512xf32>) -> ()
 
     // Gemm
     // CHECK: call @xsmm_gemm_dispatch
@@ -329,13 +329,13 @@ module @predict_function {
     // CHECK: %[[cast2:.*]] = memref.cast %[[ARG1]]
     // CHECK: call @xsmm_gemm_invoke({{.*}}%[[cast1]], %[[cast2]], %[[cast0]]
     %1 = xsmm.gemm.dispatch [128, 512, 256, 256, 512, 512] flags = (none) data_type = f32
-    xsmm.gemm(dataType f32, %1, %arg0, %arg1, %arg3) : (i64, memref<128x256xf32>, memref<256x512xf32>, memref<128x512xf32>) -> ()
+    xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %arg3) : (i64, memref<128x256xf32>, memref<256x512xf32>, memref<128x512xf32>) -> ()
 
     // Relu
     // CHECK: call @xsmm_unary_dispatch
     // CHECK: call @xsmm_unary_invoke({{.*}}%[[cast0]], %[[cast0]]
     %2 = xsmm.unary.dispatch relu [128, 512, 512, 512] flags = (none) data_type = f32
-    xsmm.unary relu(dataType f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
+    xsmm.unary relu(data_type = f32, %2, %arg3, %arg3) : (i64, memref<128x512xf32>, memref<128x512xf32>) -> ()
 
     return
   }


### PR DESCRIPTION
MLIR uses `snake_case` for IR. We followed this convention when re-working dispatch 
operations.