### PR TITLE
Naive TPP to GPU lowering

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -83,6 +83,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createConvertLinalgToTppPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertLinalgToTppPass(bool, bool, ArrayRef<int64_t> tiles = {});
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTppToLoopsPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTppToLoopsPass(bool parallel);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertXsmmToFuncPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertCheckToLoopsPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertVNNIToTppPass();

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -79,12 +79,15 @@ class GpuDialect;
 namespace tpp {
 class TppDialect;
 
+// The pass options are provided with default argument values to avoid
+// API duplications and combinatorial explosion of flags.
+// The values should be kept consistent with the default values of the pass
+// declarations present in the corresponding TableGen file.
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertLinalgToTppPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertLinalgToTppPass(bool, bool, ArrayRef<int64_t> tiles = {});
-std::unique_ptr<OperationPass<func::FuncOp>> createConvertTppToLoopsPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
-createConvertTppToLoopsPass(bool parallel);
+createConvertTppToLoopsPass(bool parallel = false);
 std::unique_ptr<OperationPass<ModuleOp>> createConvertXsmmToFuncPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertCheckToLoopsPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertVNNIToTppPass();
@@ -129,14 +132,13 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertForAllToParallelOpPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSimplifyAndCanonicalizePackPass();
-std::unique_ptr<OperationPass<ModuleOp>> createGpuPipelinePass();
 std::unique_ptr<OperationPass<ModuleOp>>
-createGpuPipelinePass(StringRef gpuBackend);
+createGpuPipelinePass(StringRef gpuBackend = "cuda");
 std::unique_ptr<OperationPass<ModuleOp>> createGpuConversionPass();
-std::unique_ptr<OperationPass<gpu::GPUModuleOp>> createGpuToCudaPass();
 std::unique_ptr<OperationPass<gpu::GPUModuleOp>>
-createGpuToCudaPass(StringRef gpuTriple, StringRef gpuChip,
-                    StringRef gpuFeatures);
+createGpuToCudaPass(StringRef gpuTriple = "nvptx64-nvidia-cuda",
+                    StringRef gpuChip = "sm_35",
+                    StringRef gpuFeatures = "+ptx60");
 
 void registerTestStructuralMatchers();
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -28,6 +28,9 @@ def ConvertTppToLoops : Pass<"convert-tpp-to-loops", "func::FuncOp"> {
     Convert tpp operations to SCF loops.
   }];
   let dependentDialects = ["scf::SCFDialect", "memref::MemRefDialect"];
+  let options = [
+    Option<"parallel", "parallel", "bool", "false", "use parallel loops">
+  ];
 }
 
 def ConvertTppToXsmm : Pass<"convert-tpp-to-xsmm", "func::FuncOp"> {

--- a/lib/TPP/ConvertTppToLoops.cpp
+++ b/lib/TPP/ConvertTppToLoops.cpp
@@ -413,11 +413,6 @@ struct ConvertTppToLoops : public ConvertTppToLoopsBase<ConvertTppToLoops> {
 } // namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::tpp::createConvertTppToLoopsPass() {
-  return std::make_unique<ConvertTppToLoops>();
-}
-
-std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::tpp::createConvertTppToLoopsPass(bool parallel) {
   return std::make_unique<ConvertTppToLoops>(parallel);
 }

--- a/lib/TPP/GPU/GpuConversion.cpp
+++ b/lib/TPP/GPU/GpuConversion.cpp
@@ -64,6 +64,7 @@ private:
     pm.clear();
 
     // Map and lower ops to GPU-compatible format.
+    pm.addNestedPass<func::FuncOp>(createConvertTppToLoopsPass(true));
     pm.addNestedPass<func::FuncOp>(createConvertLinalgToParallelLoopsPass());
     pm.addNestedPass<func::FuncOp>(createGpuMapParallelLoopsPass());
     pm.addNestedPass<func::FuncOp>(createParallelLoopToGpuPass());

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -114,10 +114,6 @@ private:
 
 } // namespace
 
-std::unique_ptr<OperationPass<ModuleOp>> mlir::tpp::createGpuPipelinePass() {
-  return std::make_unique<GpuPipeline>();
-}
-
 std::unique_ptr<OperationPass<ModuleOp>>
 mlir::tpp::createGpuPipelinePass(StringRef gpuBackend) {
   return std::make_unique<GpuPipeline>(gpuBackend);

--- a/lib/TPP/GPU/GpuToCuda.cpp
+++ b/lib/TPP/GPU/GpuToCuda.cpp
@@ -90,11 +90,6 @@ private:
 } // namespace
 
 std::unique_ptr<OperationPass<gpu::GPUModuleOp>>
