### PR TITLE
Benchmarks - randomize splats by default

### DIFF
--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -26,7 +26,7 @@
       "type": "MLIR",
       "benchmark": "gemm-bf16_dp2-3layers-1024.mlir",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
-      "flags": [ "-n", "100", "-run-args=-def-parallel -seed=123 -splat-to-random" ],
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     }
   }},

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -436,6 +436,10 @@ if __name__ == '__main__':
                         help='Suppress warnings')
     parser.add_argument('--ignore-errors', action='count', default=0,
                         help='Ignore errors and only show the results that work')
+    parser.add_argument('--seed', type=int, default=123,
+                        help='Random seed (default: enabled)')
+    parser.add_argument('--splat-to-random', action='store_true', default=True,
+                        help='Replace splat dense tensors with random value (default: enabled)')
     args = parser.parse_args()
 
     # Creates the logger object

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -294,6 +294,16 @@ class IrGeneratorRun(BaseRun):
                 command[command.index('-n')+1] = self.args.n
             else:
                 command.extend(["-n", self.args.n])
+        if self.args.seed:
+            if '--seed' in command:
+                command[command.index('--seed')+1] = self.args.seed
+            else:
+                command.extend(["--seed", self.args.seed])
+        if self.args.splat_to_random:
+            if '--splat-to-random' in command:
+                command[command.index('--splat-to-random')+1] = self.args.splat_to_random
+            else:
+                command.extend(["--splat-to-random", self.args.splat_to_random])
         res = self.runner.run(command, input=irContents)
         self.stdout = res.stdout
         self.stderr = res.stderr

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -235,6 +235,16 @@ class MLIRRun(BaseRun):
                 command[command.index('-n')+1] = self.args.n
             else:
                 command.extend(["-n", self.args.n])
+        if self.args.seed:
+            if '--seed' in command:
+                command[command.index('--seed')+1] = self.args.seed
+            else:
+                command.extend(["--seed", self.args.seed])
+        if self.args.splat_to_random:
+            if '--splat-to-random' in command:
+                command[command.index('--splat-to-random')+1] = self.args.splat_to_random
+            else:
+                command.extend(["--splat-to-random", self.args.splat_to_random])
         command.append(self.benchmark)
         res = self.runner.run(command)
         self.stdout = res.stdout
@@ -436,9 +446,9 @@ if __name__ == '__main__':
                         help='Suppress warnings')
     parser.add_argument('--ignore-errors', action='count', default=0,
                         help='Ignore errors and only show the results that work')
-    parser.add_argument('--seed', type=int, default=123,
+    parser.add_argument('--seed', type=str, default="",
                         help='Random seed (default: enabled)')
-    parser.add_argument('--splat-to-random', action='store_true', default=True,
+    parser.add_argument('--splat-to-random', type=str, default="",
                         help='Replace splat dense tensors with random value (default: enabled)')
     args = parser.parse_args()
 

--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -137,9 +137,10 @@ class BenchmarkController(object):
                                              '-e', self.args.entry,
                                              '--entry-point-result=void',
                                              '--print=0',
-                                             '--seed=123',
-                                             '--splat-to-random',
+                                             '--seed', str(self.args.seed),
                   ]
+        if self.args.splat_to_random:
+            runCmd.append('--splat-to-random')
         if self.args.run_args:
             runCmd.extend(shlex.split(self.args.run_args))
         runResult = executor.run(runCmd, irContents)
@@ -212,6 +213,10 @@ if __name__ == '__main__':
                         help='Disable LSAN')
     parser.add_argument('--build', type=str, default="",
                         help='Path to the build dir')
+    parser.add_argument('--seed', type=int, default=123,
+                        help='Random seed (default: enabled)')
+    parser.add_argument('--splat-to-random', action='store_true', default=True,
+                        help='Replace splat dense tensors with random value (default: enabled)')
     args = parser.parse_args()
 
     # List of ASAN_OPTIONS

--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -137,6 +137,8 @@ class BenchmarkController(object):
                                              '-e', self.args.entry,
                                              '--entry-point-result=void',
                                              '--print=0',
+                                             '--seed=123',
+                                             '--splat-to-random',
                   ]
         if self.args.run_args:
             runCmd.extend(shlex.split(self.args.run_args))

--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -137,10 +137,13 @@ class BenchmarkController(object):
                                              '-e', self.args.entry,
                                              '--entry-point-result=void',
                                              '--print=0',
-                                             '--seed', str(self.args.seed),
                   ]
-        if self.args.splat_to_random:
+        if self.args.seed is not None:
+            runCmd.extend(['--seed', str(self.args.seed)])
+        if self.args.splat_to_random != 0:
             runCmd.append('--splat-to-random')
+        if self.args.init_type:
+            runCmd.extend(['--init-type', self.args.init_type])
         if self.args.run_args:
             runCmd.extend(shlex.split(self.args.run_args))
         runResult = executor.run(runCmd, irContents)
@@ -213,10 +216,12 @@ if __name__ == '__main__':
                         help='Disable LSAN')
     parser.add_argument('--build', type=str, default="",
                         help='Path to the build dir')
-    parser.add_argument('--seed', type=int, default=123,
-                        help='Random seed (default: enabled)')
+    parser.add_argument('--seed', type=int,
+                        help='Random seed')
     parser.add_argument('--splat-to-random', type=int, default=1,
                         help='Replace splat dense tensors with random value (default: enabled)')
+    parser.add_argument('--init-type', type=str, default="normal",
+                        help='Random initializer type (default: normal)')
     args = parser.parse_args()
 
     # List of ASAN_OPTIONS

--- a/benchmarks/harness/controller.py
+++ b/benchmarks/harness/controller.py
@@ -215,7 +215,7 @@ if __name__ == '__main__':
                         help='Path to the build dir')
     parser.add_argument('--seed', type=int, default=123,
                         help='Random seed (default: enabled)')
