### PR TITLE
Default pipeline - remove BufferDeallocationPass

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -211,7 +211,6 @@ private:
 
     // Postprocess buffers.
     pm.addPass(bufferization::createBufferHoistingPass());
-    pm.addPass(bufferization::createBufferDeallocationPass());
     if (defHeapToStack)
       pm.addPass(createHeapToStackPass());
 

--- a/test/BF16/Integration/matmul-pbf16.mlir
+++ b/test/BF16/Integration/matmul-pbf16.mlir
@@ -40,5 +40,9 @@ func.func @entry() {
   %f1 = arith.extf %v0:vector<4x4xbf16> to vector<4x4xf32>
   vector.print %f1 : vector<4x4xf32>
 
+  memref.dealloc %da : memref<4x8xbf16>
+  memref.dealloc %0 : memref<4x4x2xbf16>
+  memref.dealloc %D : memref<4x4xbf16>
+
   return
 }

--- a/test/BF16/Integration/mlp-single-layer-bf16.mlir
+++ b/test/BF16/Integration/mlp-single-layer-bf16.mlir
@@ -26,5 +26,13 @@ func.func @entry(){
   linalg.fill ins(%c1:bf16) outs(%result:memref<128x512xbf16>)
   %threshold = arith.constant 1.0:bf16
   check.expect_almost_eq(%arg3, %result, %threshold): memref<128x512xbf16>, memref<128x512xbf16>, bf16
+  // Explicit manual buffer deallocation is required as BufferDeallocationPass
+  // inserts automatic deallocation before type casts used in generated XSMM
+  // function calls which invalidates the memory before computation.
+  memref.dealloc %arg0 : memref<128x256xbf16>
+  memref.dealloc %arg2 : memref<512xbf16>
+  memref.dealloc %arg3 : memref<128x512xbf16>
+  memref.dealloc %wt : memref<128x512x2xbf16>
+  memref.dealloc %result : memref<128x512xbf16>
   return
 }

--- a/test/Integration/tpp-add.mlir
+++ b/test/Integration/tpp-add.mlir
@@ -71,6 +71,12 @@ func.func @entry() {
   %to_print = memref.cast %arg2 : memref<1x2x56x56x32xf32> to memref<*xf32>
   // EXE-COUNT-6272: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62]
   call @printMemrefF32(%to_print) : (memref<*xf32>) -> ()
+
+  memref.dealloc %arg0 : memref<56x32xf32>
+  memref.dealloc %arg1 : memref<56x32xf32>
+  memref.dealloc %arg2 : memref<1x2x56x56x32xf32>
+  memref.dealloc %seed : memref<?xf32>
+
   return
 }
 

--- a/test/Passes/DefaultPipeline/mixed.mlir
+++ b/test/Passes/DefaultPipeline/mixed.mlir
@@ -46,31 +46,6 @@ module @predict_function  {
 
 // -----
 
-// CHECK: func.func @buffer_dealloc(
-// CHECK-SAME:  %[[ARG0:.+]]: memref<512x128xf32>,
-// CHECK-SAME:  %[[ARG1:.+]]: memref<128x512xf32>,
-// CHECK-SAME:  %[[ARG2:.+]]: memref<512x512xf32>)
-func.func @buffer_dealloc(%A: memref<512x128xf32>,
-          %B: memref<128x512xf32>, %C: memref<512x512xf32>) {
-  // CHECK: %[[alloc:.*]] = memref.alloc
-  %0 = memref.alloc() : memref<512x512xf32>
-
-  // CHECK: call @xsmm_gemm_dispatch
-  // CHECK: %[[cast0:.*]] = memref.cast %[[ARG0]]
-  // CHECK: %[[cast1:.*]] = memref.cast %[[ARG1]]
-  // CHECK: %[[cast2:.*]] = memref.cast %[[alloc]]
-  // CHECK: call @xsmm_gemm_invoke({{.*}}%[[cast0]], %[[cast1]], %[[cast2]]
-  linalg.matmul ins(%A, %B : memref<512x128xf32>, memref<128x512xf32>) outs(%0 : memref<512x512xf32>)
-
-  // CHECK: memref.copy
-  memref.copy %0, %C : memref<512x512xf32> to memref<512x512xf32>
-
-  // CHECK: memref.dealloc %[[alloc]]
-  return
-}
-
-// -----
-
 // CHECK: func.func @buffer_no_dealloc(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,
 // CHECK-SAME:  %[[ARG1:.+]]: memref<8x4xf32>,
@@ -116,6 +91,8 @@ func.func @heap_to_stack(%A: memref<4x8xf32>,
   memref.copy %0, %C : memref<4x4xf32> to memref<4x4xf32>
 
   // CHECK-NOT: memref.dealloc
+  memref.dealloc %0 : memref<4x4xf32>
+
   return
 }
 


### PR DESCRIPTION
Removes 'BufferDeallocationPass' from the default pipeline. Currently, the pass creates deallocation in invalid places as it does not process correctly memory casts as aliases, which results in invalid buffer lifetime analysis.

Also, lack of automatic memory deallocation promotes safer memory management where users have to explicitly deallocate their buffers.