-mlir::tpp::createGpuToCudaPass() {
-  return std::make_unique<GpuToCuda>();
-}
-
-std::unique_ptr<OperationPass<gpu::GPUModuleOp>>
 mlir::tpp::createGpuToCudaPass(StringRef gpuTriple, StringRef gpuChip,
                                StringRef gpuFeatures) {
   return std::make_unique<GpuToCuda>(gpuTriple, gpuChip, gpuFeatures);

--- a/test/Conversion/TppToLoops/tpp-to-loops-parallel.mlir
+++ b/test/Conversion/TppToLoops/tpp-to-loops-parallel.mlir
@@ -1,0 +1,221 @@
+// RUN: tpp-opt %s -convert-tpp-to-loops=parallel=1 -split-input-file | FileCheck %s
+
+// CHECK: func.func @identity_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>) {
+func.func @identity_to_loops(%arg0: memref<3x3xf32>) {
+  // CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[fill:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+  // CHECK:   memref.store %[[fill]], %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  tpp.identity ins(%cst: f32) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+// CHECK: func.func @relu_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>) {
+func.func @relu_to_loops(%arg0: memref<3x3xf32>) {
+  // CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[relu:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+  // CHECK:   %[[load:.*]] = memref.load %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+  // CHECK:   %[[max:.*]] = arith.maxf %[[load]], %[[relu]] : f32
+  // CHECK:   memref.store %[[max]], %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+  tpp.relu ins(%arg0: memref<3x3xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+// CHECK: func.func @relu_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>)
+func.func @relu_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  // CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[relu:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+  // CHECK:   %[[load:.*]] = memref.load %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+  // CHECK:   %[[max:.*]] = arith.maxf %[[load]], %[[relu]] : f32
+  // CHECK:   memref.store %[[max]], %[[ARG1]][%[[i]], %[[j]]] : memref<3x3xf32>
+  tpp.relu ins(%arg0: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+// CHECK: func.func @zero_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>) {
+func.func @zero_to_loops(%arg0: memref<3x3xf32>) {
+  // CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[zero:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+  // CHECK:   memref.store %[[zero]], %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+  tpp.zero ins(%arg0: memref<3x3xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+// CHECK: func.func @add_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<3x3xf32>) {
+func.func @add_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  // CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+  // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+  // CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+  // CHECK:   %[[load1:.*]] = memref.load %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+  // CHECK:   %[[load2:.*]] = memref.load %[[ARG1]][%[[i]], %[[j]]] : memref<3x3xf32>
+  // CHECK:   %[[add:.*]] = arith.addf %[[load1]], %[[load2]] : f32
+  // CHECK:   memref.store %[[add]], %[[ARG1]][%[[i]], %[[j]]] : memref<3x3xf32>
+  tpp.add ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3xf32>) {
+  tpp.identity ins(%arg1: memref<3xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// CHECK: func.func @identity_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<3xf32>) {
+// CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+// CHECK:   %[[tostore:.*]] = memref.load %[[ARG1]][%[[j]]] : memref<3xf32>
+// CHECK:   memref.store %[[tostore]], %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+
+
+// -----
+
+func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) {
+  tpp.identity ins(%arg1: memref<1x3xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// CHECK: func.func @identity_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<1x3xf32>) {
+// CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+// CHECK:   %[[tostore:.*]] = memref.load %arg1[%[[lb]], %[[j]]] : memref<1x3xf32>
+// CHECK:   memref.store %[[tostore]], %arg0[%[[i]], %[[j]]] : memref<3x3xf32>
+
+// -----
+
+func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
+  tpp.identity ins(%arg1: memref<1x1xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// CHECK: func.func @identity_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<1x1xf32>) {
+// CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+// CHECK:   %[[tostore:.*]] = memref.load %[[ARG1]][%[[lb]], %[[lb]]] : memref<1x1xf32>
+// CHECK:   memref.store %[[tostore]], %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+
+// -----
+
+func.func @identity_to_loops(%arg0: memref<5x1xf32>, %arg1: memref<5x6xf32>) {
+  tpp.identity ins(%arg0: memref<5x1xf32>) outs(%arg1: memref<5x6xf32>)
+  return
+}
+
+// CHECK: func.func @identity_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<5x1xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<5x6xf32>) {
+// CHECK-DAG: %[[five:.*]] = arith.constant 5 : index
+// CHECK-DAG: %[[six:.*]] = arith.constant 6 : index
+// CHECK-DAG: %[[zero:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[one:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[five]], %[[six]]) step (%[[step]], %[[step]]) {
+// CHECK:   %[[tostore:.*]] = memref.load %[[ARG0]][%[[i]], %[[zero]]] : memref<5x1xf32>
+// CHECK:   memref.store %[[tostore]], %[[ARG1]][%[[i]], %[[j]]] : memref<5x6xf32>
+
+// -----
+
+func.func @brgemm_to_loops(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
+  tpp.brgemm ins(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>)
+             outs(%arg2: memref<3x3xf32>)
+  return
+}
+
+// CHECK: func.func @brgemm_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<2x3x4xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<2x4x3xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<3x3xf32>) {
+// CHECK-DAG: %[[three:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[four:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[two:.*]] = arith.constant 2 : index
+// CHECK-DAG: %[[zero:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[one:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[three]], %[[three]]) step (%[[step]], %[[step]]) {
+// CHECK:   scf.for %[[b:.*]] = %[[zero]] to %[[two]] step %[[one]] {
+// CHECK:     scf.for %[[k:.*]] = %[[zero]] to %[[four]] step %[[one]] {
+// CHECK:       %[[ma:.*]] = memref.load %[[ARG0]][%[[b]], %[[i]], %[[k]]] : memref<2x3x4xf32>
+// CHECK:       %[[mb:.*]] = memref.load %[[ARG1]][%[[b]], %[[k]], %[[j]]] : memref<2x4x3xf32>
+// CHECK:       %[[mc:.*]] = memref.load %[[ARG2]][%[[i]], %[[j]]] : memref<3x3xf32>
+// CHECK:       %[[mul:.*]] = arith.mulf %[[ma]], %[[mb]] : f32
+// CHECK:       %[[add:.*]] = arith.addf %[[mc]], %[[mul]] : f32
+// CHECK:       memref.store %[[add]], %[[ARG2]][%[[i]], %[[j]]] : memref<3x3xf32>
+
+// -----
+
+func.func @add_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) {
+  tpp.add ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) outs(%arg2: memref<3x3xf32>)
+  return
+}
+
+// CHECK: func.func @add_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>, %[[ARG2:.+]]: memref<3x3xf32>) {
+// CHECK-DAG: %[[ub:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ub]], %[[ub]]) step (%[[step]], %[[step]]) {
+// CHECK:   %[[load1:.*]] = memref.load %[[ARG0]][%[[i]], %[[j]]] : memref<3x3xf32>
+// CHECK:   %[[load2:.*]] = memref.load %[[ARG1]][%[[i]], %[[j]]] : memref<3x3xf32>
+// CHECK:   %[[add:.*]] = arith.addf %[[load1]], %[[load2]] : f32
+// CHECK:   memref.store %[[add]], %[[ARG2]][%[[i]], %[[j]]] : memref<3x3xf32>
+
+// -----
+
+func.func @gemm_to_loops(%arg0: memref<8x9xf32>, %arg1: memref<9x10xf32>, %arg2: memref<8x10xf32>) {
+  tpp.gemm ins(%arg0 : memref<8x9xf32>, %arg1 : memref<9x10xf32>, %arg2: memref<8x10xf32>)
+           outs(%arg2: memref<8x10xf32>)
+  return
+}
+
+// CHECK: func.func @gemm_to_loops(
+// CHECK-SAME:  %[[ARG0:.+]]: memref<8x9xf32>, %[[ARG1:.+]]: memref<9x10xf32>, %[[ARG2:.+]]: memref<8x10xf32>) {
+// CHECK-DAG: %[[ubP1:.*]] = arith.constant 8 : index
+// CHECK-DAG: %[[ubP2:.*]] = arith.constant 10 : index
+// CHECK-DAG: %[[ubR:.*]] = arith.constant 9 : index
+// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+// CHECK: scf.parallel (%[[i:.*]], %[[j:.*]]) = (%[[lb]], %[[lb]]) to (%[[ubP1]], %[[ubP2]]) step (%[[step]], %[[step]]) {
+// CHECK:   scf.for %[[k:.*]] = %[[lb]] to %[[ubR]] step %[[step]] {
+// CHECK:     %[[load0:.*]] = memref.load %[[ARG0]][%[[i]], %[[k]]] : memref<8x9xf32>
+// CHECK:     %[[load1:.*]] = memref.load %[[ARG1]][%[[k]], %[[j]]] : memref<9x10xf32>
+// CHECK:     %[[load2:.*]] = memref.load %[[ARG2]][%[[i]], %[[j]]] : memref<8x10xf32>
+// CHECK:     %[[mul:.*]] = arith.mulf %[[load0]], %[[load1]] : f32
+// CHECK:     %[[add:.*]] = arith.addf %[[load2]], %[[mul]] : f32
+// CHECK:     memref.store %[[add]], %[[ARG2]][%[[i]], %[[j]]] : memref<8x10xf32>

--- a/test/Conversion/TppToLoops/tpp-to-loops.mlir
+++ b/test/Conversion/TppToLoops/tpp-to-loops.mlir
@@ -48,7 +48,7 @@ func.func @relu_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // CHECK:     %[[max:.*]] = arith.maxf %[[load]], %[[relu]] : f32
   // CHECK:     memref.store %[[max]], %[[ARG1]][%[[i]], %[[j]]] : memref<3x3xf32>
   tpp.relu ins(%arg0: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
-  return 
+  return
 }
 
 // -----
@@ -107,7 +107,7 @@ func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3xf32>) {
 
 // -----
 
-func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) { 
+func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) {
   tpp.identity ins(%arg1: memref<1x3xf32>) outs(%arg0: memref<3x3xf32>)
   return
 }
@@ -125,7 +125,7 @@ func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x3xf32>) {
 
 // -----
 
-func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) { 
+func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
   tpp.identity ins(%arg1: memref<1x1xf32>) outs(%arg0: memref<3x3xf32>)
   return
 }
@@ -143,7 +143,7 @@ func.func @identity_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
 
 // -----
 
-func.func @identity_to_loops(%arg0: memref<5x1xf32>, %arg1: memref<5x6xf32>) { 
+func.func @identity_to_loops(%arg0: memref<5x1xf32>, %arg1: memref<5x6xf32>) {
   tpp.identity ins(%arg0: memref<5x1xf32>) outs(%arg1: memref<5x6xf32>)
   return
 }
@@ -162,8 +162,8 @@ func.func @identity_to_loops(%arg0: memref<5x1xf32>, %arg1: memref<5x6xf32>) {
 
 // -----
 
-func.func @brgemm_to_loops(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) { 
-  tpp.brgemm ins(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) 
+func.func @brgemm_to_loops(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
+  tpp.brgemm ins(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>)
              outs(%arg2: memref<3x3xf32>)
   return
 }

--- a/test/GPU/Integration/tpp-gemm.mlir
+++ b/test/GPU/Integration/tpp-gemm.mlir
@@ -1,0 +1,44 @@
+// RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
+// RUN: tpp-run %s \
+// RUN:  -entry-point-result=void -e entry 2>&1 | \
+// RUN: FileCheck %s --check-prefix=NONE
+
+// RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
+// RUN: tpp-run %s -gpu=cuda \
+// RUN:  -entry-point-result=void -e entry 2>&1 | \
+// RUN: FileCheck %s --check-prefix=CUDA
+
+func.func @entry() {
+  %0 = memref.alloc() : memref<8x8xf32>
+  %1 = memref.alloc() : memref<8x8xf32>
+  %2 = memref.alloc() : memref<8x8xf32>
+
+  %cst0 = arith.constant 0.0 : f32
+  %cst1 = arith.constant 1.0 : f32
+  %cst2 = arith.constant 2.0 : f32
+
+  %cast_a = memref.cast %0 : memref<8x8xf32> to memref<*xf32>
+  gpu.host_register %cast_a : memref<*xf32>
+  %cast_b = memref.cast %1 : memref<8x8xf32> to memref<*xf32>
+  gpu.host_register %cast_b : memref<*xf32>
+  %cast_c = memref.cast %2 :memref<8x8xf32> to memref<*xf32>
+  gpu.host_register %cast_c : memref<*xf32>
+
+  linalg.fill ins(%cst1 : f32) outs(%0 : memref<8x8xf32>)
+  linalg.fill ins(%cst2 : f32) outs(%1 : memref<8x8xf32>)
+  linalg.fill ins(%cst0 : f32) outs(%2 : memref<8x8xf32>)
+
+  tpp.gemm ins(%0 : memref<8x8xf32>, %1 : memref<8x8xf32>, %2: memref<8x8xf32>)
+           outs(%2: memref<8x8xf32>)
+
+  call @printMemrefF32(%cast_c) : (memref<*xf32>) -> ()
+
+  return
+}
+
+func.func private @printMemrefF32(memref<*xf32>)
+
+// NONE-COUNT-8: {{\[}}16,   16,   16,   16,   16,   16,   16,   16{{\]}}
+
+// TODO check real values when 'CUDA_ERROR_ILLEGAL_ADDRESS' bug is resolved
+// CUDA-COUNT-8: {{\[}}{{-?}}{{[0-9]+}}{{.?}}{{[0-9e-]*}}, {{-?}}{{[0-9]+}}{{.?}}{{[0-9e-]*}}

--- a/test/GPU/gpu-pipeline.mlir
+++ b/test/GPU/gpu-pipeline.mlir
@@ -1,7 +1,7 @@
 // RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
-// RUN: tpp-opt %s -gpu-pipeline=gpu=cuda | FileCheck %s --check-prefix=CUDA
+// RUN: tpp-opt %s -gpu-pipeline=gpu=cuda -split-input-file | FileCheck %s --check-prefix=CUDA
 
-func.func @entry() {
+func.func @linalg_matmul() {
   %0 = memref.alloc() : memref<8x8xf32>
   %1 = memref.alloc() : memref<8x8xf32>
   %2 = memref.alloc() : memref<8x8xf32>
@@ -24,18 +24,35 @@ func.func @entry() {
 func.func private @printMemrefF32(memref<*xf32>)
 
 // CUDA: module attributes {gpu.container_module}
-// CUDA-LABEL: func.func @entry
+// CUDA-LABEL: func.func @linalg_matmul
 // CUDA:         %[[C1:.*]] = memref.cast
 // CUDA:         gpu.host_register %[[C1]]
 // CUDA:         %[[C2:.*]] = memref.cast
 // CUDA:         gpu.host_register %[[C2]]
 // CUDA:         %[[C3:.*]] = memref.cast
 // CUDA:         gpu.host_register %[[C3]]
-// CUDA:         gpu.launch_func  @entry_kernel::@entry_kernel
+// CUDA:         gpu.launch_func  @linalg_matmul_kernel::@linalg_matmul_kernel
 // CUDA:         call @printMemrefF32
 // CUDA:       }
-// CUDA: gpu.module @entry_kernel attributes {gpu.binary = "
-// CUDA-LABEL: llvm.func @entry_kernel
+// CUDA: gpu.module @linalg_matmul_kernel attributes {gpu.binary = "
+// CUDA-LABEL: llvm.func @linalg_matmul_kernel
+// CUDA-DAG:     nvvm.read
+// CUDA-DAG:     llvm.mul
+// CUDA-DAG:     llvm.add
+
+// -----
+
+func.func @tpp_gemm(%arg0: memref<8x9xf32>, %arg1: memref<9x10xf32>, %arg2: memref<8x10xf32>) {
+  tpp.gemm ins(%arg0 : memref<8x9xf32>, %arg1 : memref<9x10xf32>, %arg2: memref<8x10xf32>)
+           outs(%arg2: memref<8x10xf32>)
+  return
+}
+
+// CUDA: module attributes {gpu.container_module}
+// CUDA-LABEL: func.func @tpp_gemm
+// CUDA:         gpu.launch_func  @tpp_gemm_kernel::@tpp_gemm_kernel
+// CUDA: gpu.module @tpp_gemm_kernel attributes {gpu.binary = "
+// CUDA-LABEL: llvm.func @tpp_gemm_kernel
 // CUDA-DAG:     nvvm.read
 // CUDA-DAG:     llvm.mul
 // CUDA-DAG:     llvm.add

--- a/test/GPU/tpp-to-gpu.mlir
+++ b/test/GPU/tpp-to-gpu.mlir
@@ -1,0 +1,116 @@
+// RUN: tpp-opt %s -gpu-conversion -split-input-file | FileCheck %s
+
+func.func @tpp_identity(%arg0: memref<5x1xf32>, %arg1: memref<5x6xf32>) {
+  tpp.identity ins(%arg0: memref<5x1xf32>) outs(%arg1: memref<5x6xf32>)
+  return
+}
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_identity
+// CHECK:         gpu.launch_func  @tpp_identity_kernel::@tpp_identity_kernel
+// CHECK: gpu.module @tpp_identity_kernel
+// CHECK-LABEL: gpu.func @tpp_identity_kernel
+// CHECK:         gpu.block_id
+// CHECK:         memref.load
+// CHECK:         memref.store
+// CHECK:         gpu.return
+
+// -----
+
+func.func @tpp_relu(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  tpp.relu ins(%arg0: memref<3x3xf32>) outs(%arg1: memref<3x3xf32>)
+  return
+}
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_relu
+// CHECK:         gpu.launch_func  @tpp_relu_kernel::@tpp_relu_kernel
+// CHECK: gpu.module @tpp_relu_kernel
+// CHECK-LABEL: gpu.func @tpp_relu_kernel
+// CHECK:         gpu.block_id
+// CHECK:         memref.load
+// CHECK:         arith.maxf
+// CHECK:         memref.store
+// CHECK:         gpu.return
+
+// -----
+
+func.func @tpp_zero(%arg0: memref<3x3xf32>) {
+  tpp.zero ins(%arg0: memref<3x3xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_zero
+// CHECK:         gpu.launch_func  @tpp_zero_kernel::@tpp_zero_kernel
+// CHECK: gpu.module @tpp_zero_kernel
+// CHECK-LABEL: gpu.func @tpp_zero_kernel
+// CHECK:         gpu.block_id
+// CHECK:         memref.store
+// CHECK:         gpu.return
+
+// -----
+
+func.func @tpp_add(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) {
+  tpp.add ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) outs(%arg2: memref<3x3xf32>)
+  return
+}
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_add
+// CHECK:         gpu.launch_func  @tpp_add_kernel::@tpp_add_kernel
+// CHECK: gpu.module @tpp_add_kernel
+// CHECK-LABEL: gpu.func @tpp_add_kernel
+// CHECK:         gpu.block_id
+// CHECK:         memref.load
+// CHECK:         memref.load
+// CHECK:         arith.addf
+// CHECK:         memref.store
+// CHECK:         gpu.return
+
+// -----
+
+func.func @tpp_brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
+  tpp.brgemm ins(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>)
+             outs(%arg2: memref<3x3xf32>)
+  return
+}
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_brgemm
+// CHECK:         gpu.launch_func  @tpp_brgemm_kernel::@tpp_brgemm_kernel
+// CHECK: gpu.module @tpp_brgemm_kernel
+// CHECK-LABEL: gpu.func @tpp_brgemm_kernel
+// CHECK:         gpu.block_id
+// CHECK:         scf.for
+// CHECK:           scf.for
+// CHECK:             memref.load
+// CHECK:             memref.load
+// CHECK:             memref.load
+// CHECK:             arith.mulf
+// CHECK:             arith.addf
+// CHECK:             memref.store
+// CHECK:         gpu.return
+
+// -----
+
+func.func @tpp_gemm(%arg0: memref<8x9xf32>, %arg1: memref<9x10xf32>, %arg2: memref<8x10xf32>) {
+  tpp.gemm ins(%arg0 : memref<8x9xf32>, %arg1 : memref<9x10xf32>, %arg2: memref<8x10xf32>)
+           outs(%arg2: memref<8x10xf32>)
+  return
+}
+
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_gemm
+// CHECK:         gpu.launch_func  @tpp_gemm_kernel::@tpp_gemm_kernel
+// CHECK: gpu.module @tpp_gemm_kernel
+// CHECK-LABEL: gpu.func @tpp_gemm_kernel
+// CHECK:         gpu.block_id
+// CHECK:         scf.for
+// CHECK:           memref.load
+// CHECK:           memref.load
+// CHECK:           memref.load
+// CHECK:           arith.mulf
+// CHECK:           arith.addf
+// CHECK:           memref.store
+// CHECK:         gpu.return


### PR DESCRIPTION
Adds a simple TPP to GPU lowering through parallel loops and standard MLIR infrastructure.

The `tpp-to-loops` pass is extended with optional use of parallel loops. The parallelization is disable by default as primary use of this pass is debugging when producing the simplest possible IR is desired.
The new lowering path is integrated into the GPU pipeline to allow moving TPP ops into GPU devices.