### PR TITLE
[TPP] Add tensor builders

### DIFF
--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -60,7 +60,8 @@ class Tpp_UnaryOp<string mnemonic, list<Trait> traits = []> :
   let skipDefaultBuilders = 1; 
 
   let builders = [
-    OpBuilder<(ins "Value":$input, "Value":$output)>
+    OpBuilder<(ins "Value":$input, "Value":$output)>,
+    OpBuilder<(ins "Value":$input, "Type":$output)>
   ]; 
 }
 
@@ -162,7 +163,8 @@ class Tpp_BinaryOp<string mnemonic, list<Trait> traits = []> :
   let skipDefaultBuilders = 1;
 
   let builders = [
-    OpBuilder<(ins "ValueRange":$inputs, "Value":$out)>
+    OpBuilder<(ins "ValueRange":$inputs, "Value":$output)>,
+    OpBuilder<(ins "ValueRange":$inputs, "Type":$output)>
   ];
 }
 
@@ -222,7 +224,8 @@ class Tpp_TernaryOp<string mnemonic, list<Trait> traits = []> :
   let skipDefaultBuilders = 1;
 
   let builders = [
-    OpBuilder<(ins "ValueRange":$inputs, "Value":$output)>
+    OpBuilder<(ins "ValueRange":$inputs, "Value":$output)>,
+    OpBuilder<(ins "ValueRange":$inputs, "Type":$output_type)>
   ]; 
 }
 
@@ -296,11 +299,7 @@ class Tpp_QuaternaryOp<string mnemonic, list<Trait> traits = []> :
   let results = (outs Variadic<TppGemmLikeOperand>:$results);
 
   let hasCustomAssemblyFormat = 1;
-  let skipDefaultBuilders = 1;
-
-  let builders = [
-    OpBuilder<(ins "ValueRange":$inputs, "Value":$output)>
-  ]; 
+  let skipDefaultBuilders = 1; 
 }
 
 //===----------------------------------------------------------------------===//
@@ -337,12 +336,17 @@ def Tpp_FusedBrgemmOp : Tpp_QuaternaryOp<"fused_brgemm"> {
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "Value":$output, "Value":$bias, 
                    "FusedUnaryOpKindAttr":$unary_kind,
+                   "FusedBinaryOpKindAttr":$binary_kind)>,
+    OpBuilder<(ins "ValueRange":$inputs, "Type":$output_type, "Value":$bias,
+                   "FusedUnaryOpKindAttr":$unary_kind,
                    "FusedBinaryOpKindAttr":$binary_kind)>
   ];
   let extraClassDeclaration = [{
     // Get the operand to be used as input to the binary operation.
     Value getBiasOperand() { return getInputs()[3]; };
   }];
+
+  let skipDefaultBuilders = 1;
   let hasVerifier = 1;
 }
 

--- a/lib/TPP/CombineTpp.cpp
+++ b/lib/TPP/CombineTpp.cpp
@@ -49,8 +49,8 @@ struct CombineBrgemmAddAndRelu : public OpRewritePattern<tpp::ReluOp> {
     auto binaryType =
         tpp::FusedBinaryOpKindAttr::get(ctx, tpp::FusedBinaryOpKind::ADD);
     rewriter.replaceOpWithNewOp<tpp::FusedBrgemmOp>(
-        reluOp, brgemmOperands, brgemmOperands.back(), addOperand, unaryType,
-        binaryType);
+        reluOp, brgemmOperands, brgemmOperands.back().getType(), addOperand,
+        unaryType, binaryType);
     return success();
   }
 };

--- a/lib/TPP/RewriteToBatchReduceGemm.cpp
+++ b/lib/TPP/RewriteToBatchReduceGemm.cpp
@@ -368,10 +368,18 @@ rewriteToBrGemmVnniOp(RewriterBase &rewriter, linalg::LinalgOp linalgOp) {
     }
     SmallVector<Value> slicedOperands = *maybeSlicedOperands;
     assert(slicedOperands.size() == 3 && "expect three operands");
-    auto brgemm = builder.create<tpp::BrgemmOp>(
-        loc,
-        ValueRange{slicedOperands[0], slicedOperands[1], slicedOperands[2]},
-        slicedOperands[2]);
+    Operation *brgemm = nullptr;
+    if (linalgOp.hasBufferSemantics()) {
+      brgemm = builder.create<tpp::BrgemmOp>(
+          loc,
+          ValueRange{slicedOperands[0], slicedOperands[1], slicedOperands[2]},
+          slicedOperands[2]);
+    } else {
+      brgemm = brgemm = builder.create<tpp::BrgemmOp>(
+          loc,
+          ValueRange{slicedOperands[0], slicedOperands[1], slicedOperands[2]},
+          slicedOperands[2].getType());
+    }
     tensorResults =
         (loopRanges.empty())
             ? brgemm->getResults()

--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -579,7 +579,7 @@ mlir::linalgx::packVNNIBRGemmOp(RewriterBase &rewriter,
       loc,
       ValueRange{brgemmOp.getInputs()[0], packedMatrixB,
                  brgemmOp.getOutputs()[0]},
-      brgemmOp.getOutputs()[0]);
+      brgemmOp.getOutputs()[0].getType());
   rewriter.replaceOp(brgemmOp, replacementOp.getResult(0));
   return replacementOp;
 }


### PR DESCRIPTION
Provide more ergonomics builder for tpp operations at tensor level.  At tensor abstraction there is not output value and only the output type is needed.

```cpp
// memref builder
tppOpBuilderMemRef(..., ValueRange = input(s), Value = output)

// tensor builder
tppOpBuilderTensor(..., ValueRange = input(s), Type = outputType)
```

Fix #612 