### PR TITLE
Improve pack/unpack generalization

### DIFF
--- a/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
+++ b/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
@@ -11,12 +11,16 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "decompose-pack-unpack-ops"
 
 using namespace mlir;
 
@@ -25,45 +29,200 @@ using namespace mlir;
 
 namespace {
 
+// A warpper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
+// a tensor.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
+struct LowerPackPattern : public OpRewritePattern<tensor::PackOp> {
+  using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PackOp op,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<linalg::LowerPackResult> res = linalg::lowerPack(rewriter, op);
+    if (failed(res)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot lower to pad + expand + transpose");
+    }
+    return success();
+  }
+};
+
+// TODO: (lorenzo) upstream does not respect DPS-style for unpackOp. DPS is
+// preserved by emitting a linalg.copy that takes as input the collapse output
+// (non-DPS op) and move it to the unpack destination. Discuss with upstream
+// how to proceed here.
+LogicalResult lowerUnPack(RewriterBase &rewriter, tensor::UnPackOp unPackOp) {
+
+  // 1. Filter out NYI cases.
+  if (!unPackOp.getOuterDimsPerm().empty())
+    return rewriter.notifyMatchFailure(unPackOp, "outer dims perm NYI");
+
+  RankedTensorType packedTensorType = unPackOp.getSourceType();
+  if (!packedTensorType.hasStaticShape()) {
+    return rewriter.notifyMatchFailure(
+        unPackOp,
+        "non-static shape NYI, needs a more powerful tensor.expand_shape op");
+  }
+
+  Location loc = unPackOp->getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(unPackOp);
+
+  int64_t packedRank = packedTensorType.getRank();
+
+  OpFoldResult zero = rewriter.getIndexAttr(0), one = rewriter.getIndexAttr(1);
+  auto destTensorType = unPackOp.getDest().getType().cast<RankedTensorType>();
+  if (unPackOp.isLikeUnPad()) {
+    // This unpack is just a plain unpad.
+    // Just extract the slice from the higher ranked tensor.
+    ArrayRef<int64_t> destShape = destTensorType.getShape();
+    // The inner dimensions stay the same as the destination tensor, but the
+    // outer ones are additional 1s.
+    SmallVector<OpFoldResult> sizes(packedRank - destShape.size(), one);
+    sizes.append(linalg::getMixedDimensions(rewriter, loc, unPackOp.getDest()));
+
+    auto extractSliceOp = rewriter.create<tensor::ExtractSliceOp>(
+        loc, destTensorType, unPackOp.getSource(),
+        SmallVector<OpFoldResult>(packedRank, zero), sizes,
+        SmallVector<OpFoldResult>(packedRank, one));
+
+    rewriter.replaceOp(unPackOp, extractSliceOp->getResults());
+    return success();
+  }
+  // 2. Compute the permutation vector to move the last `numPackedDims` into
+  // the `innerPosDims` of a shape of rank `packedRank`.
+  int64_t numPackedDims = unPackOp.getInnerDimsPos().size();
+  auto lastDims = llvm::to_vector(
+      llvm::seq<int64_t>(packedRank - numPackedDims, packedRank));
+  PackingMetadata packingMetadata =
+      computePackingMetadata(packedRank, unPackOp.getInnerDimsPos());
+  SmallVector<int64_t> lastDimsToInsertPositionsPerm = computePermutationVector(
+      packedRank, lastDims, packingMetadata.insertPositions);
+
+  // 3. Compute the stripMinedShape: this is the packed shape without outer and
+  // inner permutations.
+  SmallVector<int64_t> stripMinedShape(packedTensorType.getShape());
+  applyPermutationToVector(stripMinedShape, lastDimsToInsertPositionsPerm);
+
+  // 4. Transpose packedShape to stripMinedShape.
+  RankedTensorType stripMinedTensorType =
+      RankedTensorType::Builder(packedTensorType).setShape(stripMinedShape);
+  RankedTensorType collapsedType = tensor::CollapseShapeOp::inferCollapsedType(
+      stripMinedTensorType, packingMetadata.reassociations);
+  auto emptyOp =
+      rewriter.create<tensor::EmptyOp>(loc, stripMinedTensorType, ValueRange{});
+  auto transposeOp = rewriter.create<linalg::TransposeOp>(
+      loc, unPackOp.getSource(), emptyOp, lastDimsToInsertPositionsPerm);
+
+  // 5. Collapse from the stripMinedShape to the padded result.
+  auto reshapeOp = rewriter.create<tensor::CollapseShapeOp>(
+      loc, collapsedType, transposeOp->getResult(0),
+      packingMetadata.reassociations);
+
+  // 6. ExtractSlice
+  int64_t destRank = destTensorType.getRank();
+  auto extractSliceOp = rewriter.create<tensor::ExtractSliceOp>(
+      loc, destTensorType, reshapeOp->getResult(0),
+      SmallVector<OpFoldResult>(destRank, zero),
+      tensor::getMixedSizes(rewriter, loc, unPackOp->getResult(0)),
+      SmallVector<OpFoldResult>(destRank, one));
+
+  // 7. copy to preserve DPS.
+  auto copyOp = rewriter.create<linalg::CopyOp>(
+      loc, extractSliceOp->getResult(0), unPackOp.getDest());
+
+  // 8. Replace unPackOp by copOp.
+  rewriter.replaceOp(unPackOp, copyOp->getResults());
+  return success();
+}
+
+// A warpper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
+// lowers a tensor.unpack op to tensor.empty + linalg.transpose +
+// tensor.collapse_shape + tensor.extract_slice ops.
+struct LowerUnPackPattern : public OpRewritePattern<tensor::UnPackOp> {
+  using OpRewritePattern<tensor::UnPackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::UnPackOp op,
+                                PatternRewriter &rewriter) const override {
+    if (failed(lowerUnPack(rewriter, op))) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot lower to empty + transpose + reshape + extract_slice");
+    }
+    return success();
+  }
+};
+
 struct GeneralizeTensorPackAndUnPack
     : public GeneralizeTensorPackAndUnPackBase<GeneralizeTensorPackAndUnPack> {
   GeneralizeTensorPackAndUnPack() = default;
-
   void runOnOperation() override {
-    func::FuncOp func = getOperation();
 
-    IRRewriter rewriter(&getContext());
-    func->walk([&](tensor::UnPackOp unPackOp) {
-      scf::SCFTilingOptions unpackTilingOptions;
-      SmallVector<int64_t> tiles(unPackOp.getDestType().getRank(), 1);
-      unpackTilingOptions.setTileSizes(tiles);
-      FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
-          rewriter, cast<TilingInterface>(unPackOp.getOperation()),
-          unpackTilingOptions);
-      if (failed(tilingResult))
+    MLIRContext *ctx = &getContext();
+    auto funcOp = getOperation();
+
+    // Upstream generalization patterns. Decomposition of tensor.unpack
+    // does not support yet outer dim perm.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<LowerPackPattern, LowerUnPackPattern>(ctx);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        funcOp.emitError(
+            "failed to apply generalization patterns on pack/unpack ops for "
+            "general cases.");
         return signalPassFailure();
-      rewriter.replaceOp(unPackOp, tilingResult->replacements);
-    });
-    func->walk([&](tensor::PackOp packOp) {
-      SmallVector<int64_t> tiles(packOp.getSourceType().getRank(), 1);
-      scf::SCFTilingOptions packTilingOptions;
-      packTilingOptions.setTileSizes(tiles);
-      FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
-          rewriter, cast<TilingInterface>(packOp.getOperation()),
-          packTilingOptions);
-      if (failed(tilingResult))
-        return signalPassFailure();
-      rewriter.replaceOp(packOp, tilingResult->replacements);
-    });
-    RewritePatternSet patterns(&getContext());
-    patterns.add<linalg::GeneralizeOuterUnitDimsUnPackOpPattern,
-                 linalg::GeneralizeOuterUnitDimsPackOpPattern>(&getContext());
-    tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
-      return signalPassFailure();
+      }
     }