-    parser.add_argument('--splat-to-random', action='store_true', default=True,
+    parser.add_argument('--splat-to-random', type=int, default=1,
                         help='Replace splat dense tensors with random value (default: enabled)')
     args = parser.parse_args()
 

--- a/benchmarks/mlir/mlp-bf16-10layers-3584.mlir
+++ b/benchmarks/mlir/mlp-bf16-10layers-3584.mlir
@@ -11,7 +11,8 @@
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
 
-func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
+// TODO: Remove output argument when benchmarks can correctly deallocate returned buffers.
+func.func @entry(%arg0: tensor<8x112x32x32xbf16>, %output: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
 
   // Zero initialized output buffer for GEMMs
@@ -19,24 +20,39 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   %init_shape = tensor.empty() : tensor<8x112x32x32xbf16>
   %zero_init = linalg.fill ins(%zero : bf16) outs(%init_shape : tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> 
 
-  // Use the same weights and biases for all the layers due to the extremely high memory
-  // usage of MLIR dense constants
-  // TODO: replace with different constants for each layer when memory issues are fixed
-  %weights = arith.constant dense<0.01> : tensor<112x112x32x32xbf16>
-  %bias = arith.constant dense<0.02> : tensor<3584xbf16>
+  %weights0 = arith.constant dense<0.01> : tensor<112x112x32x32xbf16>
+  %weights1 = arith.constant dense<0.02> : tensor<112x112x32x32xbf16>
+  %weights2 = arith.constant dense<0.03> : tensor<112x112x32x32xbf16>
+  %weights3 = arith.constant dense<0.04> : tensor<112x112x32x32xbf16>
+  %weights4 = arith.constant dense<0.05> : tensor<112x112x32x32xbf16>
+  %weights5 = arith.constant dense<0.06> : tensor<112x112x32x32xbf16>
+  %weights6 = arith.constant dense<0.07> : tensor<112x112x32x32xbf16>
+  %weights7 = arith.constant dense<0.08> : tensor<112x112x32x32xbf16>
+  %weights8 = arith.constant dense<0.09> : tensor<112x112x32x32xbf16>
+  %weights9 = arith.constant dense<0.011> : tensor<112x112x32x32xbf16>
+  %bias0 = arith.constant dense<0.1> : tensor<3584xbf16>
+  %bias1 = arith.constant dense<0.2> : tensor<3584xbf16>
+  %bias2 = arith.constant dense<0.3> : tensor<3584xbf16>
+  %bias3 = arith.constant dense<0.4> : tensor<3584xbf16>
+  %bias4 = arith.constant dense<0.5> : tensor<3584xbf16>
+  %bias5 = arith.constant dense<0.6> : tensor<3584xbf16>
+  %bias6 = arith.constant dense<0.7> : tensor<3584xbf16>
+  %bias7 = arith.constant dense<0.8> : tensor<3584xbf16>
+  %bias8 = arith.constant dense<0.9> : tensor<3584xbf16>
+  %bias9 = arith.constant dense<0.11> : tensor<3584xbf16>
 
   // Empty tensor to indicate shape of the output buffer
   %out_shape = tensor.empty() : tensor<8x112x32x32xbf16>
 
   %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%arg0, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%arg0, %weights0 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded = tensor.expand_shape %bias0 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %2 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%0, %expanded : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%out_shape : tensor<8x112x32x32xbf16>) {
@@ -53,14 +69,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
   %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%3, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%3, %weights1 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded2 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded2 = tensor.expand_shape %bias1 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %6 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%4, %expanded2 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%out_shape : tensor<8x112x32x32xbf16>) {
@@ -77,14 +93,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
   %8 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%7, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%7, %weights2 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded3 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded3 = tensor.expand_shape %bias2 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %10 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%8, %expanded3 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%out_shape : tensor<8x112x32x32xbf16>) {
@@ -101,14 +117,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
    %12 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%11, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%11, %weights3 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded4 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded4 = tensor.expand_shape %bias3 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %14 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%12, %expanded4 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%out_shape : tensor<8x112x32x32xbf16>) {
@@ -125,14 +141,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
   %16 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%15, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%15, %weights4 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded5 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded5 = tensor.expand_shape %bias4 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %18 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%16, %expanded5 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%out_shape : tensor<8x112x32x32xbf16>) {
@@ -149,14 +165,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
    %20 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%19, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%19, %weights5 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded6 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded6 = tensor.expand_shape %bias5 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %22 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%20, %expanded6 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%out_shape : tensor<8x112x32x32xbf16>) {
@@ -173,14 +189,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
   %24 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%23, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%23, %weights6 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded7 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded7 = tensor.expand_shape %bias6 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %26 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%24, %expanded7 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
@@ -198,14 +214,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
 
 
   %28 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%27, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%27, %weights7 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded8 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded8 = tensor.expand_shape %bias7 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %30 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%28, %expanded8 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
@@ -222,14 +238,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
   %32 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%31, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%31, %weights8 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded9 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded9 = tensor.expand_shape %bias8 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %34 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%32, %expanded9 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
@@ -246,14 +262,14 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
 
   %36 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]}
-    ins(%35, %weights : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
+    ins(%35, %weights9 : tensor<8x112x32x32xbf16>, tensor<112x112x32x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<8x112x32x32xbf16>
-  %expanded10 = tensor.expand_shape %bias [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
+  %expanded10 = tensor.expand_shape %bias9 [[0, 1]] : tensor<3584xbf16> into tensor<112x32xbf16>
   %38 = linalg.generic {indexing_maps = [#map3, #map4, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%36, %expanded10 : tensor<8x112x32x32xbf16>, tensor<112x32xbf16>)
     outs(%zero_init : tensor<8x112x32x32xbf16>) {
@@ -263,7 +279,7 @@ func.func @entry(%arg0: tensor<8x112x32x32xbf16>) -> tensor<8x112x32x32xbf16> {
   } -> tensor<8x112x32x32xbf16>
   %39 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%38 : tensor<8x112x32x32xbf16>)
-    outs(%zero_init : tensor<8x112x32x32xbf16>) {
+    outs(%output : tensor<8x112x32x32xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16

--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -89,7 +89,7 @@ enum class TensorInitType {
   Invalid
 };
 
-// Unique pointer for tensor init to help with memory management
+// Smart pointer for tensor init to help with memory management
 using TensorInitPtr = std::shared_ptr<ITensorInit>;
 
 // Parse init type string into TensorInitType

--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -41,6 +41,7 @@ template <typename T> struct TensorInit : public ITensorInit {
   // a reasonable distribution.
   virtual mlir::DenseElementsAttr get(mlir::ShapedType shape) override {
     buffer.clear();
+    size = 1;
     for (size_t dim = 0, rank = shape.getRank(); dim < rank; dim++)
       size *= shape.getDimSize(dim);
     fillData();

--- a/include/TPP/TensorInit.h
+++ b/include/TPP/TensorInit.h
@@ -89,7 +89,7 @@ enum class TensorInitType {
 };
 
 // Unique pointer for tensor init to help with memory management
-using TensorInitPtr = std::unique_ptr<ITensorInit>;
+using TensorInitPtr = std::shared_ptr<ITensorInit>;
 
 // Parse init type string into TensorInitType
 TensorInitType parseTensorInitType(llvm::StringRef name);

--- a/include/TPP/TensorInitFloat.h
+++ b/include/TPP/TensorInitFloat.h
@@ -25,7 +25,7 @@
 // Base class for float values.
 struct TensorInitFloat : public TensorInit<llvm::APFloat> {
   // Supported data types. (TODO: Support 8-bit data types)
-  enum class DataType { FP32, FP64, BF16 };
+  enum class DataType { AUTO, FP32, FP64, BF16 };
 
   static bool isTypeSupported(const mlir::Type &type) {
     return type.isF32() || type.isF64() || type.isBF16();

--- a/include/TPP/TensorInitInt.h
+++ b/include/TPP/TensorInitInt.h
@@ -27,7 +27,7 @@
 struct TensorInitInt : public TensorInit<llvm::APInt> {
   // Supported data types.
   // TODO: Support signed (si32) and unsinged (ui32) integers
-  enum class DataType { I8, I16, I32, I64 };
+  enum class DataType { AUTO, I8, I16, I32, I64 };
 
   static bool isTypeSupported(const mlir::Type &type) {
     return type.isSignlessInteger(8) || type.isSignlessInteger(16) ||

--- a/lib/TPP/TensorInit.cpp
+++ b/lib/TPP/TensorInit.cpp
@@ -10,7 +10,49 @@
 #include "TPP/TensorInitFloat.h"
 #include "TPP/TensorInitInt.h"
 
+#include <functional>
+#include <unordered_map>
+
 using namespace mlir;
+
+namespace {
+
+struct InitKey {
+  InitKey() = default;
+  explicit InitKey(TensorInitType type, mlir::Type elmType, int seed)
+      : type(type), elmType(elmType) {
+    // Seed only matters for randomized types.
+    switch (type) {
+    case TensorInitType::Random:
+    case TensorInitType::Normal:
+      this->seed = seed;
+      break;
+    default:
+      this->seed = 0;
+      break;
+    }
+  }
+
+  bool operator==(const InitKey &ik) const {
+    return type == ik.type && elmType == ik.elmType && seed == ik.seed;
+  }
+
+  TensorInitType type;
+  mlir::Type elmType;
+  int seed;
+};
+
+struct InitKeyHash_fn {
+  std::size_t operator()(const InitKey &ik) const {
+    auto h1 = std::hash<TensorInitType>{}(ik.type);
+    auto h2 = std::hash<mlir::Type>{}(ik.elmType);
+    auto h3 = std::hash<int>{}(ik.seed);
+    return h1 ^ h2 ^ h3;
+  }
+};
+
+std::unordered_map<InitKey, TensorInitPtr, InitKeyHash_fn> tensorInitializers;
+} // namespace
 
 TensorInitType parseTensorInitType(StringRef name) {
   auto type = StringSwitch<TensorInitType>(name)
@@ -33,21 +75,27 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
       type = TensorInitType::Constant;
   }
 
+  InitKey key(type, elmType, seed);
+  if (tensorInitializers.find(key) != tensorInitializers.end())
+    return tensorInitializers[key];
+
+  TensorInitPtr initPtr = nullptr;
+
   if (TensorInitFloat::isTypeSupported(elmType)) {
     auto dataType = TensorInitFloat::getTensorInitDataType(elmType);
     switch (type) {
     case TensorInitType::Constant:
-      return std::make_unique<ConstantTensorInitFloat>(dataType);
+      initPtr = std::make_unique<ConstantTensorInitFloat>(dataType);
     case TensorInitType::Simple:
-      return std::make_unique<SimpleTensorInitFloat>(dataType);
+      initPtr = std::make_unique<SimpleTensorInitFloat>(dataType);
     case TensorInitType::Continuous:
-      return std::make_unique<ContinuousTensorInitFloat>(dataType);
+      initPtr = std::make_unique<ContinuousTensorInitFloat>(dataType);
     case TensorInitType::Random:
       assert(seed && "Can't call random initializers without seed");
-      return std::make_unique<RandomTensorInitFloat>(dataType, seed);
+      initPtr = std::make_unique<RandomTensorInitFloat>(dataType, seed);
     case TensorInitType::Normal:
       assert(seed && "Can't call random initializers without seed");
-      return std::make_unique<NormalTensorInitFloat>(dataType, seed);
+      initPtr = std::make_unique<NormalTensorInitFloat>(dataType, seed);
     default:
       assert(false && "Invalid tensor initializer type");
     }
@@ -57,24 +105,26 @@ TensorInitPtr getTensorInit(TensorInitType type, mlir::Type elmType, int seed) {
     auto dataType = TensorInitInt::getTensorInitDataType(elmType);
     switch (type) {
     case TensorInitType::Constant:
-      return std::make_unique<ConstantTensorInitInt>(dataType);
+      initPtr = std::make_unique<ConstantTensorInitInt>(dataType);
     case TensorInitType::Simple:
-      return std::make_unique<SimpleTensorInitInt>(dataType);
+      initPtr = std::make_unique<SimpleTensorInitInt>(dataType);
     case TensorInitType::Continuous:
-      return std::make_unique<ContinuousTensorInitInt>(dataType);
+      initPtr = std::make_unique<ContinuousTensorInitInt>(dataType);
     case TensorInitType::Random:
       assert(seed && "Can't call random initializers without seed");
-      return std::make_unique<RandomTensorInitInt>(dataType, seed);
+      initPtr = std::make_unique<RandomTensorInitInt>(dataType, seed);
     case TensorInitType::Normal:
       assert(seed && "Can't call random initializers without seed");
-      return std::make_unique<NormalTensorInitInt>(dataType, seed);
+      initPtr = std::make_unique<NormalTensorInitInt>(dataType, seed);
     default:
       assert(false && "Invalid tensor initializer type");
     }
   }
 
-  assert(false && "Unsupported tensor element type");
-  return nullptr;
+  assert(initPtr && "Unsupported tensor element type");
+  tensorInitializers[key] = initPtr;
+
+  return initPtr;
 }
 
 TensorInitPtr getTensorInit(StringRef type, mlir::Type elmType, int seed) {

--- a/lib/TPP/TensorInitFloat.cpp
+++ b/lib/TPP/TensorInitFloat.cpp
@@ -18,7 +18,7 @@ TensorInitFloat::getTensorInitDataType(mlir::Type type) {
     return DataType::FP32;
   if (type.isF64())
     return DataType::FP64;
-  assert(false && "Invalid tensor init data type (only FP32, FP64, BF16)");
+  return DataType::AUTO;
 }
 
 void TensorInitFloat::insert(size_t index, float value) {
@@ -39,6 +39,9 @@ void TensorInitFloat::convertType(llvm::APFloat &value) {
     break;
   case DataType::BF16:
     toBF16(value);
+    break;
+  case DataType::AUTO:
+    toFP32(value);
     break;
   }
 }

--- a/lib/TPP/TensorInitInt.cpp
+++ b/lib/TPP/TensorInitInt.cpp
@@ -19,7 +19,7 @@ TensorInitInt::DataType TensorInitInt::getTensorInitDataType(mlir::Type type) {
     return DataType::I32;
   if (type.isSignlessInteger(64))
     return DataType::I64;
-  assert(false && "Invalid tensor init data type (only I8, I16, I32, I64)");
+  return DataType::AUTO;
 }
 
 unsigned TensorInitInt::getDataTypeBitWidth(TensorInitInt::DataType type) {
@@ -32,6 +32,8 @@ unsigned TensorInitInt::getDataTypeBitWidth(TensorInitInt::DataType type) {
     return 32;
   case DataType::I64:
     return 64;
+  case DataType::AUTO:
+    return 32;
   }
 }
 
@@ -41,6 +43,7 @@ bool TensorInitInt::isDataTypeSigned(TensorInitInt::DataType type) {
   case DataType::I16:
   case DataType::I32:
   case DataType::I64:
+  case DataType::AUTO:
     return true;
   }
 }

--- a/test/BF16/Integration/tpp-run-splat-shape.mlir
+++ b/test/BF16/Integration/tpp-run-splat-shape.mlir
@@ -1,0 +1,41 @@
+// RUN: tpp-run %s \
+// RUN:  -e entry -entry-point-result=void \
+// RUN:  -print-mlir=mid -seed=123 -splat-to-random 2>&1 | \
+// RUN: FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
+// 1 layer MLP with compile-time weights and bias values
+func.func @entry(%arg0: tensor<4x8x8x8xbf16>, %arg3: tensor<4x8x8x8xbf16>, %arg6: tensor<4x8x8x8xbf16>, %arg9: tensor<4x8x8x8xbf16> ) -> tensor<4x8x8x8xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %arg1 = arith.constant dense<0.01> : tensor<8x8x8x8xbf16>
+  %arg2 = arith.constant dense<0.4> : tensor<4x8x8x8xbf16>
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x8x8x8xbf16>, tensor<8x8x8x8xbf16>) outs(%arg3 : tensor<4x8x8x8xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %mul = arith.mulf %in, %in_0 : bf16
+      %add = arith.addf %out, %mul : bf16
+      linalg.yield %add : bf16
+  } -> tensor<4x8x8x8xbf16>
+  %2 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %arg2 : tensor<4x8x8x8xbf16>, tensor<4x8x8x8xbf16>) outs(%arg3 : tensor<4x8x8x8xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %add = arith.addf %in, %in_0 : bf16
+      linalg.yield %add : bf16
+  } -> tensor<4x8x8x8xbf16>
+  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<4x8x8x8xbf16>) outs(%arg3 : tensor<4x8x8x8xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %max = arith.maxf %in, %cst : bf16
+      linalg.yield %max : bf16
+  } -> tensor<4x8x8x8xbf16>
+
+  return %3 : tensor<4x8x8x8xbf16>
+}
+
+// CHECK-NOT: memref.global "private" constant @__constant_{{.*}}: memref<8x8xbf16>
+// CHECK-DAG: memref.global "private" constant @__constant_{{.*}}: memref<4x8x8x8xbf16>
+// CHECK-DAG: memref.global "private" constant @__constant_{{.*}}: memref<8x8x4x8x2xbf16>
+// CHECK: xsmm_brgemm_invoke
+// CHECK: xsmm_binary_invoke
+// CHECK: xsmm_unary_invoke

--- a/test/BF16/Integration/tpp-run-splat-shape.mlir
+++ b/test/BF16/Integration/tpp-run-splat-shape.mlir
@@ -8,23 +8,27 @@
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
-// 1 layer MLP with compile-time weights and bias values
-func.func @entry(%arg0: tensor<4x8x8x8xbf16>, %arg3: tensor<4x8x8x8xbf16>, %arg6: tensor<4x8x8x8xbf16>, %arg9: tensor<4x8x8x8xbf16> ) -> tensor<4x8x8x8xbf16> {
+// 1 layer MLP with compile-time weights and bias values.
+func.func @entry(%arg0: tensor<4x8x8x8xbf16>, %output: tensor<4x8x8x8xbf16>) -> tensor<4x8x8x8xbf16> {
   %cst = arith.constant 0.000000e+00 : bf16
-  %arg1 = arith.constant dense<0.01> : tensor<8x8x8x8xbf16>
-  %arg2 = arith.constant dense<0.4> : tensor<4x8x8x8xbf16>
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x8x8x8xbf16>, tensor<8x8x8x8xbf16>) outs(%arg3 : tensor<4x8x8x8xbf16>) {
+  %out_shape = tensor.empty() : tensor<4x8x8x8xbf16>
+  %zero_init = linalg.fill ins(%cst : bf16) outs(%out_shape : tensor<4x8x8x8xbf16>) -> tensor<4x8x8x8xbf16>
+
+  %weights = arith.constant dense<0.01> : tensor<8x8x8x8xbf16>
+  %bias = arith.constant dense<0.4> : tensor<4x8x8x8xbf16>
+
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %weights : tensor<4x8x8x8xbf16>, tensor<8x8x8x8xbf16>) outs(%zero_init : tensor<4x8x8x8xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %mul = arith.mulf %in, %in_0 : bf16
       %add = arith.addf %out, %mul : bf16
       linalg.yield %add : bf16
   } -> tensor<4x8x8x8xbf16>
-  %2 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %arg2 : tensor<4x8x8x8xbf16>, tensor<4x8x8x8xbf16>) outs(%arg3 : tensor<4x8x8x8xbf16>) {
+  %2 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%0, %bias : tensor<4x8x8x8xbf16>, tensor<4x8x8x8xbf16>) outs(%out_shape : tensor<4x8x8x8xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
       %add = arith.addf %in, %in_0 : bf16
       linalg.yield %add : bf16
   } -> tensor<4x8x8x8xbf16>
-  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<4x8x8x8xbf16>) outs(%arg3 : tensor<4x8x8x8xbf16>) {
+  %3 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<4x8x8x8xbf16>) outs(%output : tensor<4x8x8x8xbf16>) {
     ^bb0(%in: bf16, %out: bf16):
       %max = arith.maxf %in, %cst : bf16
       linalg.yield %max : bf16
@@ -33,6 +37,8 @@ func.func @entry(%arg0: tensor<4x8x8x8xbf16>, %arg3: tensor<4x8x8x8xbf16>, %arg6
   return %3 : tensor<4x8x8x8xbf16>
 }
 
+// Random initialization of splat tensors ensures that bias shape does not get folded
+// due to compile time packing.
 // CHECK-NOT: memref.global "private" constant @__constant_{{.*}}: memref<8x8xbf16>
 // CHECK-DAG: memref.global "private" constant @__constant_{{.*}}: memref<4x8x8x8xbf16>
 // CHECK-DAG: memref.global "private" constant @__constant_{{.*}}: memref<8x8x4x8x2xbf16>

--- a/test/Integration/tpp-run-splat-mlp.mlir
+++ b/test/Integration/tpp-run-splat-mlp.mlir
@@ -41,13 +41,14 @@ func.func @entry(%arg0: tensor<8x8xf32>, %output: tensor<8x8xf32>) -> tensor<8x8
   } -> tensor<8x8xf32>
   %5 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]}
     ins(%4 : tensor<8x8xf32>)
-    outs(%output : tensor<8x8xf32>) {
+    outs(%out_shape : tensor<8x8xf32>) {
     ^bb0(%in: f32, %out: f32):
       %16 = arith.maxf %in, %c0 : f32
       linalg.yield %16 : f32
   } -> tensor<8x8xf32>
+  %6 = linalg.copy ins(%5 : tensor<8x8xf32>) outs(%output : tensor<8x8xf32>) -> tensor<8x8xf32>
 
-  return %5 : tensor<8x8xf32>
+  return %6 : tensor<8x8xf32>
 }
 
 // Ensure that each weight and bias gets their own global buffer.

--- a/test/Integration/tpp-run-splat-mlp.mlir
+++ b/test/Integration/tpp-run-splat-mlp.mlir
@@ -1,0 +1,63 @@
+// RUN: tpp-run %s -e entry -entry-point-result=void \
+// RUN:  -print-mlir=mid -seed 123 -splat-to-random 2>&1 | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d0)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @entry(%arg0: tensor<8x8xf32>, %output: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %out_shape = tensor.empty() : tensor<8x8xf32>
+  %zero_init = linalg.fill ins(%c0 : f32) outs(%out_shape : tensor<8x8xf32>) -> tensor<8x8xf32>
+
+  %weights0 = arith.constant dense<0.01> : tensor<8x8xf32>
+  %weights1 = arith.constant dense<0.02> : tensor<8x8xf32>
+  %bias0 = arith.constant dense<0.1> : tensor<8xf32>
+  %bias1 = arith.constant dense<0.2> : tensor<8xf32>
+
+  %0 = linalg.matmul ins(%arg0, %weights0 : tensor<8x8xf32>, tensor<8x8xf32>) outs(%zero_init : tensor<8x8xf32>) -> tensor<8x8xf32>
+  %1 = linalg.generic {indexing_maps = [#map1, #map0, #map1], iterator_types = ["parallel", "parallel"]}
+    ins(%0, %bias0 : tensor<8x8xf32>, tensor<8xf32>)
+    outs(%out_shape : tensor<8x8xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %add = arith.addf %in, %in_0 : f32
+      linalg.yield %add : f32
+  } -> tensor<8x8xf32>
+  %2 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]}
+    ins(%1 : tensor<8x8xf32>)
+    outs(%out_shape : tensor<8x8xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %16 = arith.maxf %in, %c0 : f32
+      linalg.yield %16 : f32
+  } -> tensor<8x8xf32>
+
+  %3 = linalg.matmul ins(%2, %weights1 : tensor<8x8xf32>, tensor<8x8xf32>) outs(%zero_init : tensor<8x8xf32>) -> tensor<8x8xf32>
+  %4 = linalg.generic {indexing_maps = [#map1, #map0, #map1], iterator_types = ["parallel", "parallel"]}
+    ins(%3, %bias1 : tensor<8x8xf32>, tensor<8xf32>)
+    outs(%out_shape : tensor<8x8xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %add = arith.addf %in, %in_0 : f32
+      linalg.yield %add : f32
+  } -> tensor<8x8xf32>
+  %5 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]}
+    ins(%4 : tensor<8x8xf32>)
+    outs(%output : tensor<8x8xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %16 = arith.maxf %in, %c0 : f32
+      linalg.yield %16 : f32
+  } -> tensor<8x8xf32>
+
+  return %5 : tensor<8x8xf32>
+}
+
+// Ensure that each weight and bias gets their own global buffer
+// CHECK-DAG: memref.global "private" constant @__constant_8x8xf32 : memref<8x8xf32>
+// CHECK-DAG: memref.global "private" constant @__constant_8x8xf32_0 : memref<8x8xf32>
+// CHECK-DAG: memref.global "private" constant @__constant_8xf32 : memref<8xf32>
+// CHECK-DAG: memref.global "private" constant @__constant_8xf32_0 : memref<8xf32>
+
+// Randomized input
+// CHECK-DAG: memref.global "private" @__wrapper_0 : memref<8x8xf32>
+// CHECK-LABEL: @entry
+// CHECK: %[[input:.+]] = memref.get_global @__wrapper_0
+// CHECK: call @_entry(%[[input]]

--- a/test/Integration/tpp-run-splat-mlp.mlir
+++ b/test/Integration/tpp-run-splat-mlp.mlir
@@ -50,13 +50,13 @@ func.func @entry(%arg0: tensor<8x8xf32>, %output: tensor<8x8xf32>) -> tensor<8x8
   return %5 : tensor<8x8xf32>
 }
 
-// Ensure that each weight and bias gets their own global buffer
+// Ensure that each weight and bias gets their own global buffer.
 // CHECK-DAG: memref.global "private" constant @__constant_8x8xf32 : memref<8x8xf32>
 // CHECK-DAG: memref.global "private" constant @__constant_8x8xf32_0 : memref<8x8xf32>
 // CHECK-DAG: memref.global "private" constant @__constant_8xf32 : memref<8xf32>
 // CHECK-DAG: memref.global "private" constant @__constant_8xf32_0 : memref<8xf32>
 
-// Randomized input
+// Randomized input.
 // CHECK-DAG: memref.global "private" @__wrapper_0 : memref<8x8xf32>
 // CHECK-LABEL: @entry
 // CHECK: %[[input:.+]] = memref.get_global @__wrapper_0

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -17,14 +17,16 @@
 // RUN: tpp-run %s -e entry -entry-point-result=void -print-mlir=early -seed 123 -splat-to-random -init-type=normal 2>&1 | \
 // RUN: FileCheck %s --check-prefix=OPT-NORMAL
 
-func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
+func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>, %arg2: tensor<4x2xi32>) {
   %0 = arith.constant dense<1.0> : tensor<2x16xf32>
   %5 = arith.constant dense<1.0> : tensor<2x16xf64>
   %1 = arith.constant dense<2.0> : tensor<4x16xf32>
+  %10 = arith.constant dense<2.0> : tensor<4x4xf32>
   %2 = arith.constant dense<0.0> : tensor<4x8xf32>
   %3 = arith.constant dense<[[0.0, 1.0],[2.0, 3.0]]> : tensor<2x2xf32>
   %4 = arith.constant dense<0> : tensor<4x8xi32>
   %6 = arith.constant dense<1> : tensor<4x8xi32>
+  %11 = arith.constant dense<1> : tensor<4x8xi32>
   %7 = arith.constant dense<1> : tensor<4x8xi64>
   %8 = arith.constant dense<[[0, 1],[2, 3]]> : tensor<2x2xi32>
   %9 = arith.constant 1.0 : f32
@@ -34,13 +36,16 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // Constants
 // SPLAT-DAG: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // SPLAT-DAG: memref.global "private" @__wrapper_1 : memref<4x2xi32> = dense<1>
+// SPLAT-DAG: memref.global "private" @__wrapper_2 : memref<4x2xi32> = dense<1>
 // SPLAT-LABEL: @_entry
 // SPLAT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // SPLAT: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
 // SPLAT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
+// SPLAT: arith.constant dense<2.000000e+00> : tensor<4x4xf32>
 // SPLAT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
-// SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}> : tensor<2x2xf32>
 // SPLAT: arith.constant dense<0> : tensor<4x8xi32>
+// SPLAT: arith.constant dense<1> : tensor<4x8xi32>
 // SPLAT: arith.constant dense<1> : tensor<4x8xi32>
 // SPLAT: arith.constant dense<1> : tensor<4x8xi64>
 // SPLAT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
@@ -50,15 +55,18 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // SPLAT: memref.get_global @__wrapper_0
 
 // Constants
-// RANDOM-NOT: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
-// RANDOM-NOT: memref.global "private" @__wrapper_1 : memref<4x2xi32> = dense<1>
+// RANDOM-DAG: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<{{\[}}{{\[}}0.000000e+00, 1.303520e-01], [0.151291341, 0.0106364777]
+// RANDOM-DAG: memref.global "private" @__wrapper_1 : memref<4x2xi32> = dense<{{\[}}{{\[}}132, 126], [117, 123], [126, 121], [132, 133]]>
+// RANDOM-DAG: memref.global "private" @__wrapper_2 : memref<4x2xi32> = dense<{{\[}}{{\[}}129, 134], [129, 126], [141, 131], [138, 121]]>
 // RANDOM-LABEL: @_entry
 // RANDOM: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
 // RANDOM: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
+// RANDOM: arith.constant dense<2.000000e+00> : tensor<4x4xf32>
 // RANDOM: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
-// RANDOM: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// RANDOM: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}> : tensor<2x2xf32>
 // RANDOM: arith.constant dense<0> : tensor<4x8xi32>
+// RANDOM: arith.constant dense<1> : tensor<4x8xi32>
 // RANDOM: arith.constant dense<1> : tensor<4x8xi32>
 // RANDOM: arith.constant dense<1> : tensor<4x8xi64>
 // RANDOM: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
@@ -70,16 +78,23 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // Constants
 // RANDOM-SPLAT-NOT: memref.global "private" @__wrapper_0 : memref<4x2xf32> = dense<1.000000e+00>
 // RANDOM-SPLAT-NOT: memref.global "private" @__wrapper_1 : memref<4x2xi32> = dense<1>
+// RANDOM-SPLAT-NOT: memref.global "private" @__wrapper_2 : memref<4x2xi32> = dense<1>
 // RANDOM-SPLAT-LABEL: @_entry
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // RANDOM-SPLAT-NOT: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
 // RANDOM-SPLAT-NOT: arith.constant dense<2.000000e+00> : tensor<4x16xf32>
+// RANDOM-SPLAT-NOT: arith.constant dense<2.000000e+00> : tensor<4x4xf32>
+// RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}0.000000e+00, 1.303520e-01, 0.151291341{{.*}}: tensor<2x16xf32>
+// RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}0.000000e+00, 0.13035200536251068, 0.15129134058952332{{.*}}: tensor<2x16xf64>
+// RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}0.186750099, 0.111865185, 0.388891816{{.*}}: tensor<4x16xf32>
+// RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}0.0440550111, 0.221581057, 0.000000e+00{{.*}}: tensor<4x4xf32>
 // RANDOM-SPLAT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
-// RANDOM-SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
+// RANDOM-SPLAT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}> : tensor<2x2xf32>
 // RANDOM-SPLAT: arith.constant dense<0> : tensor<4x8xi32>
 // RANDOM-SPLAT-NOT: arith.constant dense<1> : tensor<4x8xi32>
 // RANDOM-SPLAT-NOT: arith.constant dense<1> : tensor<4x8xi64>
 // RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}132, 126, 117{{.*}}> : tensor<4x8xi32>
+// RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}130, 121, 126{{.*}}> : tensor<4x8xi32>
 // RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}132, 126, 117{{.*}}> : tensor<4x8xi64>
 // RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
 // RANDOM-SPLAT: arith.constant 1.000000e+00 : f32
@@ -91,9 +106,11 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-CONST: arith.constant dense<1.000000e+00> : tensor<2x16xf32>
 // OPT-CONST: arith.constant dense<1.000000e+00> : tensor<2x16xf64>
 // OPT-CONST: arith.constant dense<1.000000e+00> : tensor<4x16xf32>
+// OPT-CONST: arith.constant dense<1.000000e+00> : tensor<4x4xf32>
 // OPT-CONST: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // OPT-CONST: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // OPT-CONST: arith.constant dense<0> : tensor<4x8xi32>
+// OPT-CONST: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-CONST: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-CONST: arith.constant dense<1> : tensor<4x8xi64>
 // OPT-CONST: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
@@ -103,11 +120,13 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<2x16xf32>
 // OPT-SIMPLE: arith.constant dense<{{.*}}0.30000001192092896, 0.60000002384185791, 0.89999997615814208, {{.*}}> : tensor<2x16xf64>
 // OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<4x16xf32>
+// OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<4x4xf32>
 // OPT-SIMPLE: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // OPT-SIMPLE: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // OPT-SIMPLE: arith.constant dense<0> : tensor<4x8xi32>
 // OPT-SIMPLE-NOT: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-SIMPLE-NOT: arith.constant dense<1> : tensor<4x8xi64>
+// OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi32>
 // OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi32>
 // OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi64>
 // OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
@@ -117,11 +136,13 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<2x16xf32>
 // OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<2x16xf64>
 // OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.562500e-02, 3.125000e-02,  {{.*}}> : tensor<4x16xf32>
+// OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 6.250000e-02, 1.250000e-01,  {{.*}}> : tensor<4x4xf32>
 // OPT-CONT: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // OPT-CONT: arith.constant dense<0> : tensor<4x8xi32>
 // OPT-CONT-NOT: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-CONT-NOT: arith.constant dense<1> : tensor<4x8xi64>
+// OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi32>
 // OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi32>
 // OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi64>
 // OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
@@ -130,13 +151,15 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-RANDOM-LABEL: @_entry
 // OPT-RANDOM: arith.constant dense<{{.*}}9.62642952E-4, 0.179147944, 0.939454615, {{.*}}> : tensor<2x16xf32>
 // OPT-RANDOM: arith.constant dense<{{.*}}9.6264295279979705E-4, 0.17914794385433197, 0.93945461511611938, {{.*}}> : tensor<2x16xf64>
-// OPT-RANDOM: arith.constant dense<{{.*}}9.62642952E-4, 0.179147944, 0.939454615, {{.*}}> : tensor<4x16xf32>
+// OPT-RANDOM: arith.constant dense<{{.*}}0.281718224, 0.838135182, 0.538071811, {{.*}}> : tensor<4x16xf32>
+// OPT-RANDOM: arith.constant dense<{{.*}}0.685934782, 0.505808651, 0.126024485, {{.*}}> : tensor<4x4xf32>
 // OPT-RANDOM: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // OPT-RANDOM: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // OPT-RANDOM: arith.constant dense<0> : tensor<4x8xi32>
 // OPT-RANDOM-NOT: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-RANDOM-NOT: arith.constant dense<1> : tensor<4x8xi64>
 // OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}0, 45, 240, 105, 135{{.*}}> : tensor<4x8xi32>
+// OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}72, 214, 137, 95, 208{{.*}}> : tensor<4x8xi32>
 // OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}0, 45, 240, 105, 135{{.*}}> : tensor<4x8xi64>
 // OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
 // OPT-RANDOM: arith.constant 1.000000e+00 : f32
@@ -144,13 +167,15 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-NORMAL-LABEL: @_entry
 // OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.303520e-01, 0.151291341, {{.*}}> : tensor<2x16xf32>
 // OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 0.13035200536251068, 0.15129134058952332, {{.*}}> : tensor<2x16xf64>
-// OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.303520e-01, 0.151291341, {{.*}}> : tensor<4x16xf32>
+// OPT-NORMAL: arith.constant dense<{{.*}}0.186750099, 0.111865185, 0.388891816, {{.*}}> : tensor<4x16xf32>
+// OPT-NORMAL: arith.constant dense<{{.*}}0.0440550111, 0.221581057, 0.000000e+00, {{.*}}> : tensor<4x4xf32>
 // OPT-NORMAL: arith.constant dense<0.000000e+00> : tensor<4x8xf32>
 // OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00{{.*}}>
 // OPT-NORMAL: arith.constant dense<0> : tensor<4x8xi32>
 // OPT-NORMAL-NOT: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-NORMAL-NOT: arith.constant dense<1> : tensor<4x8xi64>
 // OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}132, 126, 117, 123, 126{{.*}}> : tensor<4x8xi32>
+// OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}130, 121, 126, 112, 129{{.*}}> : tensor<4x8xi32>
 // OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}132, 126, 117, 123, 126{{.*}}> : tensor<4x8xi64>
 // OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
 // OPT-NORMAL: arith.constant 1.000000e+00 : f32

--- a/test/Integration/tpp-run-splat-tensor.mlir
+++ b/test/Integration/tpp-run-splat-tensor.mlir
@@ -27,6 +27,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
   %6 = arith.constant dense<1> : tensor<4x8xi32>
   %7 = arith.constant dense<1> : tensor<4x8xi64>
   %8 = arith.constant dense<[[0, 1],[2, 3]]> : tensor<2x2xi32>
+  %9 = arith.constant 1.0 : f32
   return
 }
 
@@ -43,6 +44,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // SPLAT: arith.constant dense<1> : tensor<4x8xi32>
 // SPLAT: arith.constant dense<1> : tensor<4x8xi64>
 // SPLAT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// SPLAT: arith.constant 1.000000e+00 : f32
 // Input
 // SPLAT-LABEL: @entry
 // SPLAT: memref.get_global @__wrapper_0
@@ -60,6 +62,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // RANDOM: arith.constant dense<1> : tensor<4x8xi32>
 // RANDOM: arith.constant dense<1> : tensor<4x8xi64>
 // RANDOM: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// RANDOM: arith.constant 1.000000e+00 : f32
 // Input
 // RANDOM-LABEL: @entry
 // RANDOM: memref.get_global @__wrapper_0
@@ -79,6 +82,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}132, 126, 117{{.*}}> : tensor<4x8xi32>
 // RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}132, 126, 117{{.*}}> : tensor<4x8xi64>
 // RANDOM-SPLAT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// RANDOM-SPLAT: arith.constant 1.000000e+00 : f32
 // Input
 // RANDOM-SPLAT-LABEL: @entry
 // RANDOM-SPLAT: memref.get_global @__wrapper_0
@@ -93,6 +97,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-CONST: arith.constant dense<1> : tensor<4x8xi32>
 // OPT-CONST: arith.constant dense<1> : tensor<4x8xi64>
 // OPT-CONST: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// OPT-CONST: arith.constant 1.000000e+00 : f32
 
 // OPT-SIMPLE-LABEL: @_entry
 // OPT-SIMPLE: arith.constant dense<{{.*}}3.000000e-01, 6.000000e-01, 0.899999976, {{.*}}> : tensor<2x16xf32>
@@ -106,6 +111,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi32>
 // OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1, 2, 0, 1, 2{{.*}}> : tensor<4x8xi64>
 // OPT-SIMPLE: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// OPT-SIMPLE: arith.constant 1.000000e+00 : f32
 
 // OPT-CONT-LABEL: @_entry
 // OPT-CONT: arith.constant dense<{{.*}}0.000000e+00, 3.125000e-02, 6.250000e-02, {{.*}}> : tensor<2x16xf32>
@@ -119,6 +125,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi32>
 // OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 7, 15, 23, 31{{.*}}> : tensor<4x8xi64>
 // OPT-CONT: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// OPT-CONT: arith.constant 1.000000e+00 : f32
 
 // OPT-RANDOM-LABEL: @_entry
 // OPT-RANDOM: arith.constant dense<{{.*}}9.62642952E-4, 0.179147944, 0.939454615, {{.*}}> : tensor<2x16xf32>
@@ -132,6 +139,7 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}0, 45, 240, 105, 135{{.*}}> : tensor<4x8xi32>
 // OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}0, 45, 240, 105, 135{{.*}}> : tensor<4x8xi64>
 // OPT-RANDOM: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// OPT-RANDOM: arith.constant 1.000000e+00 : f32
 
 // OPT-NORMAL-LABEL: @_entry
 // OPT-NORMAL: arith.constant dense<{{.*}}0.000000e+00, 1.303520e-01, 0.151291341, {{.*}}> : tensor<2x16xf32>
@@ -145,3 +153,4 @@ func.func @entry(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>) {
 // OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}132, 126, 117, 123, 126{{.*}}> : tensor<4x8xi32>
 // OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}132, 126, 117, 123, 126{{.*}}> : tensor<4x8xi64>
 // OPT-NORMAL: arith.constant dense<{{\[}}{{\[}}0, 1], [2, 3]]> : tensor<2x2xi32>
+// OPT-NORMAL: arith.constant 1.000000e+00 : f32

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -159,8 +159,10 @@ LogicalResult MLIRBench::replaceSplatWithRandom() {
     auto constant = dyn_cast<arith::ConstantOp>(op);
     if (!constant)
       continue;
-    auto newAttr = replaceSplat(constant.getType().cast<ShapedType>(),
-                                constant.getValueAttr());
+    auto cstType = constant.getType().dyn_cast<ShapedType>();
+    if (!cstType)
+      continue;
+    auto newAttr = replaceSplat(cstType, constant.getValueAttr());
     constant.setValueAttr(cast<TypedAttr>(newAttr));
   }
 

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -156,14 +156,16 @@ MLIRBench::PrintStage parsePrintStage(StringRef stage) {
 // so we can modify the IR with the needed wrappers
 static LogicalResult prepareMLIRKernel(Operation *op,
                                        JitRunnerOptions &options) {
+  auto tensorInitType = parseTensorInitType(initType);
+
   // Randon options need seed
-  if (!seed && (splatRandom || initType == "random" || initType == "normal")) {
+  if (!seed && (splatRandom || tensorInitType == TensorInitType::Random ||
+                tensorInitType == TensorInitType::Normal)) {
     seed = std::time(0);
   }
 
   // Benchmark object
-  MLIRBenchConfig config(seed, tppToLoops, linalgToLoops,
-                         parseTensorInitType(initType));
+  MLIRBenchConfig config(seed, tppToLoops, linalgToLoops, tensorInitType);
   MLIRBench bench(op, config);
 
   // Basic checks


### PR DESCRIPTION
Enables splat randomization by default in the benchmarks.
Tensor random initializers now produce continuous random data upon multiple requests for the same splat data type instead of restarting the generated number sequence each time.
Also, incorrect scalar tensor initialization is fixed.

This approach aims to improve benchmarking by providing more realistic workloads containing varied inputs and model constants (weighs, biases etc.). Moreover, randomizing splats prevents unrealistic optimizations such as dimension folding caused by compile time packing.
Continuous random data generation prevent unexpected CSE and helps to measure more realistic memory consumption.

Fixes #515 