### PR TITLE
Deallocate buffers returned by function calls

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -137,6 +137,7 @@ std::unique_ptr<OperationPass<gpu::GPUModuleOp>> createGpuToCudaPass();
 std::unique_ptr<OperationPass<gpu::GPUModuleOp>>
 createGpuToCudaPass(StringRef gpuTriple, StringRef gpuChip,
                     StringRef gpuFeatures);
+std::unique_ptr<OperationPass<func::FuncOp>> createDeallocReturnsPass();
 
 void registerTestStructuralMatchers();
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -411,6 +411,7 @@ def GpuToCuda : Pass<"gpu-to-cuda", "gpu::GPUModuleOp"> {
             /*default=*/"\"+ptx60\"",
            "GPU target features.">,
   ];
+}
 
 def DeallocReturns : Pass<"dealloc-returns", "func::FuncOp"> {
   let summary = "Deallocate returned buffers";

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -411,6 +411,13 @@ def GpuToCuda : Pass<"gpu-to-cuda", "gpu::GPUModuleOp"> {
             /*default=*/"\"+ptx60\"",
            "GPU target features.">,
   ];
+
+def DeallocReturns : Pass<"dealloc-returns", "func::FuncOp"> {
+  let summary = "Deallocate returned buffers";
+  let description = [{
+    Deallocate memory buffers returned by function calls.
+  }];
+  let constructor = "mlir::tpp::createDeallocReturnsPass()";
 }
 
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_library(MLIRTPP
     ConvertForAllToParallelOp.cpp
     CombineTpp.cpp
     HeapToStack.cpp
+    DeallocReturns.cpp
 
   # Utils
     TensorInit.cpp

--- a/lib/TPP/DeallocReturns.cpp
+++ b/lib/TPP/DeallocReturns.cpp
@@ -18,7 +18,7 @@ using namespace mlir;
 
 namespace {
 
-// Convert buffers from heap to stack allocation.
+// Deallocate buffers returned by function calls.
 struct DeallocFuncReturn : public OpRewritePattern<func::CallOp> {
   using OpRewritePattern<func::CallOp>::OpRewritePattern;
 
@@ -60,6 +60,7 @@ struct DeallocFuncReturn : public OpRewritePattern<func::CallOp> {
   }
 };
 
+// Deallocate returned buffers.
 struct DeallocReturns : public DeallocReturnsBase<DeallocReturns> {
   DeallocReturns() = default;
 

--- a/lib/TPP/DeallocReturns.cpp
+++ b/lib/TPP/DeallocReturns.cpp
@@ -38,6 +38,9 @@ struct DeallocFuncReturn : public OpRewritePattern<func::CallOp> {
       return rewriter.notifyMatchFailure(callOp, "Expected memref returns");
 
     auto terminator = callOp->getParentRegion()->begin()->getTerminator();
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(terminator);
+
     for (auto &buf : buffs) {
       // Do not deallocate if the buffer is returned from the current region.
       if (llvm::any_of(terminator->getOperands(),
@@ -50,8 +53,6 @@ struct DeallocFuncReturn : public OpRewritePattern<func::CallOp> {
           }))
         continue;
 
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPoint(terminator);
       rewriter.create<memref::DeallocOp>(loc, buf);
     }
 

--- a/lib/TPP/DeallocReturns.cpp
+++ b/lib/TPP/DeallocReturns.cpp
@@ -1,0 +1,77 @@
+//===- DeallocReturns.cpp ----------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+// Convert buffers from heap to stack allocation.
+struct DeallocFuncReturn : public OpRewritePattern<func::CallOp> {
+  using OpRewritePattern<func::CallOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::CallOp callOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = callOp.getLoc();
+    auto results = callOp.getResults();
+    if (results.size() == 0)
+      return rewriter.notifyMatchFailure(callOp, "Expected call return values");
+
+    SmallVector<Value> buffs;
+    for (auto result : results) {
+      if (result.getType().isa<MemRefType>())
+        buffs.push_back(result);
+    }
+    if (buffs.size() == 0)
+      return rewriter.notifyMatchFailure(callOp, "Expected memref returns");
+
+    auto terminator = callOp->getParentRegion()->begin()->getTerminator();
+    for (auto &buf : buffs) {
+      // Do not deallocate if the buffer is returned from the current region.
+      if (llvm::any_of(terminator->getOperands(),
+                       [&](Value op) { return op == buf; }))
+        continue;
+
+      // Do nothing if there is a deallocator already.
+      if (llvm::any_of(buf.getUsers(), [](Operation *user) {
+            return isa<memref::DeallocOp>(user);
+          }))
+        continue;
+
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(terminator);
+      rewriter.create<memref::DeallocOp>(loc, buf);
+    }
+
+    return success();
+  }
+};
+
+struct DeallocReturns : public DeallocReturnsBase<DeallocReturns> {
+  DeallocReturns() = default;
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(getOperation().getContext());
+    patterns.add<DeallocFuncReturn>(patterns.getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createDeallocReturnsPass() {
+  return std::make_unique<DeallocReturns>();
+}

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -31,7 +31,7 @@
 !tensor_print_t = tensor<1x8xf32>
 
 func.func @multi_head_attention(
-        %input : !multi_head_attention_input_tensor_t, %output : !tensor_print_t) -> !tensor_print_t {
+        %input : !multi_head_attention_input_tensor_t) -> !tensor_print_t {
     %cst = arith.constant 0xFF800000 : f32
     %cst_0 = arith.constant -0.000000e+00 : f32
     %cst_1 = arith.constant 0.000000e+00 : f32
@@ -252,12 +252,12 @@ func.func @multi_head_attention(
       linalg.yield %490 : f32
     } -> tensor<32x8x128xf32>
     // Extract a 2D slice for printing
+    // Explicitly copy the slice to a tensor which can be returned
     %149 = tensor.extract_slice %148[0, 0, 0][1, 1, 8][1, 1, 1] : tensor<32x8x128xf32> to !tensor_print_t
-    // Copy the slice to the argument output tensor
-    // This ensures that no allocated buffers are returned from the test kernel which prevent memory leaks
-    %ret = linalg.copy ins(%149 : !tensor_print_t) outs(%output : !tensor_print_t) -> !tensor_print_t
+    %150 = tensor.empty() : !tensor_print_t
+    %151 = linalg.copy ins(%149 : !tensor_print_t) outs(%150 : !tensor_print_t) -> !tensor_print_t
 
-    return %ret : !tensor_print_t
+    return %151 : !tensor_print_t
 }
 
 // Output

--- a/test/Passes/dealloc-return.mlir
+++ b/test/Passes/dealloc-return.mlir
@@ -1,0 +1,96 @@
+// RUN: tpp-opt %s -split-input-file | FileCheck %s
+// -return-dealloc
+
+func.func @kernel(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
+  %c0 = arith.constant 0 : index
+  %c5_i64 = arith.constant 5 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c8_i64 = arith.constant 8 : i64
+  %c0_i64 = arith.constant 0 : i64
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+  %0 = call @xsmm_unary_dispatch(%c5_i64, %c1_i64, %c8_i64, %c8_i64, %c8_i64, %c8_i64, %c0_i64) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+  %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<8x8xf32> -> index
+  %1 = arith.index_cast %intptr : index to i64
+  %2 = llvm.inttoptr %1 : i64 to !llvm.ptr<f32>
+  %intptr_0 = memref.extract_aligned_pointer_as_index %alloc : memref<8x8xf32> -> index
+  %3 = arith.index_cast %intptr_0 : index to i64
+  %4 = llvm.inttoptr %3 : i64 to !llvm.ptr<f32>
+  call @xsmm_unary_invoke(%c1_i64, %0, %2, %c0, %4, %c0) : (i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index) -> ()
+  return %alloc : memref<8x8xf32>
+}
+
+func.func private @xsmm_unary_invoke(i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index)
+func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
+
+func.func @alloc_return() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant -1.000000e+00 : f32
+  %cst_0 = arith.constant -1.000000e+01 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+  linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<8x8xf32>)
+  %0 = call @kernel(%alloc) : (memref<8x8xf32>) -> memref<8x8xf32>
+  %1 = vector.transfer_read %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<8x8xf32>, vector<8x8xf32>
+  vector.print %1 : vector<8x8xf32>
+  memref.dealloc %alloc : memref<8x8xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @alloc_return
+// CHECK: %[[alloc:.+]] = memref.alloc
+// CHECK: %[[ret:.+]] = call @kernel
+// CHECK-DAG: memref.dealloc %[[alloc]]
+// CHECK-DAG: memref.dealloc %[[ret]]
+// CHECK: return
+
+// -----
+
+func.func @kernel(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
+  %c0 = arith.constant 0 : index
+  %c5_i64 = arith.constant 5 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c8_i64 = arith.constant 8 : i64
+  %c0_i64 = arith.constant 0 : i64
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+  %0 = call @xsmm_unary_dispatch(%c5_i64, %c1_i64, %c8_i64, %c8_i64, %c8_i64, %c8_i64, %c0_i64) : (i64, i64, i64, i64, i64, i64, i64) -> i64
+  %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<8x8xf32> -> index
+  %1 = arith.index_cast %intptr : index to i64
+  %2 = llvm.inttoptr %1 : i64 to !llvm.ptr<f32>
+  %intptr_0 = memref.extract_aligned_pointer_as_index %alloc : memref<8x8xf32> -> index
+  %3 = arith.index_cast %intptr_0 : index to i64
+  %4 = llvm.inttoptr %3 : i64 to !llvm.ptr<f32>
+  call @xsmm_unary_invoke(%c1_i64, %0, %2, %c0, %4, %c0) : (i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index) -> ()
+  return %alloc : memref<8x8xf32>
+}
+
+func.func @middleman(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
+  %0 = call @kernel(%arg0) : (memref<8x8xf32>) -> memref<8x8xf32>
+  return %0 : memref<8x8xf32>
+}
+
+func.func private @xsmm_unary_invoke(i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index)
+func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
+
+func.func @chained_alloc_return() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant -1.000000e+00 : f32
+  %cst_0 = arith.constant -1.000000e+01 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+  linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<8x8xf32>)
+  %0 = call @middleman(%alloc) : (memref<8x8xf32>) -> memref<8x8xf32>
+  %1 = vector.transfer_read %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<8x8xf32>, vector<8x8xf32>
+  vector.print %1 : vector<8x8xf32>
+  memref.dealloc %alloc : memref<8x8xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @middleman
+// CHECK: %[[ret:.+]] = call @kernel
+// CHECK-NOT: memref.dealloc %[[ret]]
+// CHECK: return %[[ret]]
+
+// CHECK-LABEL: func.func @chained_alloc_return
+// CHECK: %[[alloc:.+]] = memref.alloc
+// CHECK: %[[ret:.+]] = call @middleman
+// CHECK-DAG: memref.dealloc %[[alloc]]
+// CHECK-DAG: memref.dealloc %[[ret]]
+// CHECK: return

--- a/test/Passes/dealloc-returns.mlir
+++ b/test/Passes/dealloc-returns.mlir
@@ -135,3 +135,72 @@ func.func @multiple_alloc_returns() {
 // CHECK-DAG: memref.dealloc %[[ret]]#0
 // CHECK-DAG: memref.dealloc %[[ret]]#1
 // CHECK: return
+
+// -----
+
+func.func @kernel(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
+  %alloc = memref.alloc() : memref<8x8xf32>
+  memref.copy %arg0, %alloc : memref<8x8xf32> to memref<8x8xf32>
+  return %alloc : memref<8x8xf32>
+}
+
+func.func @manual_dealloc() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant -1.000000e+00 : f32
+  %cst_0 = arith.constant -1.000000e+01 : f32
+
+  %alloc = memref.alloc() : memref<8x8xf32>
+  linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<8x8xf32>)
+  %0 = call @kernel(%alloc) : (memref<8x8xf32>) -> memref<8x8xf32>
+
+  %1 = vector.transfer_read %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<8x8xf32>, vector<8x8xf32>
+  vector.print %1 : vector<8x8xf32>
+
+  memref.dealloc %alloc : memref<8x8xf32>
+  memref.dealloc %0 : memref<8x8xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @manual_dealloc
+// CHECK: %[[alloc:.+]] = memref.alloc
+// CHECK: %[[ret:.+]] = call @kernel
+// CHECK-DAG: memref.dealloc %[[alloc]]
+// CHECK-DAG: memref.dealloc %[[ret]]
+// CHECK-NOT: memref.dealloc %[[ret]]
+// CHECK: return
+
+// -----
+
+func.func @kernel(%arg0: memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>) {
+  %cst = arith.constant 42 : i32
+  %alloc = memref.alloc() : memref<8x8xf32>
+  memref.copy %arg0, %alloc : memref<8x8xf32> to memref<8x8xf32>
+  %alloc1 = memref.alloc() : memref<8x8xf32>
+  return %alloc1, %alloc : memref<8x8xf32>, memref<8x8xf32>
+}
+
+func.func @partial_manual_dealloc() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant -1.000000e+00 : f32
+  %cst_0 = arith.constant -1.000000e+01 : f32
+
+  %alloc = memref.alloc() : memref<8x8xf32>
+  linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<8x8xf32>)
+  %a1, %a0 = call @kernel(%alloc) : (memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>)
+
+  %1 = vector.transfer_read %a0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<8x8xf32>, vector<8x8xf32>
+  vector.print %1 : vector<8x8xf32>
+
+  memref.dealloc %alloc : memref<8x8xf32>
+  memref.dealloc %a0 : memref<8x8xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @partial_manual_dealloc
+// CHECK: %[[alloc:.+]] = memref.alloc
+// CHECK: %[[ret:.+]]:2 = call @kernel
+// CHECK-DAG: memref.dealloc %[[alloc]]
+// CHECK-DAG: memref.dealloc %[[ret]]#0
+// CHECK-DAG: memref.dealloc %[[ret]]#1
+// CHECK-NOT: memref.dealloc %[[ret]]
+// CHECK: return

--- a/test/Passes/dealloc-returns.mlir
+++ b/test/Passes/dealloc-returns.mlir
@@ -1,35 +1,23 @@
 // RUN: tpp-opt %s -split-input-file -dealloc-returns | FileCheck %s
 
 func.func @kernel(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
-  %c0 = arith.constant 0 : index
-  %c5_i64 = arith.constant 5 : i64
-  %c1_i64 = arith.constant 1 : i64
-  %c8_i64 = arith.constant 8 : i64
-  %c0_i64 = arith.constant 0 : i64
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
-  %0 = call @xsmm_unary_dispatch(%c5_i64, %c1_i64, %c8_i64, %c8_i64, %c8_i64, %c8_i64, %c0_i64) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-  %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<8x8xf32> -> index
-  %1 = arith.index_cast %intptr : index to i64
-  %2 = llvm.inttoptr %1 : i64 to !llvm.ptr<f32>
-  %intptr_0 = memref.extract_aligned_pointer_as_index %alloc : memref<8x8xf32> -> index
-  %3 = arith.index_cast %intptr_0 : index to i64
-  %4 = llvm.inttoptr %3 : i64 to !llvm.ptr<f32>
-  call @xsmm_unary_invoke(%c1_i64, %0, %2, %c0, %4, %c0) : (i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index) -> ()
+  %alloc = memref.alloc() : memref<8x8xf32>
+  memref.copy %arg0, %alloc : memref<8x8xf32> to memref<8x8xf32>
   return %alloc : memref<8x8xf32>
 }
-
-func.func private @xsmm_unary_invoke(i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index)
-func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
 
 func.func @alloc_return() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant -1.000000e+00 : f32
   %cst_0 = arith.constant -1.000000e+01 : f32
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+
+  %alloc = memref.alloc() : memref<8x8xf32>
   linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<8x8xf32>)
   %0 = call @kernel(%alloc) : (memref<8x8xf32>) -> memref<8x8xf32>
+
   %1 = vector.transfer_read %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<8x8xf32>, vector<8x8xf32>
   vector.print %1 : vector<8x8xf32>
+
   memref.dealloc %alloc : memref<8x8xf32>
   return
 }
@@ -44,20 +32,8 @@ func.func @alloc_return() {
 // -----
 
 func.func @kernel(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
-  %c0 = arith.constant 0 : index
-  %c5_i64 = arith.constant 5 : i64
-  %c1_i64 = arith.constant 1 : i64
-  %c8_i64 = arith.constant 8 : i64
-  %c0_i64 = arith.constant 0 : i64
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
-  %0 = call @xsmm_unary_dispatch(%c5_i64, %c1_i64, %c8_i64, %c8_i64, %c8_i64, %c8_i64, %c0_i64) : (i64, i64, i64, i64, i64, i64, i64) -> i64
-  %intptr = memref.extract_aligned_pointer_as_index %arg0 : memref<8x8xf32> -> index
-  %1 = arith.index_cast %intptr : index to i64
-  %2 = llvm.inttoptr %1 : i64 to !llvm.ptr<f32>
-  %intptr_0 = memref.extract_aligned_pointer_as_index %alloc : memref<8x8xf32> -> index
-  %3 = arith.index_cast %intptr_0 : index to i64
-  %4 = llvm.inttoptr %3 : i64 to !llvm.ptr<f32>
-  call @xsmm_unary_invoke(%c1_i64, %0, %2, %c0, %4, %c0) : (i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index) -> ()
+  %alloc = memref.alloc() : memref<8x8xf32>
+  memref.copy %arg0, %alloc : memref<8x8xf32> to memref<8x8xf32>
   return %alloc : memref<8x8xf32>
 }
 
@@ -66,18 +42,18 @@ func.func @middleman(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
   return %0 : memref<8x8xf32>
 }
 
-func.func private @xsmm_unary_invoke(i64, i64, !llvm.ptr<f32>, index, !llvm.ptr<f32>, index)
-func.func private @xsmm_unary_dispatch(i64, i64, i64, i64, i64, i64, i64) -> i64
-
 func.func @chained_alloc_return() {
   %c0 = arith.constant 0 : index
   %cst = arith.constant -1.000000e+00 : f32
   %cst_0 = arith.constant -1.000000e+01 : f32
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8xf32>
+
+  %alloc = memref.alloc() : memref<8x8xf32>
   linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<8x8xf32>)
   %0 = call @middleman(%alloc) : (memref<8x8xf32>) -> memref<8x8xf32>
+
   %1 = vector.transfer_read %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<8x8xf32>, vector<8x8xf32>
   vector.print %1 : vector<8x8xf32>
+
   memref.dealloc %alloc : memref<8x8xf32>
   return
 }

--- a/test/Passes/dealloc-returns.mlir
+++ b/test/Passes/dealloc-returns.mlir
@@ -1,5 +1,4 @@
-// RUN: tpp-opt %s -split-input-file | FileCheck %s
-// -return-dealloc
+// RUN: tpp-opt %s -split-input-file -dealloc-returns | FileCheck %s
 
 func.func @kernel(%arg0: memref<8x8xf32>) -> memref<8x8xf32> {
   %c0 = arith.constant 0 : index
@@ -84,13 +83,13 @@ func.func @chained_alloc_return() {
 }
 
 // CHECK-LABEL: func.func @middleman
-// CHECK: %[[ret:.+]] = call @kernel
-// CHECK-NOT: memref.dealloc %[[ret]]
-// CHECK: return %[[ret]]
+// CHECK: %[[retKernel:.+]] = call @kernel
+// CHECK-NOT: memref.dealloc %[[retKernel]]
+// CHECK: return %[[retKernel]]
 
 // CHECK-LABEL: func.func @chained_alloc_return
 // CHECK: %[[alloc:.+]] = memref.alloc
-// CHECK: %[[ret:.+]] = call @middleman
+// CHECK: %[[retMid:.+]] = call @middleman
 // CHECK-DAG: memref.dealloc %[[alloc]]
-// CHECK-DAG: memref.dealloc %[[ret]]
+// CHECK-DAG: memref.dealloc %[[retMid]]
 // CHECK: return

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -403,6 +403,10 @@ LogicalResult MLIRBench::finalize(PrintStage print) {
   passManager.addPass(createConvertVectorToSCFPass());
   passManager.addPass(arith::createArithExpandOpsPass());
   passManager.addPass(createLowerAffinePass());
+  // Dealloc buffers returned from function calls
+  // This addresses memory leaks when test kernels are not bufferized
+  // using destination passing style
+  passManager.addNestedPass<func::FuncOp>(tpp::createDeallocReturnsPass());
 
   // Print IR of optimized kernel and main
   if (print == PrintStage::Late)


### PR DESCRIPTION
Adds a new pass that tries to insert missing deallocations for buffers returned by function calls.

This aims to address memory leaks that can occur when test kernels are not bufferized using destination passing style or when it is desirable to return a new buffer from a function.
Additionally, the existing models are cleaned up to use simple `func(input) -> output` data flow style.

Work towards #488 