-    return;
+
+    // Fall back on tile by one + generalization patterns.
+    {
+      IRRewriter rewriter(&getContext());
+      funcOp->walk([&](tensor::UnPackOp unPackOp) {
+        scf::SCFTilingOptions unpackTilingOptions;
+        SmallVector<int64_t> tiles(unPackOp.getDestType().getRank(), 1);
+        unpackTilingOptions.setTileSizes(tiles);
+        FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
+            rewriter, cast<TilingInterface>(unPackOp.getOperation()),
+            unpackTilingOptions);
+        if (failed(tilingResult))
+          return signalPassFailure();
+        rewriter.replaceOp(unPackOp, tilingResult->replacements);
+      });
+      funcOp->walk([&](tensor::PackOp packOp) {
+        SmallVector<int64_t> tiles(packOp.getSourceType().getRank(), 1);
+        scf::SCFTilingOptions packTilingOptions;
+        packTilingOptions.setTileSizes(tiles);
+        FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
+            rewriter, cast<TilingInterface>(packOp.getOperation()),
+            packTilingOptions);
+        if (failed(tilingResult))
+          return signalPassFailure();
+        rewriter.replaceOp(packOp, tilingResult->replacements);
+      });
+      RewritePatternSet patterns(&getContext());
+      patterns.add<linalg::GeneralizeOuterUnitDimsUnPackOpPattern,
+                   linalg::GeneralizeOuterUnitDimsPackOpPattern>(&getContext());
+      tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                              std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Canonicalize tiled ops.
+    {
+      RewritePatternSet patterns(ctx);
+      linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
+      memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
+      ctx->getOrLoadDialect<tensor::TensorDialect>()
+          ->getCanonicalizationPatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After canonicalizing tiled ops ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
   }
 };
 

