### PR TITLE
Allow `isBlockedMatmul` to match blocked batch matmuls

### DIFF
--- a/test/Passes/tile-and-fuse-default.mlir
+++ b/test/Passes/tile-and-fuse-default.mlir
@@ -195,7 +195,7 @@ func.func @blocked_matmul_with_vnni_blocking(
   %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<1536xbf16> into tensor<48x32xbf16>
   %1 = linalg.generic {
     indexing_maps = [#map3, #map4, #map3], 
-    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}  
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]} 
     ins(%0, %expanded : tensor<8x48x32x32xbf16>, tensor<48x32xbf16>) 
     outs(%arg3 : tensor<8x48x32x32xbf16>) {
     ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
@@ -311,3 +311,78 @@ func.func @blocked_matmul_with_fill(%arg0: tensor<4x16x32x32xf32>, %arg1: tensor
 // CHECK: %{{.+}} = linalg.generic 
 // CHECK-SAME:  indexing_maps = [#[[MAP]]], 
 // CHECK-SAME:  iterator_types = ["parallel", "parallel"]
+
+// -----
+
+#map7 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4, d6)>
+#map8 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d6, d5)>
+#map9 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4, d5)>
+
+func.func @blocked_batch_matmul(%pack: tensor<512x1x2x32x32xf32>, 
+                                %pack1: tensor<512x1x2x32x32xf32>) -> tensor<512x1x1x32x32xf32> {
+  %0 = tensor.empty() : tensor<512x1x1x32x32xf32>
+  %cst = arith.constant 0.0 : f32
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<512x1x1x32x32xf32>) -> tensor<512x1x1x32x32xf32>
+  %2 = linalg.generic {
+    indexing_maps = [#map7, #map8, #map9], 
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} 
+    ins(%pack, %pack1 : tensor<512x1x2x32x32xf32>, tensor<512x1x2x32x32xf32>) outs(%1 : tensor<512x1x1x32x32xf32>) {
+    ^bb0(%in: f32, %in_13: f32, %out: f32):
+      %17 = arith.mulf %in, %in_13 : f32
+      %18 = arith.addf %out, %17 : f32
+      linalg.yield %18 : f32
+    } -> tensor<512x1x1x32x32xf32>
+  return %2 : tensor<512x1x1x32x32xf32>
+}
+
+// CHECK-LABEL: blocked_batch_matmul
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<512x1x2x32x32xf32>, %[[ARG1:.+]]: tensor<512x1x2x32x32xf32>
+// CHECK-DAG: %[[C512:.+]] = arith.constant 512 : index
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<512x1x1x32x32xf32>
+// CHECK: %{{.+}} = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C512]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[EMPTY]])
+// CHECK-NEXT: %{{.+}} = scf.for %[[ARG4:.+]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG3]])
+// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG2]], %[[ARG4]], 0, 0, 0] [1, 1, 1, 32, 32] [1, 1, 1, 1, 1] 
+// CHECK-SAME:  : tensor<512x1x1x32x32xf32> to tensor<32x32xf32>
+// CHECK: %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[SLICE]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+// CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], %[[ARG4]], 0, 0, 0] [1, 1, 2, 32, 32] [1, 1, 1, 1, 1] 
+// CHECK-SAME:  : tensor<512x1x2x32x32xf32> to tensor<2x32x32xf32>
+// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG2]], 0, 0, 0, 0] [1, 1, 2, 32, 32] [1, 1, 1, 1, 1] 
+// CHECK-SAME:  : tensor<512x1x2x32x32xf32> to tensor<2x32x32xf32>
+// CHECK: %{{.+}} = linalg.batch_reduce_matmul ins(%[[SLICE0]], %[[SLICE1]] : tensor<2x32x32xf32>, tensor<2x32x32xf32>) 
+// CHECK-SAME:  outs(%[[FILL]] : tensor<32x32xf32>) -> tensor<32x32xf32>
+
+// -----
+
+#map7 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4, d6)>
+#map8 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d6, d5)>
+#map9 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d4, d5)>
+
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4, d6)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d6, d5)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d4, d5)>
+
+// Expect not to match as the batch dimension is a reduction.
+// CHECK-LABEL: blocked_almost_batch_matmul
+func.func @blocked_almost_batch_matmul(%pack: tensor<512x2x2x32x32xf32>, 
+                                       %pack1: tensor<512x2x2x32x32xf32>) -> tensor<2x2x32x32xf32> {
+  %0 = tensor.empty() : tensor<2x2x32x32xf32>
+  %cst = arith.constant 0.0 : f32
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2x2x32x32xf32>) -> tensor<2x2x32x32xf32>
+  // CHECK-NOT: scf.for
+  // CHECK: linalg.generic
+  // CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+  // CHECK-SAME:  iterator_types = ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
+  %2 = linalg.generic {
+    indexing_maps = [#map7, #map8, #map9], 
+    iterator_types = ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} 
+    ins(%pack, %pack1 : tensor<512x2x2x32x32xf32>, tensor<512x2x2x32x32xf32>) outs(%1 : tensor<2x2x32x32xf32>) {
+    ^bb0(%in: f32, %in_13: f32, %out: f32):
+      %17 = arith.mulf %in, %in_13 : f32
+      %18 = arith.addf %out, %17 : f32
+      linalg.yield %18 : f32
+    } -> tensor<2x2x32x32xf32>
+  return %2 : tensor<2x2x32x32xf32>
+}


### PR DESCRIPTION
Allow affine expressions to have an (optional) extra batch dimensions that must be parallel and present in A, B and C operands.

Working on https://github.com/plaidml/tpp-mlir/issues/354