### PR TITLE
Add predicate to match operand rank

### DIFF
--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -120,9 +120,7 @@ static bool isTppOp(linalg::GenericOp linalgOp) {
   auto tppMatcher =
       StructuredOpMatcher::make<linalg::GenericOp>()
           .output(MatchAll(), HasStaticShape())
-          .output(MatchAll(), HasRank({2}))
           .input(MatchAll(), HasStaticShape())
-          .input(MatchAll(), HasRank({HasRank::SCALAR, 1, 2}))
           .operation(NumRegions(EqualsTo(1)))
           .operation(VerifyInterface(OpTrait::tpp::checkUnitStrideInnerLoop));
   return tppMatcher.match(linalgOp);
@@ -134,6 +132,10 @@ static bool isTppBinaryOp(linalg::GenericOp linalgOp) {
       StructuredOpMatcher::make<linalg::GenericOp>()
           .operation(NumDpsInits(EqualsTo(1)))
           .operation(NumDpsInputs(_OR(EqualsTo(1), EqualsTo(2))))
+          .output(MatchAll(), HasRank({2}))
+          // TODO: (lorenzo) When we introduce broadcast op we
+          // will restrict the input to 2d tiles.
+          .input(MatchAll(), HasRank({HasRank::SCALAR, 1, 2}))
           .dim(MatchAll(), mlir::utils::IteratorType::parallel)
           .operation(NumOfLoops(EqualsTo(2)))
           .output(MatchAll(), HasMap(Identity()))
@@ -148,6 +150,11 @@ static bool isTppUnaryOp(linalg::GenericOp linalgOp) {
       StructuredOpMatcher::make<linalg::GenericOp>()
           .operation(NumDpsInits(EqualsTo(1)))
           .operation(NumDpsInputs(_OR(EqualsTo(0), EqualsTo(1))))
+          // TODO: (lorenzo) When we introduce reduce operations
+          // we will relax this constraint, and allow SCALAR, 1d
+          // and 2d.
+          .output(MatchAll(), HasRank({2}))
+          .input(MatchAll(), HasRank({HasRank::SCALAR, 1, 2}))
           .dim(MatchAll(), mlir::utils::IteratorType::parallel)
           .operation(NumOfLoops(EqualsTo(2)))
           .output(MatchAll(), HasMap(Identity()))

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -120,7 +120,9 @@ static bool isTppOp(linalg::GenericOp linalgOp) {
   auto tppMatcher =
       StructuredOpMatcher::make<linalg::GenericOp>()
           .output(MatchAll(), HasStaticShape())
+          .output(MatchAll(), HasRank({2}))
           .input(MatchAll(), HasStaticShape())
+          .input(MatchAll(), HasRank({HasRank::SCALAR, 1, 2}))
           .operation(NumRegions(EqualsTo(1)))
           .operation(VerifyInterface(OpTrait::tpp::checkUnitStrideInnerLoop));
   return tppMatcher.match(linalgOp);

--- a/lib/TPP/TestMatchers.cpp
+++ b/lib/TPP/TestMatchers.cpp
@@ -159,6 +159,28 @@ void testTppIdentity(FunctionOpInterface funcOp) {
   });
 }
 
+void testTppRank(FunctionOpInterface funcOp) {
+  // clang-format off
+  auto matcherRank1 =
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .input(MatchAll(), HasRank({1}));
+  auto matcherRank2 =
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .input(MatchAll(), HasRank({2}));
+  auto matcherScalar = 
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .input(MatchAll(), HasRank({HasRank::SCALAR}));
+  // clang-format on
+  funcOp->walk([&](linalg::LinalgOp linalgOp) {
+    if (matcherRank1.match(linalgOp))
+      llvm::outs() << "match rank 1\n";
+    if (matcherRank2.match(linalgOp))
+      llvm::outs() << "match rank 2\n";
+    if (matcherScalar.match(linalgOp))
+      llvm::outs() << "match scalar\n";
+  });
+}
+
 void TestStructuralMatchers::runOnOperation() {
   auto f = getOperation();
   llvm::outs() << f.getName() << "\n";
@@ -176,6 +198,8 @@ void TestStructuralMatchers::runOnOperation() {
     testInterfaces(f);
   if (f.getName() == "test_tpp_identity")
     testTppIdentity(f);
+  if (f.getName() == "test_rank")
+    testTppRank(f);
 }
 
 namespace mlir {

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-memref.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-memref.mlir
@@ -679,3 +679,23 @@ func.func @linalg_fill_3d(%arg0: memref<2x8x32xf32>) -> memref<2x8x32xf32> {
   linalg.fill ins(%cst : f32) outs(%arg0 : memref<2x8x32xf32>)
   return %arg0 : memref<2x8x32xf32>
 }
+
+// -----
+
+#map = affine_map<(d0, d1) -> ()>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: scalar_input
+func.func @scalar_input(%arg0: memref<f32>, %arg1: memref<4x4xf32>) {
+  // CHECK-NOT: tpp.add
+  linalg.generic {
+    indexing_maps = [#map, #map1],
+    iterator_types = ["parallel", "parallel"]} 
+    ins(%arg0: memref<f32>)
+    outs(%arg1: memref<4x4xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %0 = arith.addf %in, %out : f32
+        linalg.yield %0 : f32
+  }
+  return
+}

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -283,3 +283,24 @@ func.func @linalg_fill_3d(%arg0: tensor<2x8x32xf32>) -> tensor<2x8x32xf32> {
   %0 = linalg.fill ins(%cst : f32) outs(%arg0 : tensor<2x8x32xf32>) -> tensor<2x8x32xf32>
   return %0 : tensor<2x8x32xf32>
 }
+
+// -----
+
+#map = affine_map<(d0, d1) -> ()>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+
+// We don't allow scalar input only tensor with rank 1 or 2.
+// CHECK-LABEL: scalar_input
+func.func @scalar_input(%arg0: tensor<f32>, %arg1: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // CHECK-NOT: tpp.add
+  %res = linalg.generic {
+    indexing_maps = [#map, #map1],
+    iterator_types = ["parallel", "parallel"]} 
+    ins(%arg0: tensor<f32>)
+    outs(%arg1: tensor<4x4xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %0 = arith.addf %in, %out : f32
+        linalg.yield %0 : f32
+  } -> tensor<4x4xf32>
+  return %res : tensor<4x4xf32>
+}


### PR DESCRIPTION
Commit 0ff739123309ac8e1ab68f6dbb3dadce9f1ee27f restricted tpp operation to 2d output, but the matchers to convert from linalg to tpp were not constrained, leading to verification errors. Introduce a matching predicate that allows constraining the rank of the operand, specifically the tpp matcher will filter only inputs that have rank 0 (scalar), 1 or 2. In contrast, for output, only rank 2 is allowed.