### PR TITLE
Adjust tpp-performance pipeline for report

### DIFF
--- a/cmake/modules/xsmm-dnn.cmake
+++ b/cmake/modules/xsmm-dnn.cmake
@@ -16,8 +16,8 @@ else()
 
   FetchContent_Declare(
     xsmm_dnn
-    URL https://github.com/libxsmm/libxsmm-dnn/archive/9fbb9e3c2d3b23a7d5cfe685bca2bceae998880b.tar.gz
-    URL_HASH SHA256=d3a17523d58640bd0bbb4d91a19c771fb66b119565ded7b6f20761f964cd92b2
+    URL https://github.com/libxsmm/libxsmm-dnn/archive/fc199ff7a8bb0796f336b5c39f933971aa3fbe0a.tar.gz
+    URL_HASH SHA256=ed9039ad8a5b1caaf815c436fb8054828518124cd511977bf793fc6f2c09068e
   )
 
   FetchContent_GetProperties(xsmm_dnn)

--- a/cmake/modules/xsmm.cmake
+++ b/cmake/modules/xsmm.cmake
@@ -13,8 +13,8 @@ else()
 
   FetchContent_Declare(
     xsmm
-    URL https://github.com/libxsmm/libxsmm/archive/a2b499c23682ad02a34349c563f8c6c71364030e.tar.gz
-    URL_HASH SHA256=51b7a555e200be3e5efd11489d7d2cb561f08e5fcd4972ffc94fb39bbadb6965
+    URL https://github.com/libxsmm/libxsmm/archive/1887b9924a548b4a66352498f11a950a9e2c3b99.tar.gz
+    URL_HASH SHA256=e9b686edf0c2880e7d34f7e4783ee3998dc53379151e843a0ddead167927df06
   )
 
   FetchContent_GetProperties(xsmm)

--- a/scripts/buildkite/tpp-benchmark.yml
+++ b/scripts/buildkite/tpp-benchmark.yml
@@ -18,8 +18,9 @@ steps:
       - "${SRUN} --partition=clx --time=0:30:00 -- \
             'KIND=Release COMPILER=clang LINKER=lld CHECK=1 BENCH=1 \
              scripts/buildkite/build_tpp.sh'"
-    artifact_paths:
-      - "$${BUILDKITE_BUILD_PATH}/../artifacts/${BUILDKITE_PIPELINE_SLUG}/$${BUILDKITE_BUILD_NUMBER}/*"
+      # make absolute path (do not resolve symlinks with pwd -P, mount point is different on head/compute node)
+      - buildkite-agent artifact upload \
+        "$(cd "$${BUILDKITE_BUILD_PATH}/../artifacts/${BUILDKITE_PIPELINE_SLUG}/$${BUILDKITE_BUILD_NUMBER}" && pwd)/*"
     env:
       LOGRPTSUM: "mlir"
       LOGRPTFMT: "svg pdf"

--- a/scripts/buildkite/tpp-performance.yml
+++ b/scripts/buildkite/tpp-performance.yml
@@ -10,15 +10,19 @@ env:
 
 steps:
   - label: "LLVM"
-    command: "${BUILDKITE_BUILD_CHECKOUT_PATH}/scripts/buildkite/check_llvm.sh"
+    command: "scripts/buildkite/check_llvm.sh"
   - wait
 
   - label: "TPP-MLIR-performance"
-    command: "${SRUN} --partition=clxtrb --time=1:30:00 -- \
-              'KIND=Release COMPILER=clang LINKER=lld \
-              $${BUILDKITE_BUILD_CHECKOUT_PATH}/scripts/buildkite/benchmark.sh'"
+    command:
+      - "${SRUN} --partition=clxtrb --time=1:30:00 -- \
+            'KIND=Release COMPILER=clang LINKER=lld \
+             scripts/buildkite/benchmark.sh'"
+      # make absolute path (do not resolve symlinks with pwd -P, mount point is different on head/compute node)
+      - buildkite-agent artifact upload \
+        "$(cd "$${BUILDKITE_BUILD_PATH}/../artifacts/${BUILDKITE_PIPELINE_SLUG}/$${BUILDKITE_BUILD_NUMBER}" && pwd)/*"
     env:
       LOGRPTSUM: "mlir"
-      #LOGRPTFMT: "svg"
       #LOGRPTBND: "-"
       LOGRPTQRY: ""
+      LOGRPTSEP: 1


### PR DESCRIPTION
* Cleanup absolute paths (BUILDKITE_BUILD_CHECKOUT_PATH is current directory by default).
* Untied figure by default (only PDF), no embedded figures.
* Updated LIBXSMM. Cleaned-up benchmark script.