### PR TITLE
Adds fused linalg addf + maxf detection

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -52,6 +52,10 @@ bool isTppZero(linalg::GenericOp linalgOp,
 bool isTppRelu(linalg::GenericOp linalgOp,
                SmallVectorImpl<Value> *capturedOperands = nullptr);
 
+// Returns true if the linalg.generic can convert to a tpp.add + tpp.relu.
+bool isTppBiasRelu(linalg::GenericOp linalgOp,
+                   SmallVectorImpl<Value> *capturedOperands = nullptr);
+
 // Returns true if: 1) the region has a single block. 2) The block has a single
 // operation `OP`. 3) The operation result types are int or float.
 template <typename OP> static bool hasOnlyOp(Region &region) {

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -239,16 +239,17 @@ bool tpp::structured_match::withOpChainImpl(
     // At least one operand must come from args or a previous op
     bool consumesValueFromChain = false;
     for (auto operand : innerOp.getOperands()) {
-      if (chainedValues.contains(operand) && capturedOperands) {
+      if (chainedValues.contains(operand)) {
         // First add to the captured
         auto ba = dyn_cast<BlockArgument>(operand);
-        if (ba && ba.getParentBlock() == linalgOp.getBlock()) {
+        if (capturedOperands && ba &&
+            ba.getParentBlock() == linalgOp.getBlock()) {
           capturedOperands->push_back(linalgOp.getMatchingOpOperand(ba)->get());
         }
+        // Then erase from the set
+        chainedValues.remove(operand);
+        consumesValueFromChain = true;
       }
-      // Then erase from the set
-      chainedValues.remove(operand);
-      consumesValueFromChain = true;
     }
 
     // Operation isn't in the chain

--- a/lib/TPP/IR/StructuredOpMatcher.cpp
+++ b/lib/TPP/IR/StructuredOpMatcher.cpp
@@ -201,6 +201,80 @@ bool tpp::structured_match::WithSingleOpImpl::withSingleOpImpl(
   return true;
 }
 
+// FIXME: This is a generalization of the method above and will eventually replace
+// the matcher for both no-op (yield) and one op (add, max).
+bool tpp::structured_match::withOpChainImpl(
+    Region *region, Operation *op, SmallVectorImpl<Value> *capturedOperands,
+    SmallVectorImpl<TypeCheckFunc>& typeChecks) {
+
+  // Numer of ops includes yield
+  ptrdiff_t numOps = typeChecks.size();
+
+  // Basic checks
+  if (!isa<linalg::GenericOp>(op))
+    return false;
+  auto linalgOp = cast<linalg::GenericOp>(op);
+  if (!region->hasOneBlock())
+    return false;
+  auto& block = region->front();
+  if (std::distance(block.begin(), block.end()) != (numOps + 1))
+    return false;
+  if (linalgOp.getNumDpsInits() != 1)
+    return false;
+
+  // Add generic arguments to the list of chained values
+  llvm::SmallSetVector<Value, 4> chainedValues;
+  for (auto arg: block.getArguments()) {
+    chainedValues.insert(arg);
+  }
+
+  // Check on the inner chain of operations in the right order.
+  // Make sure all operands are used and chained
+  for (auto [check, innerOp]: llvm::zip_first(typeChecks, block.getOperations())) {
+    // Must be right op in right order
+    if (!check(&innerOp))
+      return false;
+
+    // At least one operand must come from args or a previous op
+    bool consumesValueFromChain = false;
+    for (auto operand: innerOp.getOperands()) {
+      if (chainedValues.contains(operand)) {
+        // First add to the captured
+        if (capturedOperands) {
+          if (auto ba = dyn_cast<BlockArgument>(operand)) {
+            if (ba.getParentBlock() == linalgOp.getBlock()) {
+              capturedOperands->push_back(
+                  linalgOp.getMatchingOpOperand(ba)->get());
+            }
+          }
+        }
+        // Then erase from the set
+        chainedValues.remove(operand);
+        consumesValueFromChain = true;
+      }
+    }
+
+    // Operation isn't in the chain
+    if (!consumesValueFromChain)
+      return false;
+
+    // Add return value to the list of chained values
+    for (auto ret: innerOp.getResults()) {
+      chainedValues.insert(ret);
+    }
+  }
+
+  // Last op must be a chained yield.
+  Operation *yieldOp = linalgOp.getBlock()->getTerminator();
+  assert(isa<linalg::YieldOp>(yieldOp) && "Wrong terminator");
+  for (auto op: yieldOp->getOperands()) {
+    if (!chainedValues.contains(op))
+      return false;
+  }
+
+  return true;
+}
+
 structured_match::StructuredOpMatcher &
 structured_match::StructuredOpMatcher::region(
     MatchSelector range,

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -381,8 +381,7 @@ func.func @linalg_zero_gemm_bias_relu(%arg0: tensor<128x256xf32>, %arg1: tensor<
   %0 = linalg.generic
             {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]}
             ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
-            outs(%fill : tensor<128x512xf32>)
-            attrs =  {iterator_ranges = [128, 512, 256]} {
+            outs(%fill : tensor<128x512xf32>) {
   ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
     %16 = arith.mulf %arg9, %arg10 : f32
     %17 = arith.addf %arg11, %16 : f32
@@ -432,8 +431,7 @@ func.func @linalg_zero_gemm_fused_bias_relu(%arg0: tensor<128x256xf32>, %arg1: t
   %0 = linalg.generic
             {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]}
             ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
-            outs(%fill : tensor<128x512xf32>)
-            attrs =  {iterator_ranges = [128, 512, 256]} {
+            outs(%fill : tensor<128x512xf32>) {
   ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
     %16 = arith.mulf %arg9, %arg10 : f32
     %17 = arith.addf %arg11, %16 : f32

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -324,3 +324,136 @@ func.func @scalar_input(%arg0: tensor<f32>, %arg1: tensor<4x4xf32>) -> tensor<4x
   } -> tensor<4x4xf32>
   return %res : tensor<4x4xf32>
 }
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+
+// CHECK-LABEL: func.func @linalg_bias_relu
+func.func @linalg_bias_relu(%arg0: tensor<4x4xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // CHECK: tpp.add
+  // CHECK: tpp.relu
+  %cst = arith.constant 0.0:f32
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0, %arg1 : tensor<4x4xf32>, tensor<4xf32>) outs(%arg2 : tensor<4x4xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %1 = arith.addf %in, %in_1 : f32
+    %2 = arith.maxf %1, %cst : f32
+    linalg.yield %2 : f32
+    } -> tensor<4x4xf32>
+  return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+
+// CHECK-LABEL: func.func @linalg_bias_relu
+func.func @linalg_bias_relu(%arg0: tensor<4x4xf32>, %arg1: tensor<4xf32>) -> tensor<4x4xf32> {
+  // CHECK: tpp.add
+  // CHECK: tpp.relu
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = linalg.generic {indexing_maps = [#map1, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<4xf32>) outs(%arg0 : tensor<4x4xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %1 = arith.addf %in, %out : f32
+    %2 = arith.maxf %1, %cst : f32
+    linalg.yield %2 : f32
+  } -> tensor<4x4xf32>
+  return %0 : tensor<4x4xf32>
+}
+
+// -----
+
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @linalg_zero_gemm_bias_relu
+func.func @linalg_zero_gemm_bias_relu(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>, %bias: tensor<128x512xf32>) -> tensor<128x512xf32> {
+  // Matmul
+  // CHECK: tpp.zero
+  // CHECK: tpp.gemm
+  %empty = tensor.empty() : tensor<128x512xf32>
+  %c0 = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%c0 : f32) outs(%empty : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %0 = linalg.generic
+            {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]}
+            ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+            outs(%fill : tensor<128x512xf32>)
+            attrs =  {iterator_ranges = [128, 512, 256]} {
+  ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
+    %16 = arith.mulf %arg9, %arg10 : f32
+    %17 = arith.addf %arg11, %16 : f32
+    linalg.yield %17 : f32
+  } -> tensor<128x512xf32>
+
+  // Bias Add
+  // CHECK: tpp.add
+  %1 = linalg.generic
+              {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]}
+              ins(%bias: tensor<128x512xf32>)
+              outs(%0 : tensor<128x512xf32>) {
+  ^bb0(%arg9: f32, %arg10: f32):
+    %16 = arith.addf %arg9, %arg10 : f32
+    linalg.yield %16 : f32
+  } -> tensor<128x512xf32>
+
+  // Relu
+  // CHECK: tpp.relu
+  %2 = linalg.generic
+              {indexing_maps = [#map1], iterator_types = ["parallel", "parallel"]}
+              outs(%1 : tensor<128x512xf32>) {
+  ^bb0(%arg9: f32):
+    %16 = arith.maxf %arg9, %c0 : f32
+    linalg.yield %16 : f32
+  } -> tensor<128x512xf32>
+
+  // Return
+  return %2 : tensor<128x512xf32>
+}
+
+// -----
+
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @linalg_zero_gemm_fused_bias_relu
+func.func @linalg_zero_gemm_fused_bias_relu(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>, %bias: tensor<128x512xf32>) -> tensor<128x512xf32> {
+  // Matmul
+  // CHECK: tpp.zero
+  // CHECK: tpp.gemm
+  %empty = tensor.empty() : tensor<128x512xf32>
+  %c0 = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%c0 : f32) outs(%empty : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %0 = linalg.generic
+            {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]}
+            ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+            outs(%fill : tensor<128x512xf32>)
+            attrs =  {iterator_ranges = [128, 512, 256]} {
+  ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
+    %16 = arith.mulf %arg9, %arg10 : f32
+    %17 = arith.addf %arg11, %16 : f32
+    linalg.yield %17 : f32
+  } -> tensor<128x512xf32>
+
+  // Bias Add
+  // CHECK: tpp.add
+  // CHECK: tpp.relu
+  %1 = linalg.generic
+              {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]}
+              ins(%bias: tensor<128x512xf32>)
+              outs(%0 : tensor<128x512xf32>) {
+  ^bb0(%arg9: f32, %arg10: f32):
+    %16 = arith.addf %arg9, %arg10 : f32
+    %17 = arith.maxf %16, %c0 : f32
+    linalg.yield %17 : f32
+  } -> tensor<128x512xf32>
+
+  // Return
+  return %1 : tensor<128x512xf32>
+}
+


### PR DESCRIPTION
This adds a generic detection for multiple chained ops in a linalg body to allow for fused element-wise addf + maxf that are generated by IREE.

It introduces a generic mechanism that duplicated a bit of the one-op matcher but that will eventually replace no-op and one-op matcher with a generic multi-op (zero or more) detector.

This can later be used for matmul (mulf + addf), groups (bcast + gemm + bias + relu) and equations.

Fixes #571