### PR TITLE
Fix TODO to use libxsmm for VNNI check (NFC)

### DIFF
--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -58,6 +58,7 @@ add_mlir_library(MLIRTPP
 
 target_include_directories(MLIRTPP
   PUBLIC
+    ${XSMM_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
 )

--- a/lib/TPP/VNNIUtils.cpp
+++ b/lib/TPP/VNNIUtils.cpp
@@ -11,23 +11,17 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/Types.h"
 
+#include "libxsmm.h"
+
 namespace mlir {
 namespace vnni {
 namespace utils {
 
 std::optional<int64_t> getVnniBlockingFactor(Type type) {
   auto elementType = getElementTypeOrSelf(type);
-  if (!elementType.isBF16())
-    return std::nullopt;
-  // @ TODO we should call LIBXSMM here to query the 
-  // VNNI packing factor we need to match to
-#if defined(__x86_64__)
-  return 2;
-#elif defined(__aarch64__)
-  return 4;
-#else
-#error Unsupported architecture
-#endif
+  if (elementType.isBF16())
+    return libxsmm_cpuid_dot_pack_factor(LIBXSMM_DATATYPE_BF16);
+  return std::nullopt;
 }
 
 bool isBF16Type(Type type) {


### PR DESCRIPTION
Does not change the semantics, just makes sure to use a libxsmm call instead of macros.

Working towards #561