### PR TITLE
Add createGeneralizeTensorPackAndUnPackPass to Linalg lowering

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -419,6 +419,8 @@ private:
     if (linalgToLoops) {
       // Lower linalg directly to loops.
       // Skip all TPP transformations.
+      // Generalize tensor.pack and tensor.unpack.
+      pm.addPass(createGeneralizeTensorPackAndUnPackPass());
       pm.addPass(createBufferizePass());
       pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
       pm.addNestedPass<func::FuncOp>(createCleanupPass());

--- a/test/Integration/pack-unpack-conversion.mlir
+++ b/test/Integration/pack-unpack-conversion.mlir
@@ -6,6 +6,10 @@
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 
+// RUN: tpp-run %s -linalg-to-loops -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
 // FIXME: This test fails to bufferize when lowering linalg to loops
 
 func.func private @generate_1D_source(%width : index) -> tensor<?xf32> {


### PR DESCRIPTION
Pack and unpack weren't being bufferized correctly on the linalg pass because they weren't handled like the TPP side.

Fixes #397