### PR TITLE
Let benchmarks fail if last result deviates too much

### DIFF
--- a/scripts/buildkite/tpp-benchmark.yml
+++ b/scripts/buildkite/tpp-benchmark.yml
@@ -24,5 +24,5 @@ steps:
     env:
       LOGRPTSUM: "mlir"
       LOGRPTFMT: "svg pdf"
-      #LOGRPTBND: "-"
+      LOGRPTBND: "-"
       LOGRPTQRY: ""

--- a/scripts/buildkite/tpp-performance.yml
+++ b/scripts/buildkite/tpp-performance.yml
@@ -23,6 +23,6 @@ steps:
         "$(cd "$${BUILDKITE_BUILD_PATH}/../artifacts/${BUILDKITE_PIPELINE_SLUG}/$${BUILDKITE_BUILD_NUMBER}" && pwd)/*"
     env:
       LOGRPTSUM: "mlir"
-      #LOGRPTBND: "-"
+      LOGRPTBND: "-"
       LOGRPTQRY: ""
       LOGRPTSEP: 1


### PR DESCRIPTION
* Explain unit of measurement ("-" less is worse).
* Fail if performance regresses.