### PR TITLE
Parser/printer for perf ops

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -123,7 +123,7 @@ def Perf_BenchOp : Perf_Op<"bench",
 
     ```mlir
     %deltas = memref.alloc(%size) : memref<?xf64>
-    perf.bench (%n, %deltas : memref<?xf64>) {
+    perf.bench (%n, %deltas : i64, memref<?xf64>) {
       ... // body - ops under measurement
     }
     ```
@@ -143,7 +143,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     An example of a benchmark with an output result:
 
     ```mlir
-    %sum = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%val : i32) {
+    %sum = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%val : i32) {
       %sum_next = arith.addi %val, %cst : i32
       perf.yield %sum_next : i32
     } -> i32
@@ -154,7 +154,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     a benchmarking loop.
     For example, the following input:
     ```mlir
-    %res, ... = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%x, ... : ...) {
+    %res, ... = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%x, ... : ...) {
       ... // body - ops under measurement
 
       // Yield current iteration values to the next iteration iter_args (%x, ...)
@@ -188,12 +188,7 @@ def Perf_BenchOp : Perf_Op<"bench",
   let results = (outs Variadic<AnyType>:$bodyResults);
   let regions = (region SizedRegion<1>:$region);
 
-  let assemblyFormat = [{
-    `(` $numIters `,` $deltas `:` type($deltas) `)`
-    (`iter_args` `(` $iterArgs^ `:` type($iterArgs) `)`)?
-    $region attr-dict
-    (`->` type($bodyResults)^)?
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -230,8 +225,7 @@ def Perf_YieldOp : Perf_Op<"yield", [ HasParent<"BenchOp">,
   let arguments = (ins Variadic<AnyType>:$operands);
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 
-  let assemblyFormat =
-    [{  attr-dict ($operands^ `:` type($operands))? }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -247,13 +241,16 @@ def Perf_MeanOp : Perf_Op<"mean", []> {
     Example:
 
     ```mlir
+    %n = arith.constant 10 : i64
+    %size = arith.index_cast %n : i64 to index
+    %deltas = memref.alloc(%size) : memref<?xf64>
 
-    %deltas = perf.bench (%n) {
+    perf.bench (%n, %deltas: i64, memref<?xf64>) {
       ... // benchmarked code
-    } -> memref<?xf64>
+    }
 
     %mean = perf.mean(%deltas : memref<?xf64>) : f64
-
+    memref.dealloc %deltas : memref<?xf64>
     ```
   }];
 
@@ -285,14 +282,17 @@ def Perf_StdevOp : Perf_Op<"stdev", []> {
     Example:
 
     ```mlir
+    %n = arith.constant 10 : i64
+    %size = arith.index_cast %n : i64 to index
+    %deltas = memref.alloc(%size) : memref<?xf64>
 
-    %deltas = perf.bench (%n) {
+    perf.bench (%n, %deltas: i64, memref<?xf64>) {
       ... // benchmarked code
-    } -> memref<?xf64>
+    }
 
     %mean = perf.mean(%deltas : memref<?xf64>) : f64
     %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64
-
+    memref.dealloc %deltas : memref<?xf64>
     ```
   }];
 
@@ -326,10 +326,10 @@ def Perf_SinkOp : Perf_Op<"sink", [ConditionallySpeculatable]> {
 
     ```mlir
 
-    %deltas = perf.bench (%n) {
+    perf.bench (%n, %deltas: i64, memref<?xf64>) {
       %a = arith.addi %b, %c : i64
       perf.sink(%a) : i64 // make sure that 'addi' is not optimized away
-    } -> memref<?xf64>
+    }
 
     ```
   }];

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -8,6 +8,7 @@
 
 #include "TPP/Dialect/Perf/PerfOps.h"
 #include "TPP/Dialect/Perf/PerfDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -72,6 +73,146 @@ YieldOp BenchOp::getYieldOp() {
   return cast<perf::YieldOp>(getRegion().front().getTerminator());
 }
 
+void BenchOp::print(OpAsmPrinter &printer) {
+  printer << "(";
+  printer << getNumIters();
+  printer << ", ";
+  printer << getDeltas();
+  printer << " : ";
+  printer << getNumIters().getType();
+  printer << ", ";
+  {
+    auto type = getDeltas().getType();
+    if (auto validType = type.dyn_cast<::mlir::BaseMemRefType>())
+      printer.printStrippedAttrOrType(validType);
+    else
+      printer << type;
+  }
+  printer << ")";
+  if (!getIterArgs().empty()) {
+    printer << " iter_args";
+    printer << "(";
+    printer << getIterArgs();
+    printer << " : ";
+    printer << getIterArgs().getTypes();
+    printer << ")";
+  }
+  printer << ' ';
+
+  {
+    bool printTerminator = true;
+    if (auto *term = getRegion().empty() ? nullptr : getRegion().begin()->getTerminator()) {
+      printTerminator = !term->getAttrDictionary().empty() ||
+                        term->getNumOperands() != 0 ||
+                        term->getNumResults() != 0;
+    }
+    printer.printRegion(getRegion(), /*printEntryBlockArgs=*/true,
+      /*printBlockTerminators=*/printTerminator);
+  }
+  ::llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
+  printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
+  if (!getBodyResults().empty()) {
+    printer << " -> ";
+    printer << getBodyResults().getTypes();
+  }
+}
+
+ParseResult BenchOp::parse(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  SmallVector<Type> types;
+  SmallVector<llvm::SMLoc> locs;
+
+  // Types
+  // Avoid using parseTypeList because it crashes on GCC
+  auto parseType = [&]() -> ParseResult {
+    if (parser.parseType(types.emplace_back()))
+      return failure();
+    return success();
+  };
+
+  // Parse num_it + delta
+  if (parser.parseLParen())
+    return failure();
+
+  locs.push_back(parser.getCurrentLocation());
+  if (parser.parseOperand(operands.emplace_back()))
+    return failure();
+  if (parser.parseComma())
+    return failure();
+
+  locs.push_back(parser.getCurrentLocation());
+  if (parser.parseOperand(operands.emplace_back()))
+    return failure();
+  if (parser.parseColon())
+    return failure();
+
+  if (parser.parseCommaSeparatedList(parseType)) {
+    return failure();
+  }
+  if (parser.parseRParen())
+    return failure();
+
+  // Validate arguments
+  if (operands.size() != 2)
+    return parser.emitError(locs[0], "expect two arguments");
+  if (types.size() != 2)
+    return parser.emitError(locs[0], "expect two types for arguments");
+  if (parser.resolveOperand(operands[0], types[0], result.operands) ||
+      !types[0].isa<IntegerType>())
+    return parser.emitError(locs[0], "expect integer number of iterations");
+  if (parser.resolveOperand(operands[1], types[1], result.operands) ||
+      !types[1].isa<MemRefType>())
+    return parser.emitError(locs[1], "expect memref for results");
+  operands.clear();
+  types.clear();
+  locs.clear();
+
+  // Parse iter_args, if any
+  if (succeeded(parser.parseOptionalKeyword("iter_args"))) {
+    if (parser.parseLParen())
+      return failure();
+
+    locs.push_back(parser.getCurrentLocation());
+    if (parser.parseOperandList(operands))
+      return failure();
+    if (parser.parseColon())
+      return failure();
+
+    // Avoid using parseTypeList because it crashes on GCC
+    if (parser.parseCommaSeparatedList(parseType))
+      return failure();
+    if (parser.parseRParen())
+      return failure();
+
+    // Validate operands
+    if (!operands.size())
+      return parser.emitError(parser.getCurrentLocation(), "expect arguments");
+    if (operands.size() != types.size())
+      return parser.emitError(locs[0], "expect same number of types as args");
+    if (parser.resolveOperands(operands, types, locs[0], result.operands))
+      return failure();
+  }
+
+  // Parse region
+  auto region = std::make_unique<Region>();
+  if (parser.parseRegion(*region))
+    return failure();
+  ensureTerminator(*region, parser.getBuilder(), result.location);
+  result.addRegion(std::move(region));
+
+  // Attributes, if any
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  // Return type
+  SmallVector<Type> resultTypes;
+  if (parser.parseOptionalArrowTypeList(resultTypes))
+    return failure();
+  result.addTypes(resultTypes);
+
+  return success();
+}
+
 LogicalResult BenchOp::verify() {
   Operation *terminator = getRegion().front().getTerminator();
   if (!dyn_cast_or_null<perf::YieldOp>(terminator)) {
@@ -106,4 +247,50 @@ std::string SinkOp::applyTypeMangling(std::string name, Type type) {
       .Default([&](Type t) { mangledName << "_" << t; });
 
   return mangledName.str();
+}
+
+//===----------------------------------------------------------------------===//
+// YieldOp
+//===----------------------------------------------------------------------===//
+
+void YieldOp::print(OpAsmPrinter &printer) {
+  if (!getOperands().empty()) {
+    printer << ' ';
+    printer << getOperands();
+    printer << " : ";
+    printer << getOperands().getTypes();
+  }
+}
+
+ParseResult YieldOp::parse(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  SmallVector<Type> types;
+
+  // Attributes, if any
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  // Operands
+  if (parser.parseOperandList(operands))
+    return failure();
+
+  if (!operands.empty()) {
+    if (parser.parseColon())
+      return failure();
+
+    // Types
+    // Avoid using parseTypeList because it crashes on GCC
+    auto parseType = [&]() -> ParseResult {
+      if (parser.parseType(types.emplace_back()))
+        return failure();
+      return success();
+    };
+    if (parser.parseCommaSeparatedList(parseType))
+      return failure();
+  }
+
+  if (parser.resolveOperands(operands, types, parser.getCurrentLocation(),
+                             result.operands))
+    return failure();
+  return success();
 }

--- a/scripts/buildkite/tpp-mlir.yml
+++ b/scripts/buildkite/tpp-mlir.yml
@@ -16,7 +16,7 @@ steps:
 
   - label: "TPP-MLIR-gcc"
     command: "${SRUN} --partition=clxtrb,clxaptrb --time=0:30:00 -- \
-              'KIND=RelWithDebInfo COMPILER=gcc \
+              'KIND=RelWithDebInfo COMPILER=gcc CHECK=1 \
               $${BUILDKITE_BUILD_CHECKOUT_PATH}/scripts/buildkite/build_tpp.sh'"
 
   - label: "TPP-MLIR-clang"

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -150,7 +150,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
+  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>

--- a/test/Conversion/PerfToLoops/perf-to-loops.mlir
+++ b/test/Conversion/PerfToLoops/perf-to-loops.mlir
@@ -102,7 +102,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
+  %res = perf.bench (%n: i64, %deltas : memref<?xf64>) iter_args(%output : i64) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>
@@ -144,7 +144,7 @@ func.func @perf_example_multi_arg(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]], %[[mulres]]
   // CHECK: }
-  %res, %res1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output, %output1 : i64, tensor<4x4xf32>) {
+  %res, %res1 = perf.bench (%n: i64, %deltas : memref<?xf64>) iter_args(%output, %output1 : i64, tensor<4x4xf32>) {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     %sum = arith.addi %output, %k : i64

--- a/test/Dialect/Perf/perf-invalid.mlir
+++ b/test/Dialect/Perf/perf-invalid.mlir
@@ -6,7 +6,7 @@ func.func @perf_no_outs(%n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) {
     perf.sink(%n) : i64
   } -> i64
 
@@ -22,7 +22,7 @@ func.func @perf_invalid_outs_types(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
   } -> i32
@@ -40,10 +40,10 @@ func.func @perf_invalid_outs_order(%a: i32, %b: i32, %n: i64) {
   %out1 = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
-  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out1, %out : i64, i32) {
+  %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out1, %out : i64, i32) {
     %c = arith.addi %a, %b : i32
     perf.yield %c, %n : i32, i64
-  } -> i32, i64
+  } -> (i32, i64)
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -57,7 +57,7 @@ func.func @perf_no_yield(%n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i64) {
     perf.sink(%n) : i64
   } -> i64
 
@@ -73,7 +73,7 @@ func.func @perf_invalid_yield_op(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
 
   // expected-error @below {{perf.bench' op expects region to terminate with 'perf.yield'}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i32) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i32) {
     %c = arith.addi %a, %b : i32
     // expected-note @below {{terminator here}}
     scf.yield %c : i32
@@ -91,7 +91,7 @@ func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out : i64) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
   } -> i64
@@ -109,10 +109,10 @@ func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
   %out1 = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val, %val1 = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%out, %out1 : i32, i64) {
+  %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out, %out1 : i32, i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %n, %c : i64, i32
-  } -> i32, i64
+  } -> (i32, i64)
 
   memref.dealloc %deltas : memref<?xf64>
   return

