### PR TITLE
Improve `packVNNIMatmulOp`

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -111,9 +111,11 @@ def TransformDropSchedulePass : Pass<"transform-drop-schedule", "ModuleOp"> {
 def PackVNNI : Pass<"pack-vnni", "func::FuncOp"> {
   let summary = "Convert matmul/brgemm to vnni layout";
   let description = [{
-    VNNI Matmul as: C[M][N]= A[M][K] * B[K/b][N][b]
-    VNNI BRGemm as: C[M][N]= A[R][M][K] * B[R][K/b][N][b]
-    b is the VNNI factor.
+    Relayout following matmuls and brgemm as following:
+    - VNNI Matmul as: C[M][N]= A[M][K] * B[K/VNNI][N][VNNI]
+    - VNNI Blocked Matmul as:
+      [IB][JB][ib][jb] += [IB][KB][ib][kb] * [JB][KB][kb/VNNI][jb][VNNI]
+    - VNNI BRGemm as: C[M][N]= A[R][M][K] * B[R][K/VNNI][N][VNNI]
   }];
   let options = [
     ListOption<"blockingFactors", "block-factors", "int64_t", 

--- a/include/TPP/TransformUtils.h
+++ b/include/TPP/TransformUtils.h
@@ -74,6 +74,10 @@ bool validateFullTilesOnDims(TilingInterface tileOp,
 bool isMatmulOp(Operation *op,
                 SmallVectorImpl<Value> *capturedOperands = nullptr);
 
+// Return true if the `op` is a linalg.batch_reduce_matmul.
+bool isBrgemmOp(Operation *op,
+                SmallVectorImpl<Value> *capturedOperands = nullptr);
+
 // Returns true if the linalg operation has a MulAdd region.
 bool hasMulAddBody(linalg::LinalgOp linalgOp,
                    SmallVectorImpl<Value> *capturedOperands = nullptr);

--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -412,7 +412,8 @@ mlir::linalgx::packMatmulOp(RewriterBase &rewriter, linalg::MatmulOp matmulOp,
 //===----------------------------------------------------------------------===//
 // MatmulOp (VNNI packing)
 //===----------------------------------------------------------------------===//
-// Original layout: [IB][JB][ib][jb] += [IB][KB][ib][kb] * [JB][KB][kb][jb]
+// Original layout:
+//      [IB][JB][ib][jb] += [IB][KB][ib][kb] * [JB][KB][kb][jb]
 // New      layout:
 //      [IB][JB][ib][jb] += [IB][KB][ib][kb] * [JB][KB][kb/VNNI][jb][VNNI]
 FailureOr<linalg::GenericOp>

--- a/test/BF16/brgemm-vnni.mlir
+++ b/test/BF16/brgemm-vnni.mlir
@@ -1,8 +1,8 @@
 // RUN: tpp-opt -pack-vnni %s | FileCheck %s
 
 func.func @matmul(%arg0: tensor<32x4x4xbf16>, %arg1: tensor<32x4x4xbf16>, %arg2: tensor<4x4xbf16>) -> tensor<4x4xbf16>{
-  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1:tensor<32x4x4xbf16>, tensor<32x4x4xbf16>) 
-                                  outs(%arg2:tensor<4x4xbf16>) -> tensor<4x4xbf16>
+  %0 = linalg.batch_reduce_matmul ins(%arg0, %arg1: tensor<32x4x4xbf16>, tensor<32x4x4xbf16>) 
+                                  outs(%arg2: tensor<4x4xbf16>) -> tensor<4x4xbf16>
   return %0: tensor<4x4xbf16>
 }
 

--- a/test/BF16/matmul-tiled-vnni.mlir
+++ b/test/BF16/matmul-tiled-vnni.mlir
@@ -31,17 +31,11 @@ module {
   }
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
-// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4 floordiv 2, d3, d1)>
-// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
-
 // CHECK: func.func @mlp(
-// CHECK: %[[ARG0:.*]]: tensor<32x64x4x4xbf16>,
-// CHECK: %[[ARG1:.*]]: tensor<128x64x4x4xbf16>,
-// CHECK: %[[ARG2:.*]]: tensor<32x128x4x4xbf16>) -> tensor<32x128x4x4xbf16> {
+// CHECK: %{{.+}}: tensor<32x64x4x4xbf16>,
+// CHECK: %{{.+}}: tensor<128x64x4x4xbf16>,
+// CHECK: %{{.+}}: tensor<32x128x4x4xbf16>) -> tensor<32x128x4x4xbf16> {
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK:  %[[PACKBUF:.*]] = tensor.empty() : tensor<64x2x4x2xbf16> 
-// CHECK:  linalg.generic 
-// CHECK:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK:  iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]
+// CHECK:       %{{.+}} = tensor.pack
+// CHECK-NEXT:  %{{.+}} = tpp.brgemm


### PR DESCRIPTION
`packVNNIMatmulOp` was using hard-coded checks to pack a generic matmul operation. The "if" branch was VNNI-blocking an already blocked matmul, while the "else" branch was a "tiled" version. With a closer look at the "else" branch, it turned out that the generic is a simple brgemm operation, as a tile-blocked matmul is a brgemm. Thus remove the "else" branch and use a de-generalization pattern to get a named op. At this point, `PackVNNIBrgemm` can do the job of the "else" branch.