### PR TITLE
Disable transforms for default pipeline

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -410,9 +410,8 @@ private:
   void constructPipeline() override {
     pm.clear();
 
-    // Run transforms first and clean them up afterwards.
-    pm.addPass(createTransformPass());
-    pm.addNestedPass<func::FuncOp>(createCleanupPass());
+    // Default pipeline does not support transforms yet
+    pm.addPass(createTransformDropSchedulePass());
 
     // TODO: Add here propagation, constant fold and blocking.
 
@@ -424,7 +423,6 @@ private:
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
     } else {
       // Lower IR through TPP operations.
-      // Transform operations to be TPP compatible.
       pm.addPass(createTppMappingPass());
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
 

--- a/test/Integration/transform/transform-convolutions.mlir
+++ b/test/Integration/transform/transform-convolutions.mlir
@@ -5,8 +5,7 @@
 
 // RUN: tpp-opt %s -transform-dialect-interpreter | FileCheck %s -check-prefix=IR
 
-// See: #298
-// RUN: tpp-opt %s -transform-drop-schedule | \
+// RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: tpp-run -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s


### PR DESCRIPTION
We currently don't support transforms together with the default pipeline, so we shouldn't try to run it regardless. Once we start integrating transforms with the rest of the pipeline, we must have tests that show the integration as we activate more and more transforms.

For now, transforms need to be run manually via tpp-opt with the right flags.

Fixes #298