### PR TITLE
Expand GPU pipeline

### DIFF
--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -108,6 +108,7 @@ private:
     // abstraction.
     pm.addPass(createGeneralizeTensorPackAndUnPackPass());
     pm.addPass(createBufferizePass());
+    pm.addPass(createConvertForAllToParallelOpPass());
     pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
     // Convert to generic GPU ops.

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -83,8 +83,9 @@ struct GpuPipeline : public GpuPipelineBase<GpuPipeline>,
     perf::registerBufferizableOpInterfaceExternalModels(registry);
     tpp::registerBufferizableOpInterfaceExternalModels(registry);
 
-    // Add all core MLIR dialects as the default TPP passes may contain any
-    // combination of other passes.
+    // Add all core MLIR dialects to make the pipeline more robust with respect
+    // to accepted input IR by preventing cryptic runtime crashes due to missing
+    // dialect registrations.
     registerAllDialects(registry);
   }
 

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -9,6 +9,7 @@
 #include "TPP/Passes.h"
 
 #include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -25,8 +26,14 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "TPP/Dialect/Check/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Check/CheckDialect.h"
+#include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Tpp/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/Tpp/TppDialect.h"
 #include "TPP/Dialect/Transform/LinalgXTransformOps.h"
+#include "TPP/Dialect/Xsmm/XsmmDialect.h"
 #include "TPP/PassUtils.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -69,6 +76,16 @@ struct GpuPipeline : public GpuPipelineBase<GpuPipeline>,
     registry.insert<LLVM::LLVMDialect>();
     registry.insert<NVVM::NVVMDialect>();
     registry.insert<nvgpu::NVGPUDialect>();
