### PR TITLE
clang-format check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,4 +153,11 @@ if (NOT TPP_INSIDE_IREE)
                     COMMENT Run Benchmarks)
 endif()
 
+# Clang format checks
+set(CI_DIR "${PROJECT_SOURCE_DIR}/scripts/ci")
+add_custom_target(clang-format ${CI_DIR}/clang-format.sh)
+
+# Check-all
+add_custom_target(check-all DEPENDS clang-format check)
+
 message(STATUS "TPP Project CMakeLists.txt END")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ endif()
 # Clang format checks
 set(CI_DIR "${PROJECT_SOURCE_DIR}/scripts/ci")
 add_custom_target(clang-format ${CI_DIR}/clang-format.sh)
+add_custom_target(reformat ${CI_DIR}/clang-format.sh -i)
 
 # Check-all
 add_custom_target(check-all DEPENDS clang-format check)

--- a/include/TPP/Dialect/Xsmm/XsmmOps.h
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.h
@@ -10,11 +10,11 @@
 #define TPP_DIALECT_XSMM_XSMMOPS_H
 
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Dialect/Xsmm/XsmmEnum.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
-#include "TPP/Dialect/Xsmm/XsmmEnum.h"
 
 #define GET_OP_CLASSES
 #include "TPP/Dialect/Xsmm/XsmmOps.h.inc"

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -281,9 +281,9 @@ private:
 };
 
 // Implemenation to allow definition in cpp file
-using TypeCheckFunc = std::function<bool(Operation*)>;
+using TypeCheckFunc = std::function<bool(Operation *)>;
 bool withOpChainImpl(Region *region, Operation *op, SmallVectorImpl<Value> *,
-                     SmallVectorImpl<TypeCheckFunc>&);
+                     SmallVectorImpl<TypeCheckFunc> &);
 
 // Callable object to check the region for a chain of operations.
 template <typename... OpTy> struct WithOpChain {

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -78,8 +78,8 @@ struct ConvertGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
       rewriter.setInsertionPointAfter(linalgOp);
       auto add = rewriter.create<tpp::AddOp>(
           linalgOp.getLoc(), ValueRange{operands[0], operands[1]}, operands[2]);
-      rewriter.replaceOpWithNewOp<tpp::ReluOp>(
-          linalgOp, add.getResult(0), operands[2]);
+      rewriter.replaceOpWithNewOp<tpp::ReluOp>(linalgOp, add.getResult(0),
+                                               operands[2]);
       return success();
     }
 

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -101,13 +101,15 @@ void BenchOp::print(OpAsmPrinter &printer) {
 
   {
     bool printTerminator = true;
-    if (auto *term = getRegion().empty() ? nullptr : getRegion().begin()->getTerminator()) {
+    if (auto *term = getRegion().empty()
+                         ? nullptr
+                         : getRegion().begin()->getTerminator()) {
       printTerminator = !term->getAttrDictionary().empty() ||
                         term->getNumOperands() != 0 ||
                         term->getNumResults() != 0;
     }
     printer.printRegion(getRegion(), /*printEntryBlockArgs=*/true,
-      /*printBlockTerminators=*/printTerminator);
+                        /*printBlockTerminators=*/printTerminator);
   }
   ::llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
   printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);

--- a/lib/TPP/Dialect/Tpp/TppOps.cpp
+++ b/lib/TPP/Dialect/Tpp/TppOps.cpp
@@ -420,7 +420,7 @@ LogicalResult FusedBrgemmOp::verify() {
     return failure();
   Type biasType = getBiasOperand().getType();
   int64_t rank = biasType.cast<ShapedType>().getRank();
-  if (rank != 1 && rank != 2) 
+  if (rank != 1 && rank != 2)
     return emitOpError() << "expected shaped type with rank 1 or 2 for bias";
   return success();
 }

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -166,9 +166,8 @@ static bool isTppUnaryOp(linalg::GenericOp linalgOp) {
 // Return true if the linalg.generic can be mapped to a tpp.add.
 bool isTppAdd(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
-  auto addMatcher =
-      StructuredOpMatcher::make<linalg::GenericOp>()
-          .region(MatchOne(0), WithSingleOp<arith::AddFOp>(operands));
+  auto addMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
+      MatchOne(0), WithSingleOp<arith::AddFOp>(operands));
   return isTppBinaryOp(linalgOp) && addMatcher.match(linalgOp);
 }
 
