### PR TITLE
Handle 'tpp.fused_brgemm' without broadcasting

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -16,6 +16,7 @@
 namespace mlir {
 class TypeRange;
 class Value;
+class PatternRewriter;
 
 namespace linalg {
 class LinalgOp;
@@ -24,6 +25,8 @@ class YieldOp;
 } // end namespace linalg
 
 namespace tpp {
+class FusedBrgemmOp;
+
 namespace utils {
 
 // Returns true if the linalg operation is marked with 'target'.
@@ -74,6 +77,9 @@ bool isValConstZero(Value val);
 
 // Returns true if the op defining `val` represents a zero filled tensor.
 bool isZeroTensor(Value val);
+
+// Splits fused op into its individual components.
+void splitFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp, PatternRewriter &rewriter);
 
 } // namespace utils
 } // namespace tpp

--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -78,8 +78,11 @@ bool isValConstZero(Value val);
 // Returns true if the op defining `val` represents a zero filled tensor.
 bool isZeroTensor(Value val);
 
-// Splits fused op into its individual components.
-void splitFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp, PatternRewriter &rewriter);
+// Splits fused op into its individual components and returns created
+// operations.
+// The passed fused op remains untouched.
+SmallVector<Operation *> splitFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
+                                      PatternRewriter &rewriter);
 
 } // namespace utils
 } // namespace tpp

--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -82,8 +82,8 @@ bool isZeroTensor(Value val);
 // Temporary workaround for:
 // https://github.com/libxsmm/libxsmm/issues/766
 // TODO: Move into tpp-to-loops as a private helper.
-void splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
-                            PatternRewriter &rewriter);
+LogicalResult splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
+                                     PatternRewriter &rewriter);
 
 } // namespace utils
 } // namespace tpp

--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -78,11 +78,12 @@ bool isValConstZero(Value val);
 // Returns true if the op defining `val` represents a zero filled tensor.
 bool isZeroTensor(Value val);
 
-// Splits fused op into its individual components and returns created
-// operations.
-// The passed fused op remains untouched.
-SmallVector<Operation *> splitFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
-                                      PatternRewriter &rewriter);
+// Splits and replaces fused op with its individual components.
+// Temporary workaround for:
+// https://github.com/libxsmm/libxsmm/issues/766
+// TODO: Move into tpp-to-loops as a private helper.
+void splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
+                            PatternRewriter &rewriter);
 
 } // namespace utils
 } // namespace tpp

--- a/lib/TPP/ConvertTppToXsmm.cpp
+++ b/lib/TPP/ConvertTppToXsmm.cpp
@@ -299,7 +299,7 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
     auto isBitSet = static_cast<uint64_t>(binaryFlag) &
                     static_cast<uint64_t>(xsmm::BinaryFlags::BCAST_COL_IN_0);
     if (isBiasAdd && !isBitSet) {
-      tpp::utils::splitFusedOp(brgemmOp, rewriter);
+      (void)tpp::utils::splitFusedOp(brgemmOp, rewriter);
       rewriter.eraseOp(brgemmOp);
       return success();
     }

--- a/lib/TPP/ConvertTppToXsmm.cpp
+++ b/lib/TPP/ConvertTppToXsmm.cpp
@@ -287,9 +287,10 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
 
     Location loc = brgemmOp.getLoc();
 
-    // Current limitation in LIBXSMM, only bcast_col_in0 as flag for
-    // binary is supported. Split into separate operations if other flags
-    // are present.
+    // Current limitation in LIBXSMM.
+    // See: https://github.com/libxsmm/libxsmm/issues/766
+    // Split into separate operations if bcast_col_in0 is not present when add
+    // is fused.
     // TODO: remove the split once LIBXSMM is fixed.
     auto isBiasAdd = brgemmOp.getBinaryKind() == tpp::FusedBinaryOpKind::ADD;
     auto binaryFlag = getBinaryFlags(rewriter, brgemmOp)[0]