+    registry.insert<bufferization::BufferizationDialect>();
+    bufferization::registerAllocationOpInterfaceExternalModels(registry);
+    linalgx::registerTransformDialectExtension(registry);
+    check::registerBufferizableOpInterfaceExternalModels(registry);
+    perf::registerBufferizableOpInterfaceExternalModels(registry);
+    tpp::registerBufferizableOpInterfaceExternalModels(registry);
+
+    // Add all core MLIR dialects as the default TPP passes may contain any
+    // combination of other passes.
+    registerAllDialects(registry);
   }
 
   void runOnOperation() override {

--- a/lib/TPP/GPU/GpuToCuda.cpp
+++ b/lib/TPP/GPU/GpuToCuda.cpp
@@ -50,6 +50,8 @@ struct GpuToCuda : public GpuToCudaBase<GpuToCuda>,
     registry.insert<gpu::GPUDialect>();
     registry.insert<NVVM::NVVMDialect>();
     registry.insert<nvgpu::NVGPUDialect>();
+    registry.insert<memref::MemRefDialect>();
+    registry.insert<affine::AffineDialect>();
   }
 
   void runOnOperation() override {
@@ -70,6 +72,7 @@ private:
 
 #ifdef TPP_GPU_ENABLE
     // Preprocess and lower standard ops.
+    pm.addPass(memref::createExpandStridedMetadataPass());
     pm.addPass(arith::createArithExpandOpsPass());
     pm.addPass(createLowerAffinePass());
     pm.addPass(createConvertSCFToCFPass());

--- a/test/GPU/gpu-pipeline-cuda.mlir
+++ b/test/GPU/gpu-pipeline-cuda.mlir
@@ -1,5 +1,5 @@
 // RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
-// RUN: tpp-opt %s -gpu-pipeline=gpu=cuda -split-input-file | FileCheck %s --check-prefix=CUDA
+// RUN: tpp-opt %s -gpu-pipeline=gpu=cuda -split-input-file | FileCheck %s
 
 func.func @linalg_matmul() {
   %0 = memref.alloc() : memref<8x8xf32>
@@ -23,22 +23,22 @@ func.func @linalg_matmul() {
 
 func.func private @printMemrefF32(memref<*xf32>)
 
-// CUDA: module attributes {gpu.container_module}
-// CUDA-LABEL: func.func @linalg_matmul
-// CUDA:         %[[C1:.*]] = memref.cast
-// CUDA:         gpu.host_register %[[C1]]
-// CUDA:         %[[C2:.*]] = memref.cast
-// CUDA:         gpu.host_register %[[C2]]
-// CUDA:         %[[C3:.*]] = memref.cast
-// CUDA:         gpu.host_register %[[C3]]
-// CUDA:         gpu.launch_func  @linalg_matmul_kernel::@linalg_matmul_kernel
-// CUDA:         call @printMemrefF32
-// CUDA:       }
-// CUDA: gpu.module @linalg_matmul_kernel attributes {gpu.binary = "
-// CUDA-LABEL: llvm.func @linalg_matmul_kernel
-// CUDA-DAG:     nvvm.read
-// CUDA-DAG:     llvm.mul
-// CUDA-DAG:     llvm.add
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @linalg_matmul
+// CHECK:         %[[C1:.*]] = memref.cast
+// CHECK:         gpu.host_register %[[C1]]
+// CHECK:         %[[C2:.*]] = memref.cast
+// CHECK:         gpu.host_register %[[C2]]
+// CHECK:         %[[C3:.*]] = memref.cast
+// CHECK:         gpu.host_register %[[C3]]
+// CHECK:         gpu.launch_func  @linalg_matmul_kernel::@linalg_matmul_kernel
+// CHECK:         call @printMemrefF32
+// CHECK:       }
+// CHECK: gpu.module @linalg_matmul_kernel attributes {gpu.binary = "
+// CHECK-LABEL: llvm.func @linalg_matmul_kernel
+// CHECK-DAG:     nvvm.read
+// CHECK-DAG:     llvm.mul
+// CHECK-DAG:     llvm.add
 
 // -----
 
@@ -48,14 +48,14 @@ func.func @tpp_gemm(%arg0: memref<8x9xf32>, %arg1: memref<9x10xf32>, %arg2: memr
   return
 }
 
-// CUDA: module attributes {gpu.container_module}
-// CUDA-LABEL: func.func @tpp_gemm
-// CUDA:         gpu.launch_func  @tpp_gemm_kernel::@tpp_gemm_kernel
-// CUDA: gpu.module @tpp_gemm_kernel attributes {gpu.binary = "
-// CUDA-LABEL: llvm.func @tpp_gemm_kernel
-// CUDA-DAG:     nvvm.read
-// CUDA-DAG:     llvm.mul
-// CUDA-DAG:     llvm.add
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @tpp_gemm
+// CHECK:         gpu.launch_func  @tpp_gemm_kernel::@tpp_gemm_kernel
+// CHECK: gpu.module @tpp_gemm_kernel attributes {gpu.binary = "
+// CHECK-LABEL: llvm.func @tpp_gemm_kernel
+// CHECK-DAG:     nvvm.read
+// CHECK-DAG:     llvm.mul
+// CHECK-DAG:     llvm.add
 
 // -----
 
@@ -74,15 +74,15 @@ func.func @packed_brgemm(%arg0: memref<4x16x64x64xf32>, %arg1: memref<16x16x64x6
   return
 }
 
-// CUDA: module attributes {gpu.container_module}
-// CUDA-LABEL: func.func @packed_brgemm
-// CUDA-NOT:     scf.parallel
-// CUDA:         gpu.launch_func  @packed_brgemm_kernel::@packed_brgemm_kernel
-// CUDA: gpu.module @packed_brgemm_kernel attributes {gpu.binary = "
-// CUDA-LABEL: llvm.func @packed_brgemm_kernel
-// CUDA-DAG:     nvvm.read
-// CUDA-DAG:     llvm.mul
-// CUDA-DAG:     llvm.add
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @packed_brgemm
+// CHECK-NOT:     scf.parallel
+// CHECK:         gpu.launch_func  @packed_brgemm_kernel::@packed_brgemm_kernel
+// CHECK: gpu.module @packed_brgemm_kernel attributes {gpu.binary = "
+// CHECK-LABEL: llvm.func @packed_brgemm_kernel
+// CHECK-DAG:     nvvm.read
+// CHECK-DAG:     llvm.mul
+// CHECK-DAG:     llvm.add
 
 // -----
 
@@ -96,12 +96,12 @@ func.func @forall_loop(%arg0: memref<4x16x64x64xf32>, %arg1: memref<16x16x64x64x
   return
 }
 
-// CUDA: module attributes {gpu.container_module}
-// CUDA-LABEL: func.func @forall_loop
-// CUDA-NOT:     scf.forall
-// CUDA:         gpu.launch_func  @forall_loop_kernel::@forall_loop_kernel
-// CUDA: gpu.module @forall_loop_kernel attributes {gpu.binary = "
-// CUDA-LABEL: llvm.func @forall_loop_kernel
-// CUDA-DAG:     nvvm.read
-// CUDA-DAG:     llvm.mul
-// CUDA-DAG:     llvm.add
+// CHECK: module attributes {gpu.container_module}
+// CHECK-LABEL: func.func @forall_loop
+// CHECK-NOT:     scf.forall
+// CHECK:         gpu.launch_func  @forall_loop_kernel::@forall_loop_kernel
+// CHECK: gpu.module @forall_loop_kernel attributes {gpu.binary = "
+// CHECK-LABEL: llvm.func @forall_loop_kernel
+// CHECK-DAG:     nvvm.read
+// CHECK-DAG:     llvm.mul
+// CHECK-DAG:     llvm.add

--- a/test/GPU/gpu-pipeline.mlir
+++ b/test/GPU/gpu-pipeline.mlir
@@ -56,3 +56,52 @@ func.func @tpp_gemm(%arg0: memref<8x9xf32>, %arg1: memref<9x10xf32>, %arg2: memr
 // CUDA-DAG:     nvvm.read
 // CUDA-DAG:     llvm.mul
 // CUDA-DAG:     llvm.add
+
+// -----
+
+func.func @packed_brgemm(%arg0: memref<4x16x64x64xf32>, %arg1: memref<16x16x64x64xf32>, %arg2: memref<4x16x64x64xf32>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c4, %c16) step (%c1, %c1) {
+    %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<16x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xf32> to memref<64x64xf32, strided<[64, 1], offset: ?>>
+    tpp.brgemm ins(%subview : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>, %subview_0 : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>, %subview_1 : memref<64x64xf32, strided<[64, 1], offset: ?>>) outs(%subview_1 : memref<64x64xf32, strided<[64, 1], offset: ?>>)
+    scf.yield
+  }
+  return
+}
+
+// CUDA: module attributes {gpu.container_module}
+// CUDA-LABEL: func.func @packed_brgemm
+// CUDA-NOT:     scf.parallel
+// CUDA:         gpu.launch_func  @packed_brgemm_kernel::@packed_brgemm_kernel
+// CUDA: gpu.module @packed_brgemm_kernel attributes {gpu.binary = "
+// CUDA-LABEL: llvm.func @packed_brgemm_kernel
+// CUDA-DAG:     nvvm.read
+// CUDA-DAG:     llvm.mul
+// CUDA-DAG:     llvm.add
+
+// -----
+
+func.func @forall_loop(%arg0: memref<4x16x64x64xf32>, %arg1: memref<16x16x64x64xf32>, %arg2: memref<4x16x64x64xf32>) {
+  scf.forall (%arg3, %arg4) in (4, 16) {
+    %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<16x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x16x64x64xf32> to memref<64x64xf32, strided<[64, 1], offset: ?>>
+    tpp.brgemm ins(%subview : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>, %subview_0 : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>, %subview_1 : memref<64x64xf32, strided<[64, 1], offset: ?>>) outs(%subview_1 : memref<64x64xf32, strided<[64, 1], offset: ?>>)
+  }
+  return
+}
+
+// CUDA: module attributes {gpu.container_module}
+// CUDA-LABEL: func.func @forall_loop
+// CUDA-NOT:     scf.forall
+// CUDA:         gpu.launch_func  @forall_loop_kernel::@forall_loop_kernel
+// CUDA: gpu.module @forall_loop_kernel attributes {gpu.binary = "
+// CUDA-LABEL: llvm.func @forall_loop_kernel
+// CUDA-DAG:     nvvm.read
+// CUDA-DAG:     llvm.mul
+// CUDA-DAG:     llvm.add


### PR DESCRIPTION
Changes:
* Registers more dialects by default in GPU pipeline to ensure it is can handle any input.
* Add additional generic passes and corresponding tests.
* Rename gpu-pipeline.mlir -> gpu-pipeline-cuda.mlir - future supported GPU types should have their tests in separate files to improve readability.