### PR TITLE
Include extra libxsmm headers

### DIFF
--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -59,6 +59,7 @@ add_mlir_library(MLIRTPP
 target_include_directories(MLIRTPP
   PUBLIC
     ${XSMM_INCLUDE_DIRS}
+    ${XSMM_INCLUDE_DIRS}/../src/template
     $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
 )


### PR DESCRIPTION
Adds extra libxsmm include directory to address missing libxsmm_version.h header.