### PR TITLE
Enable rewrite-to-brgemm to preserve parallelism at tensor level

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -140,7 +140,9 @@ createGpuToCudaPass(StringRef gpuTriple = "nvptx64-nvidia-cuda",
                     StringRef gpuChip = "sm_35",
                     StringRef gpuFeatures = "+ptx60");
 
+// Testing passes.
 void registerTestStructuralMatchers();
+void registerTestForToForAllRewrite();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/TransformUtils.h
+++ b/include/TPP/TransformUtils.h
@@ -78,6 +78,12 @@ bool isMatmulOp(Operation *op,
 bool hasMulAddBody(linalg::LinalgOp linalgOp,
                    SmallVectorImpl<Value> *capturedOperands = nullptr);
 
+// Rewrite scf.for to scf.forall. Assumes the loop to be parallel and
+// marked with `kLoopId`.
+constexpr const static llvm::StringLiteral kLoopId = "parallel";
+constexpr const static llvm::StringLiteral kLoopRoot = "root";
+void populateScfForToForAllRewritePattern(RewritePatternSet &patterns);
+
 } // namespace utils
 } // namespace linalgx
 } // namespace mlir

--- a/include/TPP/TransformUtils.h
+++ b/include/TPP/TransformUtils.h
@@ -80,7 +80,7 @@ bool hasMulAddBody(linalg::LinalgOp linalgOp,
 
 // Rewrite scf.for to scf.forall. Assumes the loop to be parallel and
 // marked with `kLoopId`.
-constexpr const static llvm::StringLiteral kLoopId = "parallel";
+constexpr const static llvm::StringLiteral kLoopParallel = "parallel";
 constexpr const static llvm::StringLiteral kLoopRoot = "root";
 void populateScfForToForAllRewritePattern(RewritePatternSet &patterns);
 

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -39,6 +39,7 @@ add_mlir_library(MLIRTPP
 
   # Test Passes
     TestMatchers.cpp
+    TestForToForAllRewrite.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/RewriteToBatchReduceGemm.cpp
+++ b/lib/TPP/RewriteToBatchReduceGemm.cpp
@@ -312,7 +312,7 @@ mlir::linalgx::rewriteToBRGemmOp(RewriterBase &rewriter,
 
   Operation *outermostLoop = getOuterMostLoop(ivs);
   if (outermostLoop && isa<scf::ForOp>(outermostLoop)) {
-    outermostLoop->setAttr(linalgx::utils::kLoopId,
+    outermostLoop->setAttr(linalgx::utils::kLoopParallel,
                            rewriter.getStringAttr(linalgx::utils::kLoopRoot));
   }
 
@@ -393,7 +393,7 @@ rewriteToBrGemmVnniOp(RewriterBase &rewriter, linalg::LinalgOp linalgOp) {
 
   Operation *outermostLoop = getOuterMostLoop(ivs);
   if (outermostLoop && isa<scf::ForOp>(outermostLoop)) {
-    outermostLoop->setAttr(linalgx::utils::kLoopId,
+    outermostLoop->setAttr(linalgx::utils::kLoopParallel,
                            rewriter.getStringAttr(linalgx::utils::kLoopRoot));
   }
   rewriter.replaceOp(linalgOp, outermostLoop ? outermostLoop->getResults()

--- a/lib/TPP/RewriteToBatchReduceGemm.cpp
+++ b/lib/TPP/RewriteToBatchReduceGemm.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
@@ -298,6 +299,8 @@ mlir::linalgx::rewriteToBRGemmOp(RewriterBase &rewriter,
   };
 
   if (linalgOp.hasBufferSemantics()) {
+    // TODO: (lorenzo) this is legacy. It will be removed from linalg too.
+    // Use the tiling interface.
     linalg::GenerateLoopNest<scf::ParallelOp>::doit(
         rewriter, linalgOp.getLoc(), loopRanges, linalgOp,
         linalgOp.getIteratorTypesArray(), brgemmBuilder);
@@ -308,6 +311,10 @@ mlir::linalgx::rewriteToBRGemmOp(RewriterBase &rewriter,
   }
 
   Operation *outermostLoop = getOuterMostLoop(ivs);
+  if (outermostLoop && isa<scf::ForOp>(outermostLoop)) {
+    outermostLoop->setAttr(linalgx::utils::kLoopId,
+                           rewriter.getStringAttr(linalgx::utils::kLoopRoot));
+  }
 
   rewriter.replaceOp(linalgOp, outermostLoop ? outermostLoop->getResults()
                                              : tensorResults);
@@ -385,6 +392,10 @@ rewriteToBrGemmVnniOp(RewriterBase &rewriter, linalg::LinalgOp linalgOp) {
   }
 
   Operation *outermostLoop = getOuterMostLoop(ivs);
+  if (outermostLoop && isa<scf::ForOp>(outermostLoop)) {
+    outermostLoop->setAttr(linalgx::utils::kLoopId,
+                           rewriter.getStringAttr(linalgx::utils::kLoopRoot));
+  }
   rewriter.replaceOp(linalgOp, outermostLoop ? outermostLoop->getResults()
                                              : tensorResults);
   return outermostLoop ? outermostLoop->getResults() : tensorResults;
@@ -434,11 +445,19 @@ struct RewriteToBatchReduceGemmVnniImpl
 struct RewriteToBatchReduceGemm
     : public RewriteToBatchReduceGemmBase<RewriteToBatchReduceGemm> {
   void runOnOperation() override {
-    RewritePatternSet patterns(getOperation().getContext());
-    patterns
-        .add<RewriteToBatchReduceGemmImpl, RewriteToBatchReduceGemmVnniImpl>(
-            patterns.getContext());
-    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    auto &ctx = getContext();
+    {
+      RewritePatternSet patterns(&ctx);
+      patterns
+          .add<RewriteToBatchReduceGemmImpl, RewriteToBatchReduceGemmVnniImpl>(
+              patterns.getContext());
+      (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    }
+    {
+      RewritePatternSet patterns(&ctx);
+      linalgx::utils::populateScfForToForAllRewritePattern(patterns);
+      (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    }
   }
 };
 

--- a/lib/TPP/TestForToForAllRewrite.cpp
+++ b/lib/TPP/TestForToForAllRewrite.cpp
@@ -1,0 +1,43 @@
+//===- TestForToForAllRewrite.cpp - ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/TransformUtils.h"
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace {
+// This is a test pass to check the scf.for to scf.forall rewrite.
+struct TestForToForAllRewrite
+    : public PassWrapper<TestForToForAllRewrite,
+                         InterfacePass<FunctionOpInterface>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestForToForAllRewrite)
+  void runOnOperation() override;
+  StringRef getArgument() const final { return "test-scf-for-rewrite"; }
+  StringRef getDescription() const final {
+    return "Test scf.for to scf.forall rewrite.";
+  }
+};
+
+} // namespace
+
+void TestForToForAllRewrite::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  linalgx::utils::populateScfForToForAllRewritePattern(patterns);
+  (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+}
+
+namespace mlir {
+namespace tpp {
+void registerTestForToForAllRewrite() {
+  PassRegistration<TestForToForAllRewrite>();
+}
+} // namespace tpp
+} // namespace mlir

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -55,8 +55,8 @@ struct ReplaceIterArgs : public OpRewritePattern<scf::ForOp> {
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
-    auto metadata = forOp->getAttrOfType<StringAttr>("fusion");
-    if (!metadata || metadata.getValue() != "root")
+    auto metadata = forOp->getAttrOfType<StringAttr>(linalgx::utils::kLoopId);
+    if (!metadata || metadata.getValue() != linalgx::utils::kLoopRoot)
       return failure();
     if (forOp.getNumRegionIterArgs() != 1)
       return failure();
@@ -65,91 +65,6 @@ struct ReplaceIterArgs : public OpRewritePattern<scf::ForOp> {
     if (nestedLoops.size() == 0)
       return failure();
     replaceIterArgs(rewriter, forOp, nestedLoops[nestedLoops.size() - 1]);
-    return success();
-  }
-};
-
-// Convert scf.for to scf.forall after fusion.
-struct ConvertToForAll : public OpRewritePattern<scf::ForOp> {
-  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(scf::ForOp forOp,
-                                PatternRewriter &rewriter) const override {
-    auto metadata = forOp->getAttrOfType<StringAttr>("fusion");
-    if (!metadata || metadata.getValue() != "root")
-      return failure();
-    if (forOp.getNumRegionIterArgs() != 1)
-      return failure();
-    SmallVector<scf::ForOp> nestedLoops;
-    getPerfectlyNestedLoops(nestedLoops, forOp);
-    if (nestedLoops.size() == 0)
-      return failure();
-
-    SmallVector<Value> loopArgs;
-    SmallVector<OpFoldResult> lbs, ubs, steps;
-    for (scf::ForOp &currentLoop : nestedLoops) {
-      if (currentLoop.getNumRegionIterArgs() != 1)
-        return failure();
-      loopArgs.push_back(currentLoop.getInductionVar());
-      lbs.push_back(currentLoop.getLowerBound());
-      ubs.push_back(currentLoop.getUpperBound());
-      steps.push_back(currentLoop.getStep());
-      auto metadata = currentLoop->getAttrOfType<StringAttr>("fusion");
-      if (metadata && metadata.getValue() == "tail")
-        loopArgs.push_back(currentLoop.getRegionIterArg(0));
-    }
-
-    rewriter.replaceOpWithNewOp<scf::ForallOp>(
-        forOp, lbs, ubs, steps, ValueRange{forOp.getInitArgs()},
-        /*mapping=*/std::nullopt,
-        [&](OpBuilder &nestedBuilder, Location loc, ValueRange regionArgs) {
-          IRMapping mapping;
-          assert(loopArgs.size() == regionArgs.size() &&
-                 "expect same region args");
-          mapping.map(loopArgs, regionArgs);
-          Block *innerLoopBlock = nestedLoops[nestedLoops.size() - 1].getBody();
-          auto yieldOp = cast<scf::YieldOp>(innerLoopBlock->getTerminator());
-          auto insertSlice =
-              yieldOp.getOperands()[0].getDefiningOp<tensor::InsertSliceOp>();
-          assert(insertSlice && "must be an insert slice");
-          for (auto &nestedOp : innerLoopBlock->without_terminator()) {
-            if (&nestedOp == insertSlice.getOperation()) {
-              auto term = nestedBuilder.create<scf::InParallelOp>(loc);
-              nestedBuilder.setInsertionPointToStart(term.getBody());
-              Value sourceVal = mapping.lookup(insertSlice.getSource());
-              Value destVal = mapping.lookup(insertSlice.getDest());
-              SmallVector<OpFoldResult> offsets;
-              for (OpFoldResult offset : insertSlice.getMixedOffsets()) {
-                if (auto valueOffset = offset.dyn_cast<Value>())
-                  offsets.push_back(mapping.lookup(valueOffset));
-                else
-                  offsets.push_back(offset);
-              }
-              SmallVector<OpFoldResult> sizes;
-              for (OpFoldResult size : insertSlice.getMixedSizes()) {
-                if (auto valueSize = size.dyn_cast<Value>())
-                  sizes.push_back(mapping.lookupOrDefault(valueSize));
-                else
-                  sizes.push_back(size);
-              }
-              SmallVector<OpFoldResult> strides;
-              for (OpFoldResult stride : insertSlice.getMixedStrides()) {
-                if (auto valueStride = stride.dyn_cast<Value>())
-                  strides.push_back(mapping.lookupOrDefault(valueStride));
-                else
-                  strides.push_back(stride);
-              }
-              assert(offsets.size() == sizes.size());
-              assert(offsets.size() == strides.size());
-
-              nestedBuilder.create<tensor::ParallelInsertSliceOp>(
-                  loc, sourceVal, destVal, offsets, sizes, strides);
-              continue;
-            }
-            Operation *clone = nestedBuilder.clone(nestedOp, mapping);
-            mapping.map(nestedOp.getResults(), clone->getResults());
-          }
-        });
     return success();
   }
 };
@@ -500,10 +415,9 @@ fuseWithEltwise(RewriterBase &rewriter, TilingInterface consumer,
     LLVM_DEBUG(llvm::dbgs() << "NEW OP: " << tiledOp << "\n");
   }
   if (!tilingResult->loops.empty()) {
-    int64_t last = tilingResult->loops.size() - 1;
-    tilingResult->loops[0]->setAttr("fusion", rewriter.getStringAttr("root"));
-    tilingResult->loops[last]->setAttr("fusion",
-                                       rewriter.getStringAttr("tail"));
+    tilingResult->loops[0]->setAttr(
+        linalgx::utils::kLoopId,
+        rewriter.getStringAttr(linalgx::utils::kLoopRoot));
   }
   tileAndFuseResult.loops = std::move(tilingResult->loops);
   for (const auto &result : llvm::enumerate(llvm::zip_equal(
@@ -703,7 +617,7 @@ struct TileConsumerAndFuseProducers
       // Patterns for scf.forall.
       RewritePatternSet patterns(&ctx);
       if (this->useForAll)
-        patterns.add<ConvertToForAll>(&ctx);
+        linalgx::utils::populateScfForToForAllRewritePattern(patterns);
       // Fold unit-extent dims for linalg on tensors.
       linalg::populateFoldUnitExtentDimsViaSlicesPatterns(patterns);
       tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -55,7 +55,8 @@ struct ReplaceIterArgs : public OpRewritePattern<scf::ForOp> {
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
-    auto metadata = forOp->getAttrOfType<StringAttr>(linalgx::utils::kLoopId);
+    auto metadata =
+        forOp->getAttrOfType<StringAttr>(linalgx::utils::kLoopParallel);
     if (!metadata || metadata.getValue() != linalgx::utils::kLoopRoot)
       return failure();
     if (forOp.getNumRegionIterArgs() != 1)
@@ -416,7 +417,7 @@ fuseWithEltwise(RewriterBase &rewriter, TilingInterface consumer,
   }
   if (!tilingResult->loops.empty()) {
     tilingResult->loops[0]->setAttr(
-        linalgx::utils::kLoopId,
+        linalgx::utils::kLoopParallel,
         rewriter.getStringAttr(linalgx::utils::kLoopRoot));
   }
   tileAndFuseResult.loops = std::move(tilingResult->loops);

--- a/lib/TPP/TransformUtils.cpp
+++ b/lib/TPP/TransformUtils.cpp
@@ -576,7 +576,8 @@ struct ConvertToForAll : public OpRewritePattern<scf::ForOp> {
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
-    auto metadata = forOp->getAttrOfType<StringAttr>(linalgx::utils::kLoopId);
+    auto metadata =
+        forOp->getAttrOfType<StringAttr>(linalgx::utils::kLoopParallel);
     if (!metadata || metadata.getValue() != linalgx::utils::kLoopRoot)
       return failure();
     if (forOp.getNumRegionIterArgs() != 1)

--- a/test/BF16/matmul-vnni.mlir
+++ b/test/BF16/matmul-vnni.mlir
@@ -31,6 +31,5 @@ func.func @matmul_static(
 // CHECK: %[[PACKED_VNNI_ARG1:.+]] = tensor.pack %[[PACKED_ARG1]] 
 // CHECK-SAME:  inner_dims_pos = [2] inner_tiles = [2] 
 // CHECK-SAME:  into %[[EMPTY_VNNI]] : tensor<32x16x32x32xbf16> -> tensor<32x16x16x32x2xbf16>
-// CHECK: %{{.+}} = scf.for
-// CHECK: %{{.+}} = scf.for
+// CHECK: %{{.+}} = scf.forall
 // CHECK: %{{.+}} = tpp.brgemm (%{{.+}} : tensor<16x32x32xbf16>, %{{.+}} : tensor<16x16x32x2xbf16>, %{{.+}} : tensor<32x32xbf16>) -> (tensor<32x32xbf16>)

--- a/test/Passes/pass-map-to-brgemm.mlir
+++ b/test/Passes/pass-map-to-brgemm.mlir
@@ -13,17 +13,12 @@ func.func @blocked_matmul(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor<8x16x32x3
   // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : index
   // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
   // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
-  // CHECK: %[[OUTER:.+]] = scf.for %[[P1:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[INIT:.+]] = %[[ARG2]]) -> (tensor<4x8x32x32xf32>) {
-  // CHECK: %[[INNER:.+]] = scf.for %[[P2:.+]] = %[[C0]] to %[[C8]] step %[[C1]] iter_args(%[[INIT2:.+]] = %[[INIT]]) -> (tensor<4x8x32x32xf32>) {
+  // CHECK: %[[OUTER:.+]] = scf.forall (%[[P1:.+]], %[[P2:.+]]) in (%[[C4]], %[[C8]]) shared_outs(%[[INIT:.+]] = %[[ARG2]]) -> (tensor<4x8x32x32xf32>) {
   // CHECK: %[[SLICEA:.+]] = tensor.extract_slice %[[ARG0]][%[[P1]], 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : tensor<4x16x32x32xf32> to tensor<16x32x32xf32>
   // CHECK: %[[SLICEB:.+]] = tensor.extract_slice %[[ARG1]][%[[P2]], 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : tensor<8x16x32x32xf32> to tensor<16x32x32xf32>
-  // CHECK: %[[SLICEC:.+]] = tensor.extract_slice %[[INIT2]][%[[P1]], %[[P2]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<4x8x32x32xf32> to tensor<32x32xf32>
+  // CHECK: %[[SLICEC:.+]] = tensor.extract_slice %[[INIT]][%[[P1]], %[[P2]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<4x8x32x32xf32> to tensor<32x32xf32>
   // CHECK: %[[MUL:.+]] = linalg.batch_reduce_matmul ins(%[[SLICEA]], %[[SLICEB]] : tensor<16x32x32xf32>, tensor<16x32x32xf32>) outs(%[[SLICEC]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-  // CHECK: %[[YIELD:.+]] = tensor.insert_slice %[[MUL]] into %[[INIT2]][%[[P1]], %[[P2]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<4x8x32x32xf32>
-  // CHECK: scf.yield %[[YIELD]] : tensor<4x8x32x32xf32>
-  // CHECK: }
-  // CHECK: scf.yield %[[INNER]] : tensor<4x8x32x32xf32>
-  // CHECK: }
+  // CHECK: tensor.parallel_insert_slice %[[MUL]] into %[[INIT]][%[[P1]], %[[P2]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<4x8x32x32xf32>
   // CHECK: return %[[OUTER]] : tensor<4x8x32x32xf32>
  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x16x32x32xf32>, tensor<8x16x32x32xf32>) outs(%arg2 : tensor<4x8x32x32xf32>) {
     ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
@@ -105,8 +100,7 @@ func.func @vnni_layout_brgemm3(%arg0: tensor<32x32x48x32x32xbf16>,
         %12 = arith.addf %out, %11 : bf16
         linalg.yield %12 : bf16
   } -> tensor<32x32x32x32xbf16>
-  // CHECK: %{{.+}} = scf.for
-  // CHECK-NEXT: %{{.+}} = scf.for
+  // CHECK: %{{.+}} = scf.forall
   // CHECK: %{{.+}} = tpp.brgemm (%{{.+}} : tensor<48x32x32xbf16>, %{{.+}} : tensor<48x16x32x2xbf16>, 
   // CHECK-SAME:                  %{{.+}} : tensor<32x32xbf16>) -> (tensor<32x32xbf16>)
   return %0 : tensor<32x32x32x32xbf16>

--- a/test/Passes/pass-matmul-fuse.mlir
+++ b/test/Passes/pass-matmul-fuse.mlir
@@ -29,10 +29,9 @@ func.func @matmul_and_relu(%arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32
 // CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]] outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF1]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
 // CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
 // CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF2]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
-// CHECK: %[[LOOP0:.+]] = scf.for %[[ARG3:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[PACK2]]) -> (tensor<4x4x32x32xf32>) {
-// CHECK: %[[LOOP1:.+]] = scf.for %[[ARG5:.+]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[ARG6:.+]] = %[[ARG4]]) -> (tensor<4x4x32x32xf32>) {
+// CHECK: %[[LOOP:.+]] = scf.forall (%[[ARG3:.+]], %[[ARG4:.+]]) in (%[[C4]], %[[C4]]) shared_outs(%[[ARG6:.+]] = %[[PACK2]]) -> (tensor<4x4x32x32xf32>) 
 // CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[PACK0]][%[[ARG3]], 0, 0, 0] [1, 4, 32, 32] [1, 1, 1, 1] : tensor<4x4x32x32xf32> to tensor<4x32x32xf32>
-// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[PACK1]][%[[ARG5]], 0, 0, 0] [1, 4, 32, 32] [1, 1, 1, 1] : tensor<4x4x32x32xf32> to tensor<4x32x32xf32>
-// CHECK: %[[SLICE2:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG3]], %[[ARG5]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<4x4x32x32xf32> to tensor<32x32xf32>
+// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[PACK1]][%[[ARG4]], 0, 0, 0] [1, 4, 32, 32] [1, 1, 1, 1] : tensor<4x4x32x32xf32> to tensor<4x32x32xf32>
+// CHECK: %[[SLICE2:.+]] = tensor.extract_slice %[[ARG6]][%[[ARG3]], %[[ARG4]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<4x4x32x32xf32> to tensor<32x32xf32>
 // CHECK: %[[MUL:.+]] = linalg.batch_reduce_matmul ins(%[[SLICE0]], %[[SLICE1]] : tensor<4x32x32xf32>, tensor<4x32x32xf32>) outs(%[[SLICE2]] : tensor<32x32xf32>) -> tensor<32x32xf32>
 // CHECK: %[[RELU:.+]] = linalg.generic {indexing_maps = [#[[MAP]]], iterator_types = ["parallel", "parallel"]} outs(%[[MUL]] : tensor<32x32xf32>)

--- a/test/Passes/test-rewrite-to-forall.mlir
+++ b/test/Passes/test-rewrite-to-forall.mlir
@@ -1,0 +1,112 @@
+// RUN: tpp-opt %s -mlir-disable-threading=true -pass-pipeline="builtin.module(func.func(test-scf-for-rewrite))" | FileCheck %s
+
+// CHECK-LABEL: test
+func.func @test() {
+  return
+}
+
+// CHECK-LABEL: missing_attribute
+func.func @missing_attribute(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  // CHECK-NOT: scf.forall
+  %outer = scf.for %i = %c0 to %c3 step %c1 iter_args(%arg2 = %arg1) -> (tensor<3x3xf32>) {
+    %inner = scf.for %j = %c0 to %c3 step %c1 iter_args(%arg3 = %arg2) -> (tensor<3x3xf32>) {
+      %source = tensor.extract %arg0[%i, %j] : tensor<3x3xf32>
+      %dest = tensor.insert %source into %arg3[%i, %j] : tensor<3x3xf32>
+      scf.yield %dest : tensor<3x3xf32>
+    }
+    scf.yield %inner : tensor<3x3xf32>
+  }
+  return %outer : tensor<3x3xf32>
+}
+
+// CHECK-LABEL: no_extract_slice
+func.func @no_extract_slice(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  // CHECK-NOT: scf.forall
+  %outer = scf.for %i = %c0 to %c3 step %c1 iter_args(%arg2 = %arg1) -> (tensor<3x3xf32>) {
+    %inner = scf.for %j = %c0 to %c3 step %c1 iter_args(%arg3 = %arg2) -> (tensor<3x3xf32>) {
+      %source = tensor.extract %arg0[%i, %j] : tensor<3x3xf32>
+      %dest = tensor.insert %source into %arg3[%i, %j] : tensor<3x3xf32>
+      scf.yield %dest : tensor<3x3xf32>
+    }
+    scf.yield %inner : tensor<3x3xf32>
+  } {parallel = "root"}
+  return %outer : tensor<3x3xf32>
+}
+
+// CHECK-LABEL: expect_to_convert_3d
+func.func @expect_to_convert_3d(%arg0: tensor<3x3x3xf32>, 
+                                            %arg1: tensor<3x3x3xf32>) -> tensor<3x3x3xf32> {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.forall
+  %outer = scf.for %i = %c0 to %c3 step %c1 iter_args(%arg2 = %arg1) -> (tensor<3x3x3xf32>) {
+    %middle = scf.for %j = %c0 to %c3 step %c1 iter_args(%arg3 = %arg2) -> (tensor<3x3x3xf32>) {
+      %inner = scf.for %k = %c0 to %c3 step %c1 iter_args(%arg4 = %arg3) -> (tensor<3x3x3xf32>) {
+        %source = tensor.extract_slice %arg0[%i, %j, %k][1, 1, 1][1, 1, 1] : tensor<3x3x3xf32> to tensor<f32>
+        %dest = tensor.insert_slice %source into %arg4[%i, %j, %k][1, 1, 1][1, 1, 1] : tensor<f32> into tensor<3x3x3xf32>
+        scf.yield %dest : tensor<3x3x3xf32>
+      }
+      scf.yield %inner : tensor<3x3x3xf32>
+    }
+    scf.yield %middle : tensor<3x3x3xf32>
+  } {parallel = "root"}
+  return %outer : tensor<3x3x3xf32>
+}
+
+// CHECK-LABEL: expect_to_convert_2d
+func.func @expect_to_convert_2d(%arg0: tensor<3x3xf32>, 
+                                            %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.forall
+  %outer = scf.for %i = %c0 to %c3 step %c1 iter_args(%arg2 = %arg1) -> (tensor<3x3xf32>) {
+    %inner = scf.for %j = %c0 to %c3 step %c1 iter_args(%arg3 = %arg2) -> (tensor<3x3xf32>) {
+      %source = tensor.extract_slice %arg0[%i, %j][1, 1][1, 1] : tensor<3x3xf32> to tensor<f32>
+      %dest = tensor.insert_slice %source into %arg3[%i, %j][1, 1][1, 1] : tensor<f32> into tensor<3x3xf32>
+      scf.yield %dest : tensor<3x3xf32>
+    }
+    scf.yield %inner : tensor<3x3xf32>
+  } {parallel = "root"}
+  return %outer : tensor<3x3xf32>
+}
+
+// CHECK-LABEL: expect_to_convert_1d
+func.func @expect_to_convert_1d(%arg0: tensor<3xf32>, 
+                                   %arg1: tensor<3xf32>) -> tensor<3xf32> {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  // CHECK: scf.forall
+  %outer = scf.for %i = %c0 to %c3 step %c1 iter_args(%arg2 = %arg1) -> (tensor<3xf32>) {
+    %source = tensor.extract_slice %arg0[%i][1][1] : tensor<3xf32> to tensor<f32>
+    %dest = tensor.insert_slice %source into %arg2[%i][1][1] : tensor<f32> into tensor<3xf32>
+    scf.yield %dest : tensor<3xf32>
+  } {parallel = "root"}
+  return %outer : tensor<3xf32>
+}
+
+// CHECK-LABEL: no_top_level
+func.func @no_top_level(%arg0: tensor<3x3xf32>, 
+                        %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  %c1 = arith.constant 1 : index
+  // CHECK-NOT: scf.forall
+  %outer = scf.for %i = %c0 to %c3 step %c1 iter_args(%arg2 = %arg1) -> (tensor<3x3xf32>) {
+    %inner = scf.for %j = %c0 to %c3 step %c1 iter_args(%arg3 = %arg2) -> (tensor<3x3xf32>) {
+      %source = tensor.extract_slice %arg0[%i, %j][1, 1][1, 1] : tensor<3x3xf32> to tensor<f32>
+      %dest = tensor.insert_slice %source into %arg3[%i, %j][1, 1][1, 1] : tensor<f32> into tensor<3x3xf32>
+      scf.yield %dest : tensor<3x3xf32>
+    } {parallel = "root"}
+    scf.yield %inner : tensor<3x3xf32>
+  }
+  return %outer : tensor<3x3xf32>
+}

--- a/test/Passes/tile-and-fuse-depth.mlir
+++ b/test/Passes/tile-and-fuse-depth.mlir
@@ -1,7 +1,7 @@
-// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=0" | FileCheck -check-prefix=DEPTH0 %s
-// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=1" | FileCheck -check-prefix=DEPTH1 %s
-// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=2" | FileCheck -check-prefix=DEPTH2 %s
-// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=3" | FileCheck -check-prefix=DEPTH3 %s
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=0 use-for-all=false" | FileCheck -check-prefix=DEPTH0 %s
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=1 use-for-all=false" | FileCheck -check-prefix=DEPTH1 %s
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=2 use-for-all=false" | FileCheck -check-prefix=DEPTH2 %s
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="tile-sizes=1,0 max-depth=3 use-for-all=false" | FileCheck -check-prefix=DEPTH3 %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/test/Passes/tile-and-fuse-wrong-tiles.mlir
+++ b/test/Passes/tile-and-fuse-wrong-tiles.mlir
@@ -1,7 +1,7 @@
-// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=5,5" -cse | FileCheck %s
-// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=0,0" -cse | FileCheck %s
-// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=5,5,5" -cse | FileCheck %s
-// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=1,0" -cse | FileCheck -check-prefix=TILE %s
+// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=5,5 use-for-all=false" -cse | FileCheck %s
+// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=0,0 use-for-all=false" -cse | FileCheck %s
+// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=5,5,5 use-for-all=false" -cse | FileCheck %s
+// RUN: tpp-opt %s -split-input-file -tile-consumer-and-fuse-producers="tile-sizes=1,0 use-for-all=false" -cse | FileCheck -check-prefix=TILE %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 

--- a/tools/tpp-opt/tpp-opt.cpp
+++ b/tools/tpp-opt/tpp-opt.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv) {
   mlir::perf::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tpp::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tpp::registerTestStructuralMatchers();
+  mlir::tpp::registerTestForToForAllRewrite();
 
   // Add the following to include *all* MLIR Core dialects, or selectively
   // include what you need like above. You only need to register dialects that


### PR DESCRIPTION
At tensor level `linalg::GenerateLoopNest` emits only scf.for loop even if the loops have parallel semantics. This changes enable to rewrite parallel scf.for to scf.forall in the same way we did for the tile and fuse pass. The PRs mainly move code around to make this possible exposing `populateScfForToForAllRewritePattern` as utils in `TransformUtils.h`. Simplify logic by retiring the tail mark attribute.