--- a/lib/TPP/ConvertTppToXsmm.cpp
+++ b/lib/TPP/ConvertTppToXsmm.cpp
@@ -298,10 +298,8 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
                           .getValue();
     auto isBitSet = static_cast<uint64_t>(binaryFlag) &
                     static_cast<uint64_t>(xsmm::BinaryFlags::BCAST_COL_IN_0);
-    if (isBiasAdd && !isBitSet) {
-      tpp::utils::splitAndReplaceFusedOp(brgemmOp, rewriter);
-      return success();
-    }
+    if (isBiasAdd && !isBitSet)
+      return tpp::utils::splitAndReplaceFusedOp(brgemmOp, rewriter);
 
     auto dims = getSizesAndLeadingDimsForGemmLikeOp(rewriter, brgemmOp);
     if (failed(dims)) {

--- a/lib/TPP/ConvertTppToXsmm.cpp
+++ b/lib/TPP/ConvertTppToXsmm.cpp
@@ -299,8 +299,7 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
     auto isBitSet = static_cast<uint64_t>(binaryFlag) &
                     static_cast<uint64_t>(xsmm::BinaryFlags::BCAST_COL_IN_0);
     if (isBiasAdd && !isBitSet) {
-      (void)tpp::utils::splitFusedOp(brgemmOp, rewriter);
-      rewriter.eraseOp(brgemmOp);
+      tpp::utils::splitAndReplaceFusedOp(brgemmOp, rewriter);
       return success();
     }
 

--- a/lib/TPP/ConvertXsmmToFunc.cpp
+++ b/lib/TPP/ConvertXsmmToFunc.cpp
@@ -433,11 +433,13 @@ struct ConvertFusedBrgemmOp : public OpRewritePattern<FusedBrgemmDispatchOp> {
 
   LogicalResult matchAndRewrite(FusedBrgemmDispatchOp dispatchOp,
                                 PatternRewriter &rewriter) const override {
-    // Currently LIBXSMM support only BCAST_COL_IN_0 as binary flag.
+    // Currently LIBXSMM support only BCAST_COL_IN_0 as binary flag with bias
+    // addition.
+    auto isFusedAdd = dispatchOp.getBinaryKind() == xsmm::BinaryKind::ADD;
     auto binaryFlags = dispatchOp.getBinaryFlags();
-    if (binaryFlags.size() != 1 ||
-        binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
-            BinaryFlags::BCAST_COL_IN_0) {
+    if (isFusedAdd && (binaryFlags.size() != 1 ||
+                       binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
+                           BinaryFlags::BCAST_COL_IN_0)) {
       return failure();
     }
     return buildDispatchOp<FusedBrgemmDispatchOp>(rewriter, dispatchOp,

--- a/lib/TPP/ConvertXsmmToFunc.cpp
+++ b/lib/TPP/ConvertXsmmToFunc.cpp
@@ -436,8 +436,10 @@ struct ConvertFusedBrgemmOp : public OpRewritePattern<FusedBrgemmDispatchOp> {
     // Currently LIBXSMM support only BCAST_COL_IN_0 as binary flag.
     auto binaryFlags = dispatchOp.getBinaryFlags();
     if (binaryFlags.size() != 1 ||
-        binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
-            BinaryFlags::BCAST_COL_IN_0) {
+        ((binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
+          BinaryFlags::BCAST_COL_IN_0) &&
+         (binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
+          BinaryFlags::NONE))) {
       return failure();
     }
     return buildDispatchOp<FusedBrgemmDispatchOp>(rewriter, dispatchOp,

--- a/lib/TPP/ConvertXsmmToFunc.cpp
+++ b/lib/TPP/ConvertXsmmToFunc.cpp
@@ -436,10 +436,8 @@ struct ConvertFusedBrgemmOp : public OpRewritePattern<FusedBrgemmDispatchOp> {
     // Currently LIBXSMM support only BCAST_COL_IN_0 as binary flag.
     auto binaryFlags = dispatchOp.getBinaryFlags();
     if (binaryFlags.size() != 1 ||
-        ((binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
-          BinaryFlags::BCAST_COL_IN_0) &&
-         (binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
-          BinaryFlags::NONE))) {
+        binaryFlags[0].cast<BinaryFlagsAttr>().getValue() !=
+            BinaryFlags::BCAST_COL_IN_0) {
       return failure();
     }
     return buildDispatchOp<FusedBrgemmDispatchOp>(rewriter, dispatchOp,

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -157,8 +157,9 @@ static bool isTppUnaryOp(linalg::GenericOp linalgOp) {
 // Return true if the linalg.generic can be mapped to a tpp.add.
 bool isTppAdd(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
-  auto addMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
-      MatchOne(0), WithSingleOp<arith::AddFOp>(operands));
+  auto addMatcher =
+      StructuredOpMatcher::make<linalg::GenericOp>()
+          .region(MatchOne(0), WithSingleOp<arith::AddFOp>(operands));
   return isTppBinaryOp(linalgOp) && addMatcher.match(linalgOp);
 }
 
@@ -225,8 +226,8 @@ private:
 // Return true if the linalg.generic can be mapped to a tpp.relu.
 bool isTppRelu(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
-  auto reluMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
-      MatchOne(0), WithReluBody(operands));
+  auto reluMatcher = StructuredOpMatcher::make<linalg::GenericOp>()
+                         .region(MatchOne(0), WithReluBody(operands));
   return isTppUnaryOp(linalgOp) && reluMatcher.match(linalgOp);
 }
 
@@ -235,8 +236,9 @@ bool isTppIdentity(linalg::GenericOp linalgOp,
                    SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
   SmallVector<Value, 2> linalgOperands;
-  auto identityMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
-      MatchOne(0), WithSingleOp<linalg::YieldOp>(&linalgOperands));
+  auto identityMatcher =
+      StructuredOpMatcher::make<linalg::GenericOp>()
+          .region(MatchOne(0), WithSingleOp<linalg::YieldOp>(&linalgOperands));
 
   if (!isTppUnaryOp(linalgOp) || !identityMatcher.match(linalgOp))
     return false;
@@ -251,8 +253,8 @@ bool isTppIdentity(linalg::GenericOp linalgOp,
 // Return true if the linalg.generic can be mapped to a tpp.zero.
 bool isTppZero(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
-  auto zeroMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
-      MatchOne(0), WithSingleOp<linalg::YieldOp>());
+  auto zeroMatcher = StructuredOpMatcher::make<linalg::GenericOp>()
+                         .region(MatchOne(0), WithSingleOp<linalg::YieldOp>());
 
   if (!isTppUnaryOp(linalgOp) || !zeroMatcher.match(linalgOp))
     return false;

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -272,10 +272,10 @@ bool isTppZero(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   return true;
 }
 
-void splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
-                            PatternRewriter &rewriter) {
-  assert(fusedBrgemmOp.hasBufferSemantics() &&
-         "tpp.fused_brgemm expects a memref type");
+LogicalResult splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
+                                     PatternRewriter &rewriter) {
+  if (!fusedBrgemmOp.hasBufferSemantics())
+    return failure();
 
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(fusedBrgemmOp);
@@ -304,6 +304,7 @@ void splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
   }
 
   rewriter.eraseOp(fusedBrgemmOp);
+  return success();
 }
 
 } // namespace utils

--- a/test/BF16/Integration/xsmm-quarternary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-quarternary-bf16.mlir
@@ -2,11 +2,18 @@
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 
-func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>, %arg2: memref<4xbf16>, %arg3: memref<4x4xbf16>) {
+func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>, %arg2: memref<4x4xbf16>, %arg3: memref<4xbf16>) {
   %c16_i64 = arith.constant 16 : i64
   %func = xsmm.fused_brgemm.dispatch [4, 4, 4, 4, 4, 4][add, relu]
     flags = (vnni_b) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = bf16
-  xsmm.fused_brgemm(data_type = bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4xbf16>, memref<4x4xbf16>, i64) -> ()
+  xsmm.fused_brgemm(data_type = bf16, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, memref<4xbf16>, i64) -> ()
+
+  %threshold = arith.constant 0.0 : bf16
+  %outVal = arith.constant 66.0 : bf16
+  %trueOut = memref.alloc(): memref<4x4xbf16>
+  linalg.fill ins(%outVal : bf16) outs(%trueOut : memref<4x4xbf16>)
+  check.expect_almost_eq(%trueOut, %arg2, %threshold): memref<4x4xbf16>, memref<4x4xbf16>, bf16
+
   return
 }
 

--- a/test/BF16/Integration/xsmm-quarternary-bf16.mlir
+++ b/test/BF16/Integration/xsmm-quarternary-bf16.mlir
@@ -1,6 +1,5 @@
-// RUN: tpp-run %s -print \
-// RUN:  -e entry -entry-point-result=void | \
-// RUN: FileCheck %s
+// RUN: tpp-run %s \
+// RUN:  -e entry -entry-point-result=void
 
 func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>, %arg2: memref<4x4xbf16>, %arg3: memref<4xbf16>) {
   %c16_i64 = arith.constant 16 : i64
@@ -16,8 +15,3 @@ func.func @entry(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>, %arg2
 
   return
 }
-
-// CHECK: ( 1, 1, 1, 1 )
-// CHECK: ( 1, 1, 1, 1 )
-// CHECK: ( 1, 1, 1, 1 )
-// CHECK: ( 1, 1, 1, 1 )

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
@@ -39,15 +39,12 @@ func.func @brgemm_fused(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
   return
 }
 
-// TODO remove split after LIBXSMM binary flag is fixed
 // CHECK-LABEL: brgemm_fused
 // CHECK-SAME:  %[[ARG0:.+]]: memref<3x5x4xf32>, %[[ARG1:.+]]: memref<3x4x5xf32>, 
 // CHECK-SAME:  %[[ARG2:.+]]: memref<5x5xf32>, %[[ARG3:.+]]: memref<5x5xf32>
 // CHECK: %[[C3:.+]] = arith.constant 3 : i64
-// CHECK-NOT: xsmm.fused_brgemm.dispatch [5, 5, 4, 4, 5, 5] [none,none]  flags = (none)  binary_flags = (none)  unary_flags = (none) data_type = f32
-// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
-// CHECK-NOT: xsmm.fused_brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[C3]])
-// CHECK: xsmm.brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[C3]])
+// CHECK:  %[[DIS:.+]] = xsmm.fused_brgemm.dispatch [5, 5, 4, 4, 5, 5][none,none]  flags = (none)  binary_flags = (none)  unary_flags = (none) data_type = f32
+// CHECK: xsmm.fused_brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[C3]])
 
 // -----
 

--- a/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
@@ -245,13 +245,20 @@ func.func @dispatch_fused_brgemm() -> i64 {
 
 // Current limitation in LIBXSMM we can use only bcast_col_in0 as flag for binary.
 // see: https://github.com/libxsmm/libxsmm/issues/766
-// CHECK-LABEL: dispatch_fused_brgemm
 func.func @dispatch_fused_brgemm() -> i64 {
-  // CHECK-NOT: xsmm_fused_brgemm.dispatch 
   %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13] [add, relu]
     flags = (vnni_a) binary_flags = (none) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
+
+// CHECK-LABEL: dispatch_fused_brgemm
+// CHECK: %[[C2:.+]] = arith.constant 2 : i64
+// CHECK-DAG: %[[C13:.+]] = arith.constant 13 : i64
+// CHECK-DAG: %[[C4096:.+]] = arith.constant 4096 : i64
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
+// CHECK-DAG: %[[C5:.+]] = arith.constant 5 : i64
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
+// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[C2]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C4096]], %[[C0]], %[[C5]], %[[C0]], %[[C1]])
 
 // -----
 

--- a/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
@@ -245,20 +245,13 @@ func.func @dispatch_fused_brgemm() -> i64 {
 
 // Current limitation in LIBXSMM we can use only bcast_col_in0 as flag for binary.
 // see: https://github.com/libxsmm/libxsmm/issues/766
+// CHECK-LABEL: dispatch_fused_brgemm
 func.func @dispatch_fused_brgemm() -> i64 {
+  // CHECK-NOT: xsmm_fused_brgemm.dispatch 
   %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13] [add, relu]
     flags = (vnni_a) binary_flags = (none) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
-
-// CHECK-LABEL: dispatch_fused_brgemm
-// CHECK: %[[C2:.+]] = arith.constant 2 : i64
-// CHECK-DAG: %[[C13:.+]] = arith.constant 13 : i64
-// CHECK-DAG: %[[C4096:.+]] = arith.constant 4096 : i64
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
-// CHECK-DAG: %[[C5:.+]] = arith.constant 5 : i64
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
-// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[C2]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C4096]], %[[C0]], %[[C5]], %[[C0]], %[[C1]])
 
 // -----
 

--- a/test/Integration/tpp-fused-brgemm-no-fusion.mlir
+++ b/test/Integration/tpp-fused-brgemm-no-fusion.mlir
@@ -1,0 +1,25 @@
+// RUN: tpp-run %s \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+memref.global "private" constant @__bias2D : memref<4x4xf32> =
+  dense<[[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]>
+
+func.func @entry(%arg0: memref<64x4x4xf32>, %arg1: memref<64x4x4xf32>, %arg2: memref<4x4xf32>, %arg3: memref<4x4xf32>) {
+  %bias2 = memref.get_global @__bias2D : memref<4x4xf32>
+  tpp.fused_brgemm [unary = none, binary = none]
+    ins(%arg0 : memref<64x4x4xf32>, %arg1 : memref<64x4x4xf32>,
+        %arg3 : memref<4x4xf32>, %bias2 : memref<4x4xf32>)
+    outs(%arg3 : memref<4x4xf32>)
+
+  %cast3 = memref.cast %arg3 :memref<4x4xf32> to memref<*xf32>
+  call @printMemrefF32(%cast3) : (memref<*xf32>) -> ()
+
+  return
+}
+func.func private @printMemrefF32(memref<*xf32>)
+
+// CHECK:  [257,   257,   257,   257],
+// CHECK:  [257,   257,   257,   257],
+// CHECK:  [257,   257,   257,   257],
+// CHECK:  [257,   257,   257,   257]

--- a/test/Integration/tpp-fused-brgemm.mlir
+++ b/test/Integration/tpp-fused-brgemm.mlir
@@ -1,5 +1,6 @@
 // RUN: tpp-run %s \
-// RUN:  -e entry -entry-point-result=void
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
 
 memref.global "private" constant @__biasBcast : memref<1x4xf32> =
   dense<[[1.0, 2.0, 3.0, 4.0]]>
@@ -28,11 +29,11 @@ func.func @entry(%arg0: memref<64x4x4xf32>, %arg1: memref<64x4x4xf32>, %arg2: me
 }
 func.func private @printMemrefF32(memref<*xf32>)
 
-// CHECK: [[258,   259,   260,   261],
 // CHECK:  [258,   259,   260,   261],
 // CHECK:  [258,   259,   260,   261],
-// CHECK:  [258,   259,   260,   261]]
-// CHECK: [[258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261]
 // CHECK:  [258,   259,   260,   261],
 // CHECK:  [258,   259,   260,   261],
-// CHECK:  [258,   259,   260,   261]]
+// CHECK:  [258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261]

--- a/test/Integration/tpp-fused-brgemm.mlir
+++ b/test/Integration/tpp-fused-brgemm.mlir
@@ -1,0 +1,38 @@
+// RUN: tpp-run %s \
+// RUN:  -e entry -entry-point-result=void
+
+memref.global "private" constant @__biasBcast : memref<1x4xf32> =
+  dense<[[1.0, 2.0, 3.0, 4.0]]>
+memref.global "private" constant @__bias2D : memref<4x4xf32> =
+  dense<[[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]>
+
+func.func @entry(%arg0: memref<64x4x4xf32>, %arg1: memref<64x4x4xf32>, %arg2: memref<4x4xf32>, %arg3: memref<4x4xf32>) {
+  %bias1 = memref.get_global @__biasBcast : memref<1x4xf32>
+  tpp.fused_brgemm [unary = relu, binary = add]
+    ins(%arg0 : memref<64x4x4xf32>, %arg1 : memref<64x4x4xf32>,
+        %arg2 : memref<4x4xf32>, %bias1 : memref<1x4xf32>)
+    outs(%arg2 : memref<4x4xf32>)
+
+  %bias2 = memref.get_global @__bias2D : memref<4x4xf32>
+  tpp.fused_brgemm [unary = relu, binary = add]
+    ins(%arg0 : memref<64x4x4xf32>, %arg1 : memref<64x4x4xf32>,
+        %arg3 : memref<4x4xf32>, %bias2 : memref<4x4xf32>)
+    outs(%arg3 : memref<4x4xf32>)
+
+  %cast2 = memref.cast %arg2 :memref<4x4xf32> to memref<*xf32>
+  call @printMemrefF32(%cast2) : (memref<*xf32>) -> ()
+  %cast3 = memref.cast %arg3 :memref<4x4xf32> to memref<*xf32>
+  call @printMemrefF32(%cast3) : (memref<*xf32>) -> ()
+
+  return
+}
+func.func private @printMemrefF32(memref<*xf32>)
+
+// CHECK: [[258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261]]
+// CHECK: [[258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261],
+// CHECK:  [258,   259,   260,   261]]

--- a/test/Integration/xsmm-quarternary.mlir
+++ b/test/Integration/xsmm-quarternary.mlir
@@ -1,0 +1,17 @@
+// RUN: tpp-run %s \
+// RUN:  -e entry -entry-point-result=void
+
+func.func @entry(%arg0: memref<64x4x4xf32>, %arg1: memref<64x2x4x2xf32>, %arg2: memref<4x4xf32>, %arg3: memref<4xf32>) {
+  %c16_i64 = arith.constant 16 : i64
+  %func = xsmm.fused_brgemm.dispatch [4, 4, 4, 4, 4, 4][add, relu]
+    flags = (none) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = f32
+  xsmm.fused_brgemm(data_type = f32, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xf32>, memref<64x2x4x2xf32>, memref<4x4xf32>, memref<4xf32>, i64) -> ()
+
+  %threshold = arith.constant 0.0 : f32
+  %outVal = arith.constant 66.0 : f32
+  %trueOut = memref.alloc(): memref<4x4xf32>
+  linalg.fill ins(%outVal : f32) outs(%trueOut : memref<4x4xf32>)
+  check.expect_almost_eq(%trueOut, %arg2, %threshold): memref<4x4xf32>, memref<4x4xf32>, f32
+
+  return
+}


### PR DESCRIPTION
Adds a workaround to enable working lowering of `tpp.fused_brgemm` without XSMM `bcast_col_in0` binary flag.
Additionally, quarternary ops testing is improved.

Due to current limitation of LIBXSMM https://github.com/libxsmm/libxsmm/issues/766, code generation fails when the specific binary flag is not present.
After TPP on tensors support was introduced, `tpp.fused_brgemm` ops which violate this limitation started showing up. To address the issue, offending fused ops are split into separate XSMM operations which do not have this limitations.

Work towards #580 