### PR TITLE
Remove concurrency group grom clang build

### DIFF
--- a/scripts/buildkite/tpp-mlir.yml
+++ b/scripts/buildkite/tpp-mlir.yml
@@ -22,8 +22,6 @@ steps:
               $${BUILDKITE_BUILD_CHECKOUT_PATH}/scripts/buildkite/build_tpp.sh'"
 
   - label: "TPP-MLIR-clang"
-    concurrency: 1
-    concurrency_group: "tpp-mlir"
     command: "${SRUN} --partition=clxtrb,clxaptrb --time=0:30:00 -- \
               'KIND=Debug COMPILER=clang LINKER=lld SANITIZERS=1 CHECK=1 \
               $${BUILDKITE_BUILD_CHECKOUT_PATH}/scripts/buildkite/build_tpp.sh'"


### PR DESCRIPTION
We don't install any build in the NFS, so we don't need concurrency groups anymore.