### PR TITLE
Tensor init integers

### DIFF
--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -15,14 +15,13 @@
 #include <vector>
 
 // Base class.
-template <typename T>
-struct TensorInit {
+template <typename T> struct TensorInit {
   TensorInit() : size(1) {}
   virtual ~TensorInit() {}
 
   // Returns a dense attribute with a specified shape, initialized
   // with a particular implementation (see derived classes) with
-  // a reasonable distribution (0.0 ~ 1.0)
+  // a reasonable distribution
   virtual mlir::DenseElementsAttr get(mlir::ShapedType shape) = 0;
 
 protected:
@@ -32,10 +31,10 @@ protected:
   std::vector<T> buffer;
 
   // Insert element indexed on the buffer
-  virtual void insert(size_t index, float value) = 0;
+  virtual void insert(size_t index, T value);
 
   // Insert element at the end of the buffer
-  virtual void push(T value) = 0;
+  virtual void push(T value);
 
   // Convert value to the tensor's data type (by reference)
   virtual void convertType(T &value) = 0;

--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -1,8 +1,14 @@
 //===- TensorInit.h - MLIR Tensor Initialization --------------------------===//
 //
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
 // Initializes tensors for kernel input/output handling with some reasonable
 // distribution to allow for layout testing (reorder, pad) without vanishing
-// or exploding values at the end of a large model (0.0 ~ 1.0).
+// or exploding values.
 //
 //===----------------------------------------------------------------------===//
 

--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -12,146 +12,40 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Types.h"
 
-#include <algorithm>
-#include <random>
 #include <vector>
 
-/// Base class
-/// Assumes float (32) as base type.
-/// TODO: Add a template parameter if/when we support double.
+// Base class.
+template <typename T>
 struct TensorInit {
-  /// Data type (TODO: Support 8-bit data types)
-  enum DataType { FP32, FP64, BF16 };
+  TensorInit() : size(1) {}
+  virtual ~TensorInit() {}
 
-  static bool isTypeSupported(const mlir::Type &type) {
-    return type.isF32() || type.isF64() || type.isBF16();
-  }
+  // Returns a dense attribute with a specified shape, initialized
+  // with a particular implementation (see derived classes) with
+  // a reasonable distribution (0.0 ~ 1.0)
+  virtual mlir::DenseElementsAttr get(mlir::ShapedType shape) = 0;
 
 protected:
-  /// FP32 conversion (by reference)
-  static void toFP32(llvm::APFloat &value) {
-    bool ignored;
-    value.convert(llvm::APFloat::IEEEsingle(),
-                  llvm::APFloat::rmNearestTiesToEven, &ignored);
-  }
-
-  /// FP64 conversion (by reference)
-  static void toFP64(llvm::APFloat &value) {
-    bool ignored;
-    value.convert(llvm::APFloat::IEEEdouble(),
-                  llvm::APFloat::rmNearestTiesToEven, &ignored);
-  }
-
-  /// BF16 conversion (by reference)
-  static void toBF16(llvm::APFloat &value) {
-    bool ignored;
-    value.convert(llvm::APFloat::BFloat(), llvm::APFloat::rmNearestTiesToEven,
-                  &ignored);
-  }
-
-  /// Data type
-  DataType type;
-  /// Number of elements in the shape
+  // Number of elements in the shape
   size_t size;
-  /// Data pointer
-  std::vector<llvm::APFloat> buffer;
+  // Data pointer
+  std::vector<T> buffer;
 
-  /// Resize the buffer with the total allocation size
-  void allocateBuffer();
+  // Insert element indexed on the buffer
+  virtual void insert(size_t index, float value) = 0;
 
-  /// Insert element indexed on the buffer
-  void insert(size_t index, float value);
+  // Insert element at the end of the buffer
+  virtual void push(T value) = 0;
 
-  /// Insert element at the end of the buffer
-  void push(float value);
+  // Convert value to the tensor's data type (by reference)
+  virtual void convertType(T &value) = 0;
 
-  /// Convert value to the tensor's data type (by reference)
-  void convertType(llvm::APFloat &value);
-
-  /// Actual implementation that fills the buffer
-  /// To be implemented by derived classes.
+  // Actual implementation that fills the buffer
+  // To be implemented by derived classes.
   virtual void fillData() = 0;
-
-public:
-  /// Returns a dense attribute with a specified shape, initialized
-  /// with a particular implementation (see derived classes) with
-  /// a reasonable distribution (0.0 ~ 1.0)
-  virtual mlir::DenseElementsAttr get(mlir::ShapedType shape);
-
-  /// DEBUG ONLY: Print a specific value as an fp32 (regardless of data type)
-  float at(size_t index);
-
-  TensorInit(DataType type) : type(type), size(1) {}
-  virtual ~TensorInit() {}
 };
 
-/// Constant init (all-ones, do not use!)
-struct ConstantTensorInit : TensorInit {
-  ConstantTensorInit(DataType type) : TensorInit(type) {}
-
-  /// Return a dense<1.0> repeated throughout the shape
-  mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
-
-  void fillData() override;
-};
-
-/// Simple init (basic example, not useful)
-struct SimpleTensorInit : TensorInit {
-  SimpleTensorInit(DataType type) : TensorInit(type) {}
-
-  /// Return a dense<0.3, 0.6, 0.9> repeated throughout the shape
-  void fillData() override;
-};
-
-/// Continuous init (normalized affine range)
-struct ContinuousTensorInit : TensorInit {
-  ContinuousTensorInit(DataType type) : TensorInit(type) {}
-
-  /// Return a dense<0.0 ... 1.0> throughout the shape
-  void fillData() override;
-};
-
-/// Random init (uniform)
-struct RandomTensorInit : TensorInit {
-  RandomTensorInit(DataType type, int seed)
-      : TensorInit(type), generator(seed), distribution(0.0, 1.0) {}
-
-  /// Next random uniform number
-  float next() { return distribution(generator); }
-
-  /// Return a dense<uniform(0.0, 1.0)> throughout the shape
-  void fillData() override;
-
-private:
-  /// Random generator
-  std::default_random_engine generator;
-  /// Random distribution
-  std::uniform_real_distribution<float> distribution;
-};
-
-/// Random init (normal)
-struct NormalTensorInit : TensorInit {
-  NormalTensorInit(DataType type, int seed)
-      : TensorInit(type), generator(seed), distribution(0.0, 0.2) {}
-
-  /// Next random number
-  float next() {
-    auto value = distribution(generator);
-    value = std::clamp(value, 0.0f, 1.0f);
-    return value;
-  }
-
-  /// Return a dense<normal(0.0, 1.0)> throughout the shape
-  void fillData() override;
-
-private:
-  /// Random generator
-  std::default_random_engine generator;
-  /// Random distribution
-  std::normal_distribution<float> distribution;
-};
-
-/// Initialization type, to use with the getter below
+// Initialization type, to use with the getter below
 enum class TensorInitType {
   Auto,
   Constant,
@@ -162,21 +56,18 @@ enum class TensorInitType {
   Invalid
 };
 
-/// Unique pointer for tensor init to help with memory management
+// Unique pointer for tensor init to help with memory management
 using TensorInitPtr = std::unique_ptr<TensorInit>;
 
-/// Parse init type string into TensorInitType
+// Parse init type string into TensorInitType
 TensorInitType parseTensorInitType(llvm::StringRef name);
 
-/// Return an initializer smart pointer (via init type)
+// Return an initializer smart pointer (via init type)
 TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType,
                             int seed = 0);
 
-/// Return an initializer smart pointer (via string init)
+// Return an initializer smart pointer (via string init)
 TensorInitPtr getTensorInit(llvm::StringRef type, mlir::Type elmType,
                             int seed = 0);
 
-/// Get data type from element type
-TensorInit::DataType getTensorInitDataType(mlir::Type type);
-
-#endif
+#endif // TPP_RUN_TENSORINIT_H

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -18,7 +18,7 @@
 
 // Base class for float values.
 struct TensorInitFloat : public TensorInit<llvm::APFloat> {
-  // Data type. (TODO: Support 8-bit data types)
+  // Supported data types. (TODO: Support 8-bit data types)
   enum class DataType { FP32, FP64, BF16 };
 
   static bool isTypeSupported(const mlir::Type &type) {

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -1,5 +1,11 @@
 //===- TensorInitFloat.h - MLIR Tensor Initialization ---------------------===//
 //
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
 // Initializes tensors for kernel input/output handling with some reasonable
 // distribution to allow for layout testing (reorder, pad) without vanishing
 // or exploding values at the end of a large model (0.0 ~ 1.0).

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -58,11 +58,11 @@ protected:
 
   // Insert element indexed on the buffer.
   using TensorInit::insert;
-  void insert(size_t index, float value);
+  virtual void insert(size_t index, float value);
 
   // Insert element at the end of the buffer.
   using TensorInit::push;
-  void push(float value);
+  virtual void push(float value);
 
   // Convert value to the tensor's data type (by reference).
   void convertType(llvm::APFloat &value) override final;

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -1,0 +1,143 @@
+//===- TensorInitFloat.h - MLIR Tensor Initialization ---------------------===//
+//
+// Initializes tensors for kernel input/output handling with some reasonable
+// distribution to allow for layout testing (reorder, pad) without vanishing
+// or exploding values at the end of a large model (0.0 ~ 1.0).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_RUN_TENSORINITFLOAT_H
+#define TPP_RUN_TENSORINITFLOAT_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Types.h"
+
+#include <algorithm>
+#include <random>
+
+// Base class for float data types.
+struct TensorInitFloat :: public TensorInit<llvm::APFloat> {
+  // Data type. (TODO: Support 8-bit data types)
+  enum DataType { FP32, FP64, BF16 };
+
+  static bool isTypeSupported(const mlir::Type &type) const {
+    return type.isF32() || type.isF64() || type.isBF16();
+  }
+
+  // Get data type from element type
+  static DataType getTensorInitDataType(mlir::Type type) const;
+
+  TensorInitFloat(DataType type) : type(type) {}
+  virtual ~TensorInitFloat() {}
+
+  // Returns a dense attribute with a specified shape, initialized
+  // with a particular implementation (see derived classes) with
+  // a reasonable distribution (0.0 ~ 1.0).
+  virtual mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
+
+protected:
+  // FP32 conversion (by reference).
+  static void toFP32(llvm::APFloat &value) {
+    bool ignored;
+    value.convert(llvm::APFloat::IEEEsingle(),
+                  llvm::APFloat::rmNearestTiesToEven, &ignored);
+  }
+
+  // FP64 conversion (by reference).
+  static void toFP64(llvm::APFloat &value) {
+    bool ignored;
+    value.convert(llvm::APFloat::IEEEdouble(),
+                  llvm::APFloat::rmNearestTiesToEven, &ignored);
+  }
+
+  // BF16 conversion (by reference).
+  static void toBF16(llvm::APFloat &value) {
+    bool ignored;
+    value.convert(llvm::APFloat::BFloat(), llvm::APFloat::rmNearestTiesToEven,
+                  &ignored);
+  }
+
+  // Tensor element data type.
+  DataType type;
+
+  // Insert element indexed on the buffer.
+  void insert(size_t index, float value) override final;
+
+  // Insert element at the end of the buffer.
+  void push(float value) override final;
+
+  // Convert value to the tensor's data type (by reference).
+  void convertType(llvm::APFloat &value) override final;
+
+  // Actual implementation that fills the buffer
+  // To be implemented by derived classes.
+  virtual void fillData() override = 0;
+};
+
+// Constant init (all-ones, do not use!).
+struct ConstantTensorInitFloat : TensorInitFloat {
+  ConstantTensorInit(DataType type) : TensorInitFloat(type) {}
+
+  // Return a dense<1.0> repeated throughout the shape.
+  mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
+
+  void fillData() override;
+};
+
+// Simple init (basic example, not useful).
+struct SimpleTensorInitFloat : TensorInitFloat {
+  SimpleTensorInit(DataType type) : TensorInitFloat(type) {}
+
+  // Return a dense<0.3, 0.6, 0.9> repeated throughout the shape.
+  void fillData() override;
+};
+
+// Continuous init (normalized affine range).
+struct ContinuousTensorInitFloat : TensorInitFloat {
+  ContinuousTensorInit(DataType type) : TensorInitFloat(type) {}
+
+  // Return a dense<0.0 ... 1.0> throughout the shape.
+  void fillData() override;
+};
+
+// Random init (uniform).
+struct RandomTensorInitFloat : TensorInitFloat {
+  RandomTensorInit(DataType type, int seed)
+      : TensorInitFloat(type), generator(seed), distribution(0.0, 1.0) {}
+
+  // Next random uniform number.
+  float next() { return distribution(generator); }
+
+  // Return a dense<uniform(0.0, 1.0)> throughout the shape.
+  void fillData() override;
+
+private:
+  // Random generator.
+  std::default_random_engine generator;
+  // Random distribution.
+  std::uniform_real_distribution<float> distribution;
+};
+
+// Random init (normal).
+struct NormalTensorInitFloat : TensorInitFloat {
+  NormalTensorInit(DataType type, int seed)
+      : TensorInitFloat(type), generator(seed), distribution(0.0, 0.2) {}
+
+  // Next random number.
+  float next() {
+    auto value = distribution(generator);
+    value = std::clamp(value, 0.0f, 1.0f);
+    return value;
+  }
+
+  // Return a dense<normal(0.0, 1.0)> throughout the shape.
+  void fillData() override;
+
+private:
+  // Random generator.
+  std::default_random_engine generator;
+  // Random distribution.
+  std::normal_distribution<float> distribution;
+};
+
+#endif // TPP_RUN_TENSORINITFLOAT_H

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -16,7 +16,7 @@
 #include <random>
 
 // Base class for float data types.
-struct TensorInitFloat :: public TensorInit<llvm::APFloat> {
+struct TensorInitFloat : public TensorInit<llvm::APFloat> {
   // Data type. (TODO: Support 8-bit data types)
   enum DataType { FP32, FP64, BF16 };
 
@@ -59,12 +59,6 @@ protected:
 
   // Tensor element data type.
   DataType type;
-
-  // Insert element indexed on the buffer.
-  void insert(size_t index, float value) override final;
-
-  // Insert element at the end of the buffer.
-  void push(float value) override final;
 
   // Convert value to the tensor's data type (by reference).
   void convertType(llvm::APFloat &value) override final;

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -56,11 +56,11 @@ protected:
   // Tensor element data type.
   DataType type;
 
-  // Insert element indexed on the buffer
+  // Insert element indexed on the buffer.
   using TensorInit::insert;
   void insert(size_t index, float value);
 
-  // Insert element at the end of the buffer
+  // Insert element at the end of the buffer.
   using TensorInit::push;
   void push(float value);
 

--- a/include/TPP/TensorInitInt.h
+++ b/include/TPP/TensorInitInt.h
@@ -1,0 +1,137 @@
+//===- TensorInitInt.h - MLIR Tensor Initialization -----------------------===//
+//
+// Initializes tensors for kernel input/output handling with some reasonable
+// distribution to allow for layout testing (reorder, pad) without vanishing
+// or exploding values at the end of a large model (0.0 ~ 1.0).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_TENSORINITINT_H
+#define TPP_TENSORINITINT_H
+
+#include "TPP/TensorInit.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Types.h"
+
+#include <algorithm>
+#include <random>
+
+// Base class for integer values.
+struct TensorInitInt : public TensorInit<llvm::APInt> {
+  // Data type. (TODO: Support more data types)
+  enum class DataType { I8, I16, I32, I64 };
+
+  static bool isTypeSupported(const mlir::Type &type) {
+    return type.isInteger(8) || type.isInteger(16) || type.isInteger(32) ||
+           type.isInteger(64);
+  }
+
+  // Get data type from element type.
+  static DataType getTensorInitDataType(mlir::Type type);
+
+  // Get bit width from data type.
+  static unsigned getDataTypeBitWidth(DataType type);
+
+  // True if the data type is signed.
+  static bool isDataTypeSigned(DataType type);
+
+  TensorInitInt(DataType type)
+      : type(type), bitWidth(getDataTypeBitWidth(type)),
+        isSigned(isDataTypeSigned(type)) {}
+  virtual ~TensorInitInt() = default;
+
+protected:
+  // Tensor element data type.
+  DataType type;
+
+  // Bit width of the data type.
+  unsigned bitWidth;
+
+  // True if the data type is signed.
+  bool isSigned;
+
+  // Insert element indexed on the buffer.
+  using TensorInit::insert;
+  void insert(size_t index, uint64_t value);
+
+  // Insert element at the end of the buffer.
+  using TensorInit::push;
+  void push(uint64_t value);
+
+  // Convert value to the tensor's data type (by reference).
+  void convertType(llvm::APInt &value) override final;
+
+  // Actual implementation that fills the buffer
+  // To be implemented by derived classes.
+  virtual void fillData() override = 0;
+};
+
+// Constant init (all-ones, do not use!).
+struct ConstantTensorInitInt : TensorInitInt {
+  ConstantTensorInitInt(DataType type) : TensorInitInt(type) {}
+
+  // Return a dense<1> repeated throughout the shape.
+  mlir::DenseElementsAttr get(mlir::ShapedType shape) override;
+
+  void fillData() override;
+};
+
+// Simple init (basic example, not useful).
+struct SimpleTensorInitInt : TensorInitInt {
+  SimpleTensorInitInt(DataType type) : TensorInitInt(type) {}
+
+  // Return a dense<0, 1, 2> repeated throughout the shape.
+  void fillData() override;
+};
+
+// Continuous init (quantized normalized affine range).
+struct ContinuousTensorInitInt : TensorInitInt {
+  ContinuousTensorInitInt(DataType type) : TensorInitInt(type) {}
+
+  // Return a dense<0 ... upperBound> throughout the shape.
+  void fillData() override;
+
+  // Upper bound for quantization.
+  int upperBound = 255;
+};
+
+// Random init (uniform).
+struct RandomTensorInitInt : TensorInitInt {
+  RandomTensorInitInt(DataType type, int seed)
+      : TensorInitInt(type), generator(seed), distribution(0, 255) {}
+
+  // Next random uniform number.
+  float next() { return distribution(generator); }
+
+  // Return a dense<uniform(0, 255)> throughout the shape.
+  void fillData() override;
+
+private:
+  // Random generator.
+  std::default_random_engine generator;
+  // Random distribution.
+  std::uniform_int_distribution<uint64_t> distribution;
+};
+
+// Random init (normal).
+struct NormalTensorInitInt : TensorInitInt {
+  NormalTensorInitInt(DataType type, int seed)
+      : TensorInitInt(type), generator(seed), distribution(255, 0.5) {}
+
+  // Next random number.
+  float next() {
+    auto value = distribution(generator);
+    return value;
+  }
+
+  // Return a dense<normal(0.0, 1.0)> throughout the shape.
+  void fillData() override;
+
+private:
+  // Random generator.
+  std::default_random_engine generator;
+  // Random distribution.
+  std::binomial_distribution<uint64_t> distribution;
+};
+
+#endif // TPP_TENSORINITINT_H

--- a/include/TPP/TensorInitInt.h
+++ b/include/TPP/TensorInitInt.h
@@ -18,12 +18,13 @@
 
 // Base class for integer values.
 struct TensorInitInt : public TensorInit<llvm::APInt> {
-  // Data type. (TODO: Support more data types)
+  // Supported data types.
+  // TODO: Support signed (si32) and unsinged (ui32) integers
   enum class DataType { I8, I16, I32, I64 };
 
   static bool isTypeSupported(const mlir::Type &type) {
-    return type.isInteger(8) || type.isInteger(16) || type.isInteger(32) ||
-           type.isInteger(64);
+    return type.isSignlessInteger(8) || type.isSignlessInteger(16) ||
+           type.isSignlessInteger(32) || type.isSignlessInteger(64);
   }
 
   // Get data type from element type.
@@ -124,7 +125,7 @@ struct NormalTensorInitInt : TensorInitInt {
     return value;
   }
 
-  // Return a dense<normal(0.0, 1.0)> throughout the shape.
+  // Return a dense<normal(0, 255)> throughout the shape.
   void fillData() override;
 
 private:

--- a/include/TPP/TensorInitInt.h
+++ b/include/TPP/TensorInitInt.h
@@ -1,8 +1,15 @@
 //===- TensorInitInt.h - MLIR Tensor Initialization -----------------------===//
 //
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
 // Initializes tensors for kernel input/output handling with some reasonable
 // distribution to allow for layout testing (reorder, pad) without vanishing
-// or exploding values at the end of a large model (0.0 ~ 1.0).
+// or exploding values at the end of a large model - uses quantization range
+// within <0 - 255> integer values.
 //
 //===----------------------------------------------------------------------===//
 

--- a/include/TPP/TensorInitInt.h
+++ b/include/TPP/TensorInitInt.h
@@ -53,11 +53,11 @@ protected:
 
   // Insert element indexed on the buffer.
   using TensorInit::insert;
-  void insert(size_t index, uint64_t value);
+  virtual void insert(size_t index, uint64_t value);
 
   // Insert element at the end of the buffer.
   using TensorInit::push;
-  void push(uint64_t value);
+  virtual void push(uint64_t value);
 
   // Convert value to the tensor's data type (by reference).
   void convertType(llvm::APInt &value) override final;

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -23,6 +23,7 @@ add_mlir_library(MLIRTPP
 
   # Utils
     TensorInit.cpp
+    TensorInitFloat.cpp
     BuilderUtils.cpp
     TransformUtils.cpp
     VNNIUtils.cpp

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_library(MLIRTPP
   # Utils
     TensorInit.cpp
     TensorInitFloat.cpp
+    TensorInitInt.cpp
     BuilderUtils.cpp
     TransformUtils.cpp
     VNNIUtils.cpp

--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -7,18 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "TPP/TensorInit.h"
+#include "TPP/TensorInitFloat.h"
 
 using namespace mlir;
-
-TensorInit::DataType getTensorInitDataType(mlir::Type type) {
-  if (type.isBF16())
-    return TensorInit::BF16;
-  if (type.isF32())
-    return TensorInit::FP32;
-  if (type.isF64())
-    return TensorInit::FP64;
-  assert(false && "Invalid tensor init data type (only FP32, FP64, BF16)");
-}
 
 TensorInitType parseTensorInitType(StringRef name) {
   auto type = StringSwitch<TensorInitType>(name)
@@ -33,7 +24,6 @@ TensorInitType parseTensorInitType(StringRef name) {
 }
 
 TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
-  auto dataType = getTensorInitDataType(elmType);
   // Defaults for seed or not
   if (type == TensorInitType::Auto) {
     if (seed)
@@ -41,104 +31,32 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     else
       type = TensorInitType::Constant;
   }
-  switch (type) {
-  case TensorInitType::Constant:
-    return std::make_unique<ConstantTensorInit>(dataType);
-  case TensorInitType::Simple:
-    return std::make_unique<SimpleTensorInit>(dataType);
-  case TensorInitType::Continuous:
-    return std::make_unique<ContinuousTensorInit>(dataType);
-  case TensorInitType::Random:
-    assert(seed && "Can't call random initializers without seed");
-    return std::make_unique<RandomTensorInit>(dataType, seed);
-  case TensorInitType::Normal:
-    assert(seed && "Can't call random initializers without seed");
-    return std::make_unique<NormalTensorInit>(dataType, seed);
-  default:
-    assert(false && "Invalid tensor initializer type");
+
+  if (TensorInitFloat::isTypeSupported(elmType)) {
+    auto dataType = TensorInitFloat::getTensorInitDataType(elmType);
+    switch (type) {
+    case TensorInitType::Constant:
+      return std::make_unique<ConstantTensorInitFloat>(dataType);
+    case TensorInitType::Simple:
+      return std::make_unique<SimpleTensorInitFloat>(dataType);
+    case TensorInitType::Continuous:
+      return std::make_unique<ContinuousTensorInitFloat>(dataType);
+    case TensorInitType::Random:
+      assert(seed && "Can't call random initializers without seed");
+      return std::make_unique<RandomTensorInitFloat>(dataType, seed);
+    case TensorInitType::Normal:
+      assert(seed && "Can't call random initializers without seed");
+      return std::make_unique<NormalTensorInitFloat>(dataType, seed);
+    default:
+      assert(false && "Invalid tensor initializer type");
+    }
   }
+
+  assert(false && "Unsupported tensor element type");
+  return nullptr;
 }
 
 TensorInitPtr getTensorInit(StringRef type, mlir::Type elmType, int seed) {
   auto initType = parseTensorInitType(type);
   return getTensorInit(initType, elmType, seed);
-}
-
-DenseElementsAttr TensorInit::get(ShapedType shape) {
-  buffer.clear();
-  for (size_t dim = 0, rank = shape.getRank(); dim < rank; dim++)
-    size *= shape.getDimSize(dim);
-  fillData();
-  // For some reason, memref global op needs dense tensor type
-  // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
-  auto tensorType =
-      RankedTensorType::get(shape.getShape(), shape.getElementType());
-  return mlir::DenseElementsAttr::get(tensorType, buffer);
-}
-
-template <typename T> void TensorInit::insert(size_t index, T value) {
-  buffer[index] = value;
-  convertType(buffer[index]);
-}
-
-template <typename T> void TensorInit::push(T value) {
-  buffer.push_back(value);
-  convertType(buffer.back());
-}
-
-void TensorInit::convertType(llvm::APFloat &value) {
-  switch (type) {
-  case DataType::FP32:
-    toFP32(value);
-    break;
-  case DataType::FP64:
-    toFP64(value);
-    break;
-  case DataType::BF16:
-    toBF16(value);
-    break;
-  }
-}
-
-float TensorInit::at(size_t index) { return buffer[index].convertToFloat(); }
-
-DenseElementsAttr ConstantTensorInit::get(ShapedType shape) {
-  auto floatValue = APFloat(1.0F);
-  if (!isTypeSupported(shape.getElementType()))
-    assert(false && "Element type not supported");
-  convertType(floatValue);
-
-  // For some reason, memref global op needs dense tensor type
-  // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
-  auto tensorType =
-      RankedTensorType::get(shape.getShape(), shape.getElementType());
-  return mlir::DenseElementsAttr::get(tensorType, floatValue);
-}
-
-void ConstantTensorInit::fillData() { assert(false && "Should not be called"); }
-
-void SimpleTensorInit::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  float data[3] = {0.3f, 0.6f, 0.9f};
-  for (size_t i = 0; i < size; i++)
-    push(data[i % 3]);
-}
-
-void ContinuousTensorInit::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  float normFactor = static_cast<float>(size);
-  for (size_t i = 0; i < size; i++)
-    push(static_cast<float>(i) / normFactor);
-}
-
-void RandomTensorInit::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  for (size_t i = 0; i < size; i++)
-    push(next());
-}
-
-void NormalTensorInit::fillData() {
-  assert(buffer.size() == 0 && "Buffer not empty");
-  for (size_t i = 0; i < size; i++)
-    push(next());
 }

--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -8,6 +8,7 @@
 
 #include "TPP/TensorInit.h"
 #include "TPP/TensorInitFloat.h"
+#include "TPP/TensorInitInt.h"
 
 using namespace mlir;
 
@@ -47,6 +48,26 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     case TensorInitType::Normal:
       assert(seed && "Can't call random initializers without seed");
       return std::make_unique<NormalTensorInitFloat>(dataType, seed);
+    default:
+      assert(false && "Invalid tensor initializer type");
+    }
+  }
+
+  if (TensorInitInt::isTypeSupported(elmType)) {
+    auto dataType = TensorInitInt::getTensorInitDataType(elmType);
+    switch (type) {
+    case TensorInitType::Constant:
+      return std::make_unique<ConstantTensorInitInt>(dataType);
+    case TensorInitType::Simple:
+      return std::make_unique<SimpleTensorInitInt>(dataType);
+    case TensorInitType::Continuous:
+      return std::make_unique<ContinuousTensorInitInt>(dataType);
+    case TensorInitType::Random:
+      assert(seed && "Can't call random initializers without seed");
+      return std::make_unique<RandomTensorInitInt>(dataType, seed);
+    case TensorInitType::Normal:
+      assert(seed && "Can't call random initializers without seed");
+      return std::make_unique<NormalTensorInitInt>(dataType, seed);
     default:
       assert(false && "Invalid tensor initializer type");
     }

--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -76,13 +76,13 @@ DenseElementsAttr TensorInit::get(ShapedType shape) {
   return mlir::DenseElementsAttr::get(tensorType, buffer);
 }
 
-void TensorInit::insert(size_t index, float value) {
-  buffer[index] = llvm::APFloat(value);
+template <typename T> void TensorInit::insert(size_t index, T value) {
+  buffer[index] = value;
   convertType(buffer[index]);
 }
 
-void TensorInit::push(float value) {
-  buffer.push_back(llvm::APFloat(value));
+template <typename T> void TensorInit::push(T value) {
+  buffer.push_back(value);
   convertType(buffer.back());
 }
 

--- a/lib/TPP/TensorInitFloat.cpp
+++ b/lib/TPP/TensorInitFloat.cpp
@@ -1,0 +1,87 @@
+//===- TensorInitFloat.cpp ---------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/TensorInitFloat.h"
+
+using namespace mlir;
+
+TensorInitFloat::DataType
+TensorInitFloat::getTensorInitDataType(mlir::Type type) {
+  if (type.isBF16())
+    return DataType::BF16;
+  if (type.isF32())
+    return DataType::FP32;
+  if (type.isF64())
+    return DataType::FP64;
+  assert(false && "Invalid tensor init data type (only FP32, FP64, BF16)");
+}
+
+void TensorInitFloat::insert(size_t index, float value) {
+  this->TensorInit::insert(index, APFloat(value));
+}
+
+void TensorInitFloat::push(float value) {
+  this->TensorInit::push(APFloat(value));
+}
+
+void TensorInitFloat::convertType(llvm::APFloat &value) {
+  switch (type) {
+  case DataType::FP32:
+    toFP32(value);
+    break;
+  case DataType::FP64:
+    toFP64(value);
+    break;
+  case DataType::BF16:
+    toBF16(value);
+    break;
+  }
+}
+
+DenseElementsAttr ConstantTensorInitFloat::get(ShapedType shape) {
+  auto floatValue = APFloat(1.0F);
+  if (!isTypeSupported(shape.getElementType()))
+    assert(false && "Element type not supported");
+  convertType(floatValue);
+
+  // For some reason, memref global op needs dense tensor type
+  // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
+  auto tensorType =
+      RankedTensorType::get(shape.getShape(), shape.getElementType());
+  return mlir::DenseElementsAttr::get(tensorType, floatValue);
+}
+
+void ConstantTensorInitFloat::fillData() {
+  assert(false && "Should not be called");
+}
+
+void SimpleTensorInitFloat::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  float data[3] = {0.3f, 0.6f, 0.9f};
+  for (size_t i = 0; i < size; i++)
+    push(data[i % 3]);
+}
+
+void ContinuousTensorInitFloat::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  float normFactor = static_cast<float>(size);
+  for (size_t i = 0; i < size; i++)
+    push(static_cast<float>(i) / normFactor);
+}
+
+void RandomTensorInitFloat::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  for (size_t i = 0; i < size; i++)
+    push(next());
+}
+
+void NormalTensorInitFloat::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  for (size_t i = 0; i < size; i++)
+    push(next());
+}

--- a/lib/TPP/TensorInitInt.cpp
+++ b/lib/TPP/TensorInitInt.cpp
@@ -1,0 +1,102 @@
+//===- TensorInitInt.cpp -----------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/TensorInitInt.h"
+
+using namespace mlir;
+
+TensorInitInt::DataType TensorInitInt::getTensorInitDataType(mlir::Type type) {
+  if (type.isInteger(8))
+    return DataType::I8;
+  if (type.isInteger(16))
+    return DataType::I16;
+  if (type.isInteger(32))
+    return DataType::I32;
+  if (type.isInteger(64))
+    return DataType::I64;
+  assert(false && "Invalid tensor init data type (only I8, I16, I32, I64)");
+}
+
+unsigned TensorInitInt::getDataTypeBitWidth(TensorInitInt::DataType type) {
+  switch (type) {
+  case DataType::I8:
+    return 8;
+  case DataType::I16:
+    return 16;
+  case DataType::I32:
+    return 32;
+  case DataType::I64:
+    return 64;
+  }
+}
+
+bool TensorInitInt::isDataTypeSigned(TensorInitInt::DataType type) {
+  switch (type) {
+  case DataType::I8:
+  case DataType::I16:
+  case DataType::I32:
+  case DataType::I64:
+    return true;
+  }
+}
+
+void TensorInitInt::insert(size_t index, uint64_t value) {
+  this->TensorInit::insert(index, APInt(bitWidth, value, isSigned));
+}
+
+void TensorInitInt::push(uint64_t value) {
+  this->TensorInit::push(APInt(bitWidth, value, isSigned));
+}
+
+void TensorInitInt::convertType(llvm::APInt &value) {
+  assert(value.getBitWidth() == bitWidth && "Invalid element size");
+}
+
+DenseElementsAttr ConstantTensorInitInt::get(ShapedType shape) {
+  auto value = APInt(bitWidth, 1, isSigned);
+  if (!isTypeSupported(shape.getElementType()))
+    assert(false && "Element type not supported");
+  convertType(value);
+
+  // For some reason, memref global op needs dense tensor type
+  // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
+  auto tensorType =
+      RankedTensorType::get(shape.getShape(), shape.getElementType());
+  return mlir::DenseElementsAttr::get(tensorType, value);
+}
+
+void ConstantTensorInitInt::fillData() {
+  assert(false && "Should not be called");
+}
+
+void SimpleTensorInitInt::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  uint64_t data[3] = {0, 1, 2};
+  for (size_t i = 0; i < size; i++)
+    push(data[i % 3]);
+}
+
+void ContinuousTensorInitInt::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  float normFactor = static_cast<float>(size);
+  for (size_t i = 0; i < size; i++)
+    push(static_cast<uint64_t>((static_cast<float>(i) / normFactor) *
+                               upperBound));
+}
+
+void RandomTensorInitInt::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  for (size_t i = 0; i < size; i++)
+    push(next());
+}
+
+void NormalTensorInitInt::fillData() {
+  assert(buffer.size() == 0 && "Buffer not empty");
+  for (size_t i = 0; i < size; i++)
+    push(next());
+}

--- a/lib/TPP/TensorInitInt.cpp
+++ b/lib/TPP/TensorInitInt.cpp
@@ -11,13 +11,13 @@
 using namespace mlir;
 
 TensorInitInt::DataType TensorInitInt::getTensorInitDataType(mlir::Type type) {
-  if (type.isInteger(8))
+  if (type.isSignlessInteger(8))
     return DataType::I8;
-  if (type.isInteger(16))
+  if (type.isSignlessInteger(16))
     return DataType::I16;
-  if (type.isInteger(32))
+  if (type.isSignlessInteger(32))
     return DataType::I32;
-  if (type.isInteger(64))
+  if (type.isSignlessInteger(64))
     return DataType::I64;
   assert(false && "Invalid tensor init data type (only I8, I16, I32, I64)");
 }

--- a/test/Integration/tpp-run-splat-memref.mlir
+++ b/test/Integration/tpp-run-splat-memref.mlir
@@ -10,36 +10,52 @@ memref.global "private" constant @__constant_2x16xf64 : memref<2x16xf64> = dense
 memref.global "private" constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.0> {alignment = 128 : i64}
 memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.0> {alignment = 128 : i64}
 memref.global "private" constant @__constant_non_splat : memref<2x2xf32> = dense<[[0.0, 1.0],[2.0, 3.0]]> {alignment = 128 : i64}
-memref.global "private" constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0> {alignment = 128 : i64}
-func.func @entry(%input: memref<4x2xf32>) {
+memref.global "private" constant @__constant_zero_i32 : memref<4x8xi32> = dense<0> {alignment = 128 : i64}
+memref.global "private" constant @__constant_one_i32 : memref<4x8xi32> = dense<1> {alignment = 128 : i64}
+memref.global "private" constant @__constant_one_i64 : memref<4x8xi64> = dense<1> {alignment = 128 : i64}
+memref.global "private" constant @__constant_non_splat_i32 : memref<2x2xi32> = dense<[[0, 1],[2, 3]]> {alignment = 128 : i64}
+func.func @entry(%arg0: memref<4x2xf32>, %arg1: memref<4x2xi32>) {
   %0 = memref.get_global @__constant_2x16xf32 : memref<2x16xf32>
   %1 = memref.get_global @__constant_4x16xf32 : memref<4x16xf32>
   %2 = memref.get_global @__constant_4x8xf32 : memref<4x8xf32>
   return
 }
-// SPLAT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+
+// SPLAT-DAG: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+// SPLAT-DAG: @__wrapper_1 : memref<4x2xi32> = dense<1>
 // SPLAT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // SPLAT: constant @__constant_2x16xf64 : memref<2x16xf64> = dense<1.000000e+00>
 // SPLAT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
 // SPLAT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
 // SPLAT: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
-// SPLAT: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
+// SPLAT: constant @__constant_zero_i32 : memref<4x8xi32> = dense<0>
+// SPLAT: constant @__constant_one_i32 : memref<4x8xi32> = dense<1>
+// SPLAT: constant @__constant_one_i64 : memref<4x8xi64> = dense<1>
+// SPLAT: constant @__constant_non_splat_i32 : memref<2x2xi32> = dense<{{\[}}{{\[}}0, 1], [2, 3]]>
 // SPLAT-LABEL: @_entry
 
 // RANDOM-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+// RANDOM-NOT: @__wrapper_1 : memref<4x2xi32> = dense<1>
 // RANDOM: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // RANDOM: constant @__constant_2x16xf64 : memref<2x16xf64> = dense<1.000000e+00>
 // RANDOM: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
 // RANDOM: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
 // RANDOM: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
-// RANDOM: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
+// RANDOM: constant @__constant_zero_i32 : memref<4x8xi32> = dense<0>
+// RANDOM: constant @__constant_one_i32 : memref<4x8xi32> = dense<1>
+// RANDOM: constant @__constant_one_i64 : memref<4x8xi64> = dense<1>
+// RANDOM: constant @__constant_non_splat_i32 : memref<2x2xi32> = dense<{{\[}}{{\[}}0, 1], [2, 3]]>
 // RANDOM-LABEL: @_entry
 
 // RANDOM-SPLAT-NOT: @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
+// RANDOM-SPLAT-NOT: @__wrapper_1 : memref<4x2xi32> = dense<1>
 // RANDOM-SPLAT-NOT: constant @__constant_2x16xf32 : memref<2x16xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_2x16xf64 : memref<2x16xf64> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: constant @__constant_4x16xf32 : memref<4x16xf32> = dense<2.000000e+00>
 // RANDOM-SPLAT: constant @__constant_4x8xf32 : memref<4x8xf32> = dense<0.000000e+00>
 // RANDOM-SPLAT: constant @__constant_non_splat : memref<2x2xf32> = dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
-// RANDOM-SPLAT: constant @__constant_4x8xi32 : memref<4x8xi32> = dense<0>
+// RANDOM-SPLAT: constant @__constant_zero_i32 : memref<4x8xi32> = dense<0>
+// RANDOM-SPLAT-NOT: constant @__constant_one_i32 : memref<4x8xi32> = dense<1>
+// RANDOM-SPLAT-NOT: constant @__constant_one_i64 : memref<4x8xi64> = dense<1>
+// RANDOM-SPLAT: constant @__constant_non_splat_i32 : memref<2x2xi32> = dense<{{\[}}{{\[}}0, 1], [2, 3]]>
 // RANDOM-SPLAT-LABEL: @_entry

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -36,6 +36,7 @@
 #include "TPP/Passes.h"
 #include "TPP/TensorInit.h"
 #include "TPP/TensorInitFloat.h"
+#include "TPP/TensorInitInt.h"
 #include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
@@ -119,17 +120,25 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
 
   // Only replace attribute if it's a dense splat
   auto replaceSplat = [&](ShapedType shape, Attribute attr) -> Attribute {
-    // We only change float types
-    auto elmTy = shape.getElementType();
-    if (!TensorInitFloat::isTypeSupported(elmTy))
-      return attr;
     // We only change dense attributes that are splat
     auto value = dyn_cast<DenseElementsAttr>(attr);
     if (!value || !value.isSplat())
       return attr;
-    // Only positive float data type (zero may be for ReLU, -1 for fill)
-    auto elm = value.getSplatValue<FloatAttr>().getValueAsDouble();
-    if (elm <= 0.0)
+    // Validate element data type
+    // Only positive data type (zero may be for ReLU, -1 for fill)
+    auto elmTy = shape.getElementType();
+    bool isTypeValid = false;
+    if (TensorInitFloat::isTypeSupported(elmTy)) {
+      auto elm = value.getSplatValue<FloatAttr>().getValueAsDouble();
+      if (elm > 0.0)
+        isTypeValid = true;
+    }
+    if (TensorInitInt::isTypeSupported(elmTy)) {
+      auto elm = value.getSplatValue<IntegerAttr>().getValue();
+      if (elm.sgt(0))
+        isTypeValid = true;
+    }
+    if (!isTypeValid)
       return attr;
     // Generate a new random dense and return
     auto init = getTensorInit(initType, elmTy, seed);

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -34,6 +34,8 @@
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Perf/PerfOps.h"
 #include "TPP/Passes.h"
+#include "TPP/TensorInit.h"
+#include "TPP/TensorInitFloat.h"
 #include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
@@ -119,7 +121,7 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
   auto replaceSplat = [&](ShapedType shape, Attribute attr) -> Attribute {
     // We only change float types
     auto elmTy = shape.getElementType();
-    if (!TensorInit::isTypeSupported(elmTy))
+    if (!TensorInitFloat::isTypeSupported(elmTy))
       return attr;
     // We only change dense attributes that are splat
     auto value = dyn_cast<DenseElementsAttr>(attr);


### PR DESCRIPTION
Adds support for initialization of integer tensors.

The original tensor init logic is refactored and split into separate concrete implementations for floats and integers.
Currently, only signless integers (i8, i32 etc.) are supported as they are the most commonly used types when working with integers.