--- a/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
+++ b/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
@@ -29,7 +29,7 @@ using namespace mlir;
 
 namespace {
 
-// A warpper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
+// A wrapper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
 // a tensor.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
 struct LowerPackPattern : public OpRewritePattern<tensor::PackOp> {
   using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
@@ -134,7 +134,7 @@ LogicalResult lowerUnPack(RewriterBase &rewriter, tensor::UnPackOp unPackOp) {
   return success();
 }
 
-// A warpper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
+// A wrapper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
 // lowers a tensor.unpack op to tensor.empty + linalg.transpose +
 // tensor.collapse_shape + tensor.extract_slice ops.
 struct LowerUnPackPattern : public OpRewritePattern<tensor::UnPackOp> {

--- a/test/Passes/pass-generalize-pack-and-unpack.mlir
+++ b/test/Passes/pass-generalize-pack-and-unpack.mlir
@@ -7,25 +7,13 @@ func.func @pack_matmul_operand_b(%in: tensor<512x1024xf32>) -> tensor<32x16x32x3
   return %1 : tensor<32x16x32x32xf32>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
 // CHECK-LABEL: pack_matmul_operand_b
 // CHECK-SAME: %[[ARG0:.+]]: tensor<512x1024xf32>
-// CHECK: %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK: %[[PACKED:.+]] = tensor.empty() : tensor<32x16x32x32xf32>
-// CHECK: %[[LOOP:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[PACKED]])
-// CHECK-NEXT: %[[LOOP1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[ARG2]])
-// CHECK: %[[APPLY:.+]] = affine.apply #[[MAP]](%[[J]])
-// CHECK: %[[APPLY1:.+]] = affine.apply #[[MAP]](%[[I]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice 
-// CHECK-SAME:  %[[ARG0]][%[[APPLY]], %[[APPLY1]]] [32, 32] [1, 1] : tensor<512x1024xf32> to tensor<32x32xf32
-// CHECK: %[[BUFF:.+]] = tensor.empty() : tensor<32x32xf32>
-// CHECK: %[[TRANS:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<32x32xf32>) 
-// CHECK-SAME:  outs(%[[BUFF]] : tensor<32x32xf32>) permutation = [0, 1]
-// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] 
-// CHECK-SAME:  into %[[ARG4]][%[[I]], %[[J]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<32x16x32x32xf32>
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<32x16x32x32xf32>
+// CHECK: %[[EXP:.+]] = tensor.expand_shape %arg0 {{\[}}[0, 1], [2, 3]] : tensor<512x1024xf32> 
+// CHECK-SAME:  into tensor<16x32x32x32xf32>
+// CHECK: %[[T:.+]] = linalg.transpose ins(%expanded : tensor<16x32x32x32xf32>) outs(%[[EMPTY]] : tensor<32x16x32x32xf32>) 
+// CHECK-SAME:  permutation = [2, 0, 1, 3]
 
 // -----
 
@@ -36,27 +24,13 @@ func.func @pack_matmul_operand_a(%in: tensor<256x512xf32>) -> tensor<8x16x32x32x
   return %1 : tensor<8x16x32x32xf32>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
 // CHECK-LABEL: pack_matmul_operand_a
 // CHECK-SAME: %[[ARG0:.+]]: tensor<256x512xf32>
-// CHECK: %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK: %[[PACKED:.+]] = tensor.empty() : tensor<8x16x32x32xf32>
-// CHECK: %{{.+}} = scf.for %[[I:.+]] = %[[C0]] to %[[C8]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[PACKED]])
-// CHECK-NEXT: %{{.+}} = scf.for %[[J:.+]] = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[ARG2]])
-// CHECK: %[[APPLY:.+]] = affine.apply #[[MAP]](%[[I]])
-// CHECK: %[[APPLY1:.+]] = affine.apply #[[MAP]](%[[J]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice 
-// CHECK-SAME:  %[[ARG0]][%[[APPLY]], %[[APPLY1]]] [32, 32] [1, 1] : tensor<256x512xf32> to tensor<32x32xf32
-// CHECK: %[[BUFF:.+]] = tensor.empty() : tensor<32x32xf32>
-// CHECK: %[[TRANS:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<32x32xf32>) 
-// CHECK-SAME:  outs(%[[BUFF]] : tensor<32x32xf32>) permutation = [0, 1]
-// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] 
-// CHECK-SAME:  into %[[ARG4]][%[[I]], %[[J]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<8x16x32x32xf32>
-
-
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<8x16x32x32xf32>
+// CHECK: %[[EXP:.+]] = tensor.expand_shape %arg0 {{\[}}[0, 1], [2, 3]] : tensor<256x512xf32> 
+// CHECK-SAME:  into tensor<8x32x16x32xf32> 
+// CHECK: %[[T:.+]] = linalg.transpose ins(%[[EXP]] : tensor<8x32x16x32xf32>) outs(%[[EMPTY]] : tensor<8x16x32x32xf32>) 
+// CHECK-SAME:  permutation = [0, 2, 1, 3]
 
 // -----
 
@@ -68,19 +42,8 @@ func.func @unpack_matmul(%in: tensor<8x32x32x32xf32>) -> tensor<256x1024xf32> {
 }
 
 // CHECK-LABEL: unpack_matmul
-// CHECK-SAME:  %[[ARG0:.+]]: tensor<8x32x32x32xf32>
-// CHECK: %[[C32:.+]] = arith.constant 32 : index
-// CHECK-DAG: %[[C1024:.+]] = arith.constant 1024 : index
-// CHECK-DAG: %[[C256:.+]] = arith.constant 256 : index
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK: %[[UNPACKED:.+]] = tensor.empty() : tensor<256x1024xf32>
-// CHECK: %{{.+}} = scf.for %[[I:.+]] = %[[C0]] to %[[C256]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[UNPACKED]])
-// CHECK-NEXT: %{{.+}} = scf.for %[[J:.+]] = %[[C0]] to %[[C1024]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[ARG2]])
-// CHECK: %[[APPLY:.+]] = affine.apply #map1(%arg1)
-// CHECK: %[[APPLY1:.+]] = affine.apply #map1(%arg3)
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice 
-// CHECK-SAME:  %[[ARG0]][%[[APPLY]], %[[APPLY1]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<8x32x32x32xf32> to tensor<32x32xf32>
-// CHECK: %[[BUFF:.+]] = tensor.empty() : tensor<32x32xf32>
-// CHECK: %[[TRANS:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<32x32xf32>) outs(%[[BUFF]] : tensor<32x32xf32>) permutation = [0, 1]
-// CHECK: %[[INSERT:.+]] = tensor.insert_slice %{{.+}} into %[[ARG4]][%[[I]], %[[J]]] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<256x1024xf32>
+// CHECK-SAME: %[[ARG0:.+]]: tensor<8x32x32x32xf32>
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<8x32x32x32xf32>
+// CHECK: %[[T:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<8x32x32x32xf32>) outs(%[[EMPTY]] : tensor<8x32x32x32xf32>) 
+// CHECK-SAME:  permutation = [0, 2, 1, 3]
+// CHECK: %[[CLP:.+]] = tensor.collapse_shape %[[T]] {{\[}}[0, 1], [2, 3]] : tensor<8x32x32x32xf32> into tensor<256x1024xf32>

--- a/test/Passes/pass-generalize-pack-and-unpack.mlir
+++ b/test/Passes/pass-generalize-pack-and-unpack.mlir
@@ -34,16 +34,17 @@ func.func @pack_matmul_operand_a(%in: tensor<256x512xf32>) -> tensor<8x16x32x32x
 
 // -----
 
-func.func @unpack_matmul(%in: tensor<8x32x32x32xf32>) -> tensor<256x1024xf32> {
-  %0 = tensor.empty() : tensor<256x1024xf32>
-  %1 = tensor.unpack %in inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %0 
+func.func @unpack_matmul(%in: tensor<8x32x32x32xf32>, %dest: tensor<256x1024xf32>) -> tensor<256x1024xf32> {
+  %1 = tensor.unpack %in inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %dest 
     : tensor<8x32x32x32xf32> -> tensor<256x1024xf32>
   return %1: tensor<256x1024xf32>
 }
 
 // CHECK-LABEL: unpack_matmul
 // CHECK-SAME: %[[ARG0:.+]]: tensor<8x32x32x32xf32>
+// CHECK-SAME: %[[ARG1:.+]]: tensor<256x1024xf32>
 // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<8x32x32x32xf32>
 // CHECK: %[[T:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<8x32x32x32xf32>) outs(%[[EMPTY]] : tensor<8x32x32x32xf32>) 
 // CHECK-SAME:  permutation = [0, 2, 1, 3]
 // CHECK: %[[CLP:.+]] = tensor.collapse_shape %[[T]] {{\[}}[0, 1], [2, 3]] : tensor<8x32x32x32xf32> into tensor<256x1024xf32>
+// CHECK: %{{.+}} = linalg.copy ins(%[[CLP]] : tensor<256x1024xf32>) outs(%[[ARG1]] : tensor<256x1024xf32>) 

--- a/test/Passes/pass-generalize-pack-and-unpack.mlir
+++ b/test/Passes/pass-generalize-pack-and-unpack.mlir
@@ -47,4 +47,30 @@ func.func @unpack_matmul(%in: tensor<8x32x32x32xf32>, %dest: tensor<256x1024xf32
 // CHECK: %[[T:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<8x32x32x32xf32>) outs(%[[EMPTY]] : tensor<8x32x32x32xf32>) 
 // CHECK-SAME:  permutation = [0, 2, 1, 3]
 // CHECK: %[[CLP:.+]] = tensor.collapse_shape %[[T]] {{\[}}[0, 1], [2, 3]] : tensor<8x32x32x32xf32> into tensor<256x1024xf32>
-// CHECK: %{{.+}} = linalg.copy ins(%[[CLP]] : tensor<256x1024xf32>) outs(%[[ARG1]] : tensor<256x1024xf32>) 
+// CHECK: %{{.+}} = linalg.copy ins(%[[CLP]] : tensor<256x1024xf32>) outs(%[[ARG1]] : tensor<256x1024xf32>)
+
+// -----
+
+func.func @unpack_conv(%in: tensor<1x4x6x6x2xf32>, %out: tensor<1x6x6x8xf32>) -> tensor<1x6x6x8xf32> {
+  %1 = tensor.unpack %in outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [2] into %out : tensor<1x4x6x6x2xf32> -> tensor<1x6x6x8xf32>
+  return %1: tensor<1x6x6x8xf32>
+}
+
+// CHECK-LABEL: unpack_conv
+// CHECK-SAME: %[[IN:.+]]: tensor<1x4x6x6x2xf32>, %[[OUT:.+]]: tensor<1x6x6x8xf32>
+// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[C6:.+]] = arith.constant 6 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK: %[[OUTER:.+]] = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[OUT]])
+// CHECK-NEXT: %[[MIDDLE:.+]] = scf.for %[[ARG4:.+]] = %[[C0]] to %[[C6]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG3]])
+// CHECK-NEXT: %[[INNER:.+]] = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C8]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[ARG5]])
+// CHECK: %[[APPLY:.+]] = affine.apply #map(%[[ARG6]])
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1x1x1x2xf32>
+// CHECK: %[[APPLY_1:.+]] = affine.apply #map1(%[[ARG6]])
+// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[IN]][0, %[[APPLY_1]], %[[ARG2]], %[[ARG4]], 0] [1, 1, 1, 1, 2] [1, 1, 1, 1, 1] : tensor<1x4x6x6x2xf32> to tensor<2xf32>
+// CHECK: %[[EMPTY1:.+]] = tensor.empty() : tensor<2xf32>
+// CHECK: %[[T:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<2xf32>) outs(%[[EMPTY1]] : tensor<2xf32>) permutation = [0]
+// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[T]] into %[[EMPTY]][0, 0, 0, 0] [1, 1, 1, 2] [1, 1, 1, 1] : tensor<2xf32> into tensor<1x1x1x2xf32>
+// CHECK: %[[SLICE_1:.+]] = tensor.extract_slice %[[INSERT]][0, 0, 0, %[[APPLY]]] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x2xf32> to tensor<1x1x1x1xf32>
+// CHECK: %[[SLICE_DEST:.+]] tensor.insert_slice %{{.+}} into %[[ARG7]][0, %[[ARG2]], %[[ARG4]], %[[ARG6]]] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x1x1x1xf32> into tensor<1x6x6x8xf32>


### PR DESCRIPTION
Update pack and unpack generalization to use upstream decomposition. Since upstream decomposition does not cover all the cases (i.e., fails if the unpack has outer dims), keep the current generalization as a fallback. In addition, upstream decomposition does not respect DPS-style for unpack, thus move part of the decomposition in tree. The code `lowerUnPack` will get removed once we upstream the fix.