--- a/test/Dialect/Perf/perf-ops.mlir
+++ b/test/Dialect/Perf/perf-ops.mlir
@@ -39,11 +39,12 @@ func.func @perf_matmul_bench(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
 
   // CHECK: perf.bench
-  perf.bench (%n, %deltas : memref<?xf64>) {
+  perf.bench (%n, %deltas : i64, memref<?xf64>) {
     // CHECK: linalg.matmul
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     // CHECK: perf.sink
     perf.sink(%D) : tensor<4x4xf32>
+    perf.yield
   }
 
   // CHECK: perf.mean
@@ -94,7 +95,7 @@ func.func @perf_yield_empty(%a: i32, %b: i32, %n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
 
   // CHECK: perf.bench
-  perf.bench (%n, %deltas : memref<?xf64>) {
+  perf.bench (%n, %deltas : i64, memref<?xf64>) {
     // CHECK: arith.addi
     %c = arith.addi %a, %b : i32
     // CHECK: perf.sink
@@ -115,7 +116,7 @@ func.func @perf_yield_result(%a: i32, %b: i32, %n: i64) -> i32 {
   %bench_res = arith.constant 0 : i32
 
   // CHECK: %[[out:.*]] = perf.bench
-  %out = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%bench_res : i32) {
+  %out = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%bench_res : i32) {
     // CHECK: %[[c:.*]] = arith.addi
     %c = arith.addi %a, %b : i32
     // CHECK: perf.yield %[[c]]
@@ -138,7 +139,7 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   %output = arith.constant 0 : i64
 
   // CHECK: %[[res:.*]] = perf.bench
-  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
+  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%output : i64) {
     // CHECK: %[[mulres:.*]] = linalg.matmul
     // CHECK: perf.sink(%[[mulres]])
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)

--- a/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
+++ b/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
@@ -31,7 +31,7 @@ func.func @perf_dialect(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
   %output = arith.constant 0 : i64
 
-  %res = perf.bench (%n, %deltas : memref<?xf64>) iter_args(%output : i64) {
+  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%output : i64) {
     %sum = arith.addi %n, %n : i64
     perf.yield %sum : i64
   } -> i64


### PR DESCRIPTION
Adds a parser and printer for both bench and yield ops as parseTypeList
was crashing the parser with `grow_pod` on `emplace_back`. This is
likely an upstream problem that isn't being hit by upstream tests
because no one uses `Variadic<>` quite like we do with the inline
assembly (and TableGen code).

So we add a custom parser/printer for both (mainly stolen from TableGen
implementation, replacing parseTypeList with parseCommaSeparatedList and
a similar lambda. This takes care of the GCC code generation crash.

Fixes #45