### PR TITLE
Fix IREE-side XsmmRunnerUtils

### DIFF
--- a/lib/TPP/ConvertXsmmToFunc.cpp
+++ b/lib/TPP/ConvertXsmmToFunc.cpp
@@ -22,6 +22,11 @@ using namespace mlir::xsmm;
 #define GEN_PASS_CLASSES
 #include "TPP/Passes.h.inc"
 
+// NOTE: The ordering of operands to XSMM function calls as it is defined here
+// is strictly followed by XsmmRunnerUtils for IREE XSMM calls. Please change
+// the ordering of the fields in XsmmRunnerUtils for any such change in this
+// file.
+
 namespace {
 
 static SmallVector<Type> extractInvokeOperandTypes(OperandRange operands,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT TPP_INSIDE_IREE)
   target_compile_definitions(tpp_c_runner_utils PRIVATE mlir_c_runner_utils_EXPORTS)
 else()
   add_library(tpp_c_runner_utils
-    STATIC
+    SHARED
     XsmmRunnerUtils.cpp
     PerfRunnerUtils.cpp
   )

--- a/runtime/XsmmRunnerUtils.h
+++ b/runtime/XsmmRunnerUtils.h
@@ -79,21 +79,21 @@ extern "C" MLIR_RUNNERUTILS_EXPORT void xsmm_fused_brgemm_invoke(
 
 /// Eternal functions imported in IREE must pass everything via void*.
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_brgemm_dispatch(void *context, void *params, void *reserved);
+iree_xsmm_brgemm_dispatch(void *params, void *context, void *reserved);
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_gemm_dispatch(void *context, void *params, void *reserved);
+iree_xsmm_gemm_dispatch(void *params, void *context, void *reserved);
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_unary_dispatch(void *context, void *params, void *reserved);
+iree_xsmm_unary_dispatch(void *params, void *context, void *reserved);
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_binary_dispatch(void *context, void *params, void *reserved);
+iree_xsmm_binary_dispatch(void *params, void *context, void *reserved);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_brgemm_invoke(void *context, void *params, void *reserved);
+iree_xsmm_brgemm_invoke(void *params, void *context, void *reserved);
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_gemm_invoke(void *context, void *params, void *reserved);
+iree_xsmm_gemm_invoke(void *params, void *context, void *reserved);
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_unary_invoke(void *context, void *params, void *reserved);
+iree_xsmm_unary_invoke(void *params, void *context, void *reserved);
 extern "C" MLIR_RUNNERUTILS_EXPORT int
-iree_xsmm_binary_invoke(void *context, void *params, void *reserved);
+iree_xsmm_binary_invoke(void *params, void *context, void *reserved);
 
 #endif // TPP_EXECUTIONENGINE_CRUNNERUTILS_H


### PR DESCRIPTION
These changes with the latest changes in IREE work for all the models including BERT.

CMake change is needed as we now enable XSMM symbol resolver (i.e., TPP import) via IREE's Executable Plugin mechanism. With this change, the symbol resolver can be built separately from IREE.