@@ -235,8 +234,8 @@ private:
 // Return true if the linalg.generic can be mapped to a tpp.relu.
 bool isTppRelu(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
-  auto reluMatcher = StructuredOpMatcher::make<linalg::GenericOp>()
-                         .region(MatchOne(0), WithReluBody(operands));
+  auto reluMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
+      MatchOne(0), WithReluBody(operands));
   return isTppUnaryOp(linalgOp) && reluMatcher.match(linalgOp);
 }
 
@@ -245,9 +244,8 @@ bool isTppIdentity(linalg::GenericOp linalgOp,
                    SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
   SmallVector<Value, 2> linalgOperands;
-  auto identityMatcher =
-      StructuredOpMatcher::make<linalg::GenericOp>()
-          .region(MatchOne(0), WithSingleOp<linalg::YieldOp>(&linalgOperands));
+  auto identityMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
+      MatchOne(0), WithSingleOp<linalg::YieldOp>(&linalgOperands));
 
   if (!isTppUnaryOp(linalgOp) || !identityMatcher.match(linalgOp))
     return false;
@@ -262,8 +260,8 @@ bool isTppIdentity(linalg::GenericOp linalgOp,
 // Return true if the linalg.generic can be mapped to a tpp.zero.
 bool isTppZero(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
-  auto zeroMatcher = StructuredOpMatcher::make<linalg::GenericOp>()
-                         .region(MatchOne(0), WithSingleOp<linalg::YieldOp>());
+  auto zeroMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
+      MatchOne(0), WithSingleOp<linalg::YieldOp>());
 
   if (!isTppUnaryOp(linalgOp) || !zeroMatcher.match(linalgOp))
     return false;
@@ -319,7 +317,8 @@ LogicalResult splitAndReplaceFusedOp(tpp::FusedBrgemmOp fusedBrgemmOp,
 // Return true if the linalg.generic can be mapped to a tpp.add + tpp.max.
 // FIXME: This is necessary because IREE fuses addf + maxf and we don't match
 // TODO: This will be done at tpp.group level later on
-bool isTppBiasRelu(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
+bool isTppBiasRelu(linalg::GenericOp linalgOp,
+                   SmallVectorImpl<Value> *operands) {
   using namespace tpp::structured_match;
   auto biasReluMatcher = StructuredOpMatcher::make<linalg::GenericOp>().region(
       MatchOne(0), WithOpChain<arith::AddFOp, arith::MaxFOp>(operands));
@@ -335,7 +334,6 @@ bool isTppBiasRelu(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands)
   operands->push_back(output);
   return true;
 }
-
 
 } // namespace utils
 } // namespace tpp

--- a/lib/TPP/Dialect/Transform/IteratorCollapsing.cpp
+++ b/lib/TPP/Dialect/Transform/IteratorCollapsing.cpp
@@ -23,8 +23,9 @@ using namespace mlir;
 
 #define DEBUG_TYPE "iterator-collapsing"
 
-// TODO: Can we drop this pass: https://github.com/llvm/llvm-project/commit/83c65fbc2842909444bfe0a74ed083d164381078 ?
-// Most of these has been adapted by "DropUnitDims.cpp".
+// TODO: Can we drop this pass:
+// https://github.com/llvm/llvm-project/commit/83c65fbc2842909444bfe0a74ed083d164381078
+// ? Most of these has been adapted by "DropUnitDims.cpp".
 
 // Return true if the result at position 'pos' in 'map' is a constant 0. False
 // otherwise.
@@ -430,8 +431,7 @@ mlir::linalgx::collapseIterators(RewriterBase &rewriter,
   if (failed(reshapedOperands))
     return failure();
 
-  assert(reshapedOperands->size() ==
-         genericOp->getNumOperands());
+  assert(reshapedOperands->size() == genericOp->getNumOperands());
 
   FailureOr<linalg::GenericOp> replacement =
       buildReplacement(rewriter, genericOp, *reshapedOperands, newIndexingMaps,

--- a/lib/TPP/RewriteConvsToMatmulOrBrgemm.cpp
+++ b/lib/TPP/RewriteConvsToMatmulOrBrgemm.cpp
@@ -14,8 +14,8 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace mlir;
 

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -343,8 +343,8 @@ static llvm::SmallDenseSet<Operation *> collectFusableProducers(
         LLVM_DEBUG(llvm::dbgs()
                    << "WORKLIST INSERT PRODUCER: " << producer << "\n");
         LLVM_DEBUG(llvm::dbgs() << "=============================\n";
-            llvm::dbgs() << *producer << "\n";
-            llvm::dbgs() << "=============================\n";);
+                   llvm::dbgs() << *producer << "\n";
+                   llvm::dbgs() << "=============================\n";);
         nextProcessingQueue.push(producer);
         incDepthAndSwap(processingQueue, nextProcessingQueue, depth);
         worklist.insert(producer);

--- a/runtime/XsmmRunnerUtils.cpp
+++ b/runtime/XsmmRunnerUtils.cpp
@@ -27,33 +27,33 @@ static void printXsmmStruct(const libxsmm_gemm_batch_reduce_config &brgemmShape,
 
 static bool hasImplicitComputeDtypeUnary(const libxsmm_meltw_unary_type dtype) {
   switch (dtype) {
-    // Zero
-    case LIBXSMM_MELTW_TYPE_UNARY_XOR:
-    // Copy
-    case LIBXSMM_MELTW_TYPE_UNARY_IDENTITY:
-    // Transpose
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_NORMT:
-    // VNNI2
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI2:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI2_TO_VNNI2T:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI2T:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI2_PAD:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADM_MOD2:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADN_MOD2:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADNM_MOD2:
-    // VNNI4
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI4:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_VNNI4T:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI4T:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI4_PAD:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADM_MOD4:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADN_MOD4:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADNM_MOD4:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_NORM:
-    case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_VNNI2:
-      return true;
-    default:
-      return false;
+  // Zero
+  case LIBXSMM_MELTW_TYPE_UNARY_XOR:
+  // Copy
+  case LIBXSMM_MELTW_TYPE_UNARY_IDENTITY:
+  // Transpose
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_NORMT:
+  // VNNI2
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI2:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI2_TO_VNNI2T:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI2T:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI2_PAD:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADM_MOD2:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADN_MOD2:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADNM_MOD2:
+  // VNNI4
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI4:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_VNNI4T:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI4T:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_NORM_TO_VNNI4_PAD:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADM_MOD4:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADN_MOD4:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_PADNM_MOD4:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_NORM:
+  case LIBXSMM_MELTW_TYPE_UNARY_TRANSFORM_VNNI4_TO_VNNI2:
+    return true;
+  default:
+    return false;
   }
 }
 
@@ -168,8 +168,8 @@ xsmm_unary_dispatch(const libxsmm_meltw_unary_type op_type,
   unary_shape.in0_type = dtype;
   // Retarget computation type from bf16 to f32 due to missing hardware support.
   // Copy and Zero should remain in BF16 to avoid useless up/down casts
-  auto force_fp32 =
-      (dtype == LIBXSMM_DATATYPE_BF16 && !hasImplicitComputeDtypeUnary(op_type));
+  auto force_fp32 = (dtype == LIBXSMM_DATATYPE_BF16 &&
+                     !hasImplicitComputeDtypeUnary(op_type));
   unary_shape.comp_type = force_fp32 ? LIBXSMM_DATATYPE_F32 : dtype;
   unary_shape.out_type = dtype;
   unary_shape.ldi = static_cast<libxsmm_blasint>(ldi);
@@ -458,7 +458,7 @@ extern "C" int iree_xsmm_brgemm_dispatch(void *params, void *context,
     int64_t ldc;
     const libxsmm_gemm_flags flags;
   } xsmm_brgemm_dispatch_t;
-  xsmm_brgemm_dispatch_t *p = (xsmm_brgemm_dispatch_t *) params;
+  xsmm_brgemm_dispatch_t *p = (xsmm_brgemm_dispatch_t *)params;
   p->address = xsmm_brgemm_dispatch((libxsmm_datatype)p->dtype, p->m, p->n,
                                     p->k, p->lda, p->ldb, p->ldc, p->flags);
   return 0;
@@ -546,7 +546,7 @@ extern "C" int iree_xsmm_brgemm_invoke(void *params, void *context,
     mlir_memref_descriptor_t memrefDescC;
     int64_t numBatches;
   } xsmm_brgemm_invoke_t;
-  xsmm_brgemm_invoke_t *p = (xsmm_brgemm_invoke_t *) params;
+  xsmm_brgemm_invoke_t *p = (xsmm_brgemm_invoke_t *)params;
 
   xsmm_brgemm_invoke((libxsmm_datatype)p->dtype, p->function_address,
                      p->memrefDescA.alignedPtr, p->memrefDescA.offset,
@@ -591,8 +591,7 @@ extern "C" int iree_xsmm_unary_invoke(void *params, void *context,
 
   xsmm_unary_invoke((libxsmm_datatype)p->dtype, p->function_address,
                     p->inputMemrefDesc.alignedPtr, p->inputMemrefDesc.offset,
-                    p->outputMemrefDesc.alignedPtr,
-                    p->outputMemrefDesc.offset);
+                    p->outputMemrefDesc.alignedPtr, p->outputMemrefDesc.offset);
   return 0;
 }
 

--- a/scripts/ci/clang-format.sh
+++ b/scripts/ci/clang-format.sh
@@ -6,11 +6,19 @@
 SCRIPT_DIR=$(realpath $(dirname $0)/..)
 source ${SCRIPT_DIR}/ci/common.sh
 
-CLANG_FORMAT=$(which clang-format-16)
-if [ ! "${CLANG_FORMAT}" ]; then
-  echo "This script needs clang-format-16 to work"
-  echo "Please install the tool and run again"
-  exit 1
+CLANG_FORMAT_VERSION=16
+CLANG_FORMAT=$(which clang-format-${CLANG_FORMAT_VERSION})
+if [ ${CLANG_FORMAT} ]; then
+  echo "Using ${CLANG_FORMAT}"
+else
+  CLANG_FORMAT=$(which clang-format)
+  if ${CLANG_FORMAT} --version | grep -q "${CLANG_FORMAT_VERSION}\.[0-9\.]\+$"; then
+    echo "Using ${CLANG_FORMAT}, as it has verison ${CLANG_FORMAT_VERSION}"
+  else
+    echo "This script needs clang-format-16 to work"
+    echo "Please install the tool and run again"
+    exit 1
+  fi
 fi
 
 # If -i is passed, actually change the formatting in place

--- a/scripts/ci/clang-format.sh
+++ b/scripts/ci/clang-format.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Checks code formatting
+
+# Include common utils
+SCRIPT_DIR=$(realpath $(dirname $0)/..)
+source ${SCRIPT_DIR}/ci/common.sh
+
+CLANG_FORMAT=$(which clang-format-16)
+if [ ! "${CLANG_FORMAT}" ]; then
+  echo "This script needs clang-format-16 to work"
+  echo "Please install the tool and run again"
+  exit 1
+fi
+
+# If -i is passed, actually change the formatting in place
+# This should NEVER be used by CI, but by developers trying
+# to conform to the CI checks.
+if [ "$1" == "-i" ]; then
+  INPLACE=1
+fi
+
+ERRORS=0
+
+_clang_format() {
+  DIR="$1"
+  PATTERN="$2"
+  FILES=$(find "${DIR}" -type f -name "${PATTERN}")
+  for FILE in ${FILES}; do
+    OUT=$(${CLANG_FORMAT} -n ${FILE} 2>&1)
+    if [ "${OUT}" ]; then
+      if [ $INPLACE ]; then
+        ${CLANG_FORMAT} -i ${FILE}
+        echo "File ${FILE} updated"
+      fi
+      ERRORS=$((ERRORS+1))
+      echo "${OUT}"
+    fi
+  done
+}
+
+clang_format() {
+  DIR="$1"
+  _clang_format ${DIR} "*.cpp"
+  _clang_format ${DIR} "*.h"
+}
+
+ROOT=$(git_root)
+clang_format "${ROOT}/lib"
+clang_format "${ROOT}/include"
+clang_format "${ROOT}/runtime"
+clang_format "${ROOT}/tools"
+
+# Returning zero always means there were no changes
+# Returns non-zero to break CI if there are.
+if [ ${ERRORS} -gt 0 ]; then
+  echo "${ERRORS} files contain formatting errors"
+  exit 1
+fi

--- a/scripts/ci/clang-format.sh
+++ b/scripts/ci/clang-format.sh
@@ -49,7 +49,7 @@ CLANG_FORMAT=$(find_program clang-format-${CLANG_FORMAT_VERSION} )
 if [ ${CLANG_FORMAT} ]; then
   echo "Using ${CLANG_FORMAT}"
 else
-  CLANG_FORMAT=$(frind_program clang-format)
+  CLANG_FORMAT=$(find_program clang-format)
   if ${CLANG_FORMAT} --version | grep -q "${CLANG_FORMAT_VERSION}\.[0-9\.]\+"; then
     echo "Using ${CLANG_FORMAT}, as it has verison ${CLANG_FORMAT_VERSION}"
   else

--- a/scripts/ci/clang-format.sh
+++ b/scripts/ci/clang-format.sh
@@ -6,21 +6,6 @@
 SCRIPT_DIR=$(realpath $(dirname $0)/..)
 source ${SCRIPT_DIR}/ci/common.sh
 
-CLANG_FORMAT_VERSION=16
-CLANG_FORMAT=$(which clang-format-${CLANG_FORMAT_VERSION})
-if [ ${CLANG_FORMAT} ]; then
-  echo "Using ${CLANG_FORMAT}"
-else
-  CLANG_FORMAT=$(which clang-format)
-  if ${CLANG_FORMAT} --version | grep -q "${CLANG_FORMAT_VERSION}\.[0-9\.]\+$"; then
-    echo "Using ${CLANG_FORMAT}, as it has verison ${CLANG_FORMAT_VERSION}"
-  else
-    echo "This script needs clang-format-16 to work"
-    echo "Please install the tool and run again"
-    exit 1
-  fi
-fi
-
 # If -i is passed, actually change the formatting in place
 # This should NEVER be used by CI, but by developers trying
 # to conform to the CI checks.
@@ -52,6 +37,27 @@ clang_format() {
   _clang_format ${DIR} "*.cpp"
   _clang_format ${DIR} "*.h"
 }
+
+find_program() {
+  NAME="$1"
+  which $NAME 2> /dev/null
+}
+
+# First, we check to make sure there is support for the right clang-format
+CLANG_FORMAT_VERSION=16
+CLANG_FORMAT=$(find_program clang-format-${CLANG_FORMAT_VERSION} )
+if [ ${CLANG_FORMAT} ]; then
+  echo "Using ${CLANG_FORMAT}"
+else
+  CLANG_FORMAT=$(frind_program clang-format)
+  if ${CLANG_FORMAT} --version | grep -q "${CLANG_FORMAT_VERSION}\.[0-9\.]\+"; then
+    echo "Using ${CLANG_FORMAT}, as it has verison ${CLANG_FORMAT_VERSION}"
+  else
+    echo "This script needs clang-format-16 to work"
+    echo "Please install the tool and run again"
+    exit 1
+  fi
+fi
 
 ROOT=$(git_root)
 clang_format "${ROOT}/lib"

--- a/scripts/ci/clang-format.sh
+++ b/scripts/ci/clang-format.sh
@@ -68,6 +68,9 @@ clang_format "${ROOT}/tools"
 # Returning zero always means there were no changes
 # Returns non-zero to break CI if there are.
 if [ ${ERRORS} -gt 0 ]; then
-  echo "${ERRORS} files contain formatting errors"
+  echo "${ERRORS} files contain formatting errors."
   exit 1
+else
+  echo "All clear! No files need reformatting."
+  exit 0
 fi

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -3,6 +3,11 @@
 # Common functions to all scripts
 # Usage: source common.sh
 
+# Find the git root directory
+git_root() {
+  git rev-parse --show-toplevel
+}
+
 # Check if a program is in the PATH
 check_program() {
   PROG=$1
@@ -21,7 +26,7 @@ echo_run() {
 
 # Get the LLVM version for this build
 llvm_version() {
-  LLVM_VERSION_FILE=$(git rev-parse --show-toplevel)/build_tools/llvm_version.txt
+  LLVM_VERSION_FILE=$(git_root)/build_tools/llvm_version.txt
   if [ ! -f "${LLVM_VERSION_FILE}" ]; then
     echo "Cannot find LLVM version file in repo $PWD"
     exit 1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,10 +12,10 @@ set(TPP_OPT_TEST_DEPENDS
         tpp-run
         )
 
-add_lit_testsuite(check-all "Running the regression tests"
+add_lit_testsuite(check "Running the regression tests"
         ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${TPP_OPT_TEST_DEPENDS}
         )
-set_target_properties(check-all PROPERTIES FOLDER "Tests")
+set_target_properties(check PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(TPP_OPT ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TPP_OPT_TEST_DEPENDS})

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -1,4 +1,4 @@
-//===- MLIRGen.h MLIR Generator ---------------------------------------------===//
+//===- MLIRGen.h MLIR Generator -------------------------------------------===//
 //
 // Class that handles MLIR generation for the MLIR options.
 //
@@ -68,9 +68,9 @@ SmallVector<int64_t> getMatMulResultShape(ShapedType lhs, ShapedType rhs) {
 } // anonymous namespace
 
 MLIRGenerator::MLIRGenerator(StringRef kernelStr, unsigned miniBatch,
-                           StringRef layersStr, StringRef tilesStr,
-                           unsigned typeWidth, int seed, bool enableSoftmax,
-                           bool biasAcc, int vnniBlockingFactor)
+                             StringRef layersStr, StringRef tilesStr,
+                             unsigned typeWidth, int seed, bool enableSoftmax,
+                             bool biasAcc, int vnniBlockingFactor)
     : builder(&context), loc(builder.getUnknownLoc()), miniBatch(miniBatch),
       seed(seed), enableSoftmax(enableSoftmax), biasAcc(biasAcc),
       vnniFactor(vnniBlockingFactor) {

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -27,8 +27,8 @@ namespace func {
 class FuncOp;
 } // namespace func
 
-/// MLIR Generator: produces MLIR linalg-on-tensor dialect for an MLIR mopdel with
-/// the appropriate number of hidden layers and other properties selected.
+/// MLIR Generator: produces MLIR linalg-on-tensor dialect for an MLIR mopdel
+/// with the appropriate number of hidden layers and other properties selected.
 class MLIRGenerator {
   /// MLIR Context
   MLIRContext context;
@@ -168,7 +168,7 @@ public:
   /// so should create new objects to not have to share / cleanup existing MLIR
   /// modules.
   MLIRGenerator(StringRef, unsigned, StringRef, StringRef, unsigned, int, bool,
-               bool, int);
+                bool, int);
 
   ~MLIRGenerator() { module->destroy(); }
 

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -89,6 +89,6 @@ int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Generator");
 
   MLIRGenerator gen(kernel, miniBatch, layers, tiles, floatWidth, seed,
-                   enableSoftmax, biasAcc, vnni);
+                    enableSoftmax, biasAcc, vnni);
   return gen.generate(filename);
 }


### PR DESCRIPTION
Adds a clang-format script and CMake target to allow developers to
monitor the conformance of their code to code formatting.

Also adding the `clang-format` target to `check-all` so that we're
always told when we're failing the formatting rules.

The `clang-format.sh` script also has a `-i` mode that actualy changes
the formatting in-place. This is meant for developers that are told
they're breaking the rules, not for CI to magically change the
formatting.

The usage is:
```
  build> ninja check-all
         ...
         2 files contain formatting errors.
  build> ninja reformat
         ...
  build> ninja check-all
         ...
         All clear! No files need reformatting.
```

Using `clang-check-16` as it's the latest and the one we use in CI. It's
also easy to install from Debian based disros and Arch Linux. RedHat
distros can get via git-clang-format.

Fixes #583