### PR TITLE
Fold reshape into eltwise consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,9 +131,18 @@ if (NOT TPP_INSIDE_IREE)
     ${CONFIG_DIR}/fc/1024x352x512.json
     ${CONFIG_DIR}/fc/1024x512x256.json
   )
-  string(JOIN ',' PERF_CFGS_STR ${MATMUL_PERF_CFGS} ${FC_PERF_CFGS})
+  set(MODELS_PERF_CFGS
+    ${CONFIG_DIR}/models/models.json
+  )
+  string(JOIN ',' PERF_CFGS_STR ${MATMUL_PERF_CFGS} ${FC_PERF_CFGS} ${MODELS_PERF_CFGS})
   add_custom_target(quick-perf ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
     -c ${PERF_CFGS_STR}
+                    DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
+                    WORKING_DIRECTORY ${BENCHMARK_DIR}
+                    COMMENT Run Quick Performance Benchmarks)
+
+  add_custom_target(quick-models-bench ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
+    -c ${MODELS_PERF_CFGS}
                     DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
                     WORKING_DIRECTORY ${BENCHMARK_DIR}
                     COMMENT Run Quick Performance Benchmarks)

--- a/benchmarks/config/models/models.json
+++ b/benchmarks/config/models/models.json
@@ -1,0 +1,12 @@
+[
+  {
+  "mha": {
+    "self_attention_full_mlir": {
+      "type": "MLIR",
+      "benchmark": "Models/self-attention-full.mlir",
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }}
+]

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -263,6 +263,8 @@ private:
     pm.addPass(createCleanupPass());
 
     // Generalize tensor.pack and tensor.unpack.
+    // Tile and fuse can create more opportunities to simplify pack/unpack.
+    pm.addPass(createSimplifyAndCanonicalizePackPass());
     pm.addPass(createGeneralizeTensorPackAndUnPackPass());
 
     // Final clenaup after all the mapping.

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -535,6 +535,11 @@ getLastFusableConsumer(linalg::LinalgOp linalgOp,
     Value resNextConsumer = nextConsumer->getResult(0);
     currentConsumer = nextConsumer;
     visitedConsumers.insert(currentConsumer);
+    // Require each eltwise to have a single user.
+    if (std::distance(resNextConsumer.getUsers().begin(),
+                      resNextConsumer.getUsers().end()) != 1) {
+      break;
+    }
     nextConsumer = *(resNextConsumer.getUsers().begin());
   }
   LLVM_DEBUG(llvm::dbgs() << "LAST FUSABLE CONSUMER: " << currentConsumer

--- a/scripts/buildkite/benchmark.sh
+++ b/scripts/buildkite/benchmark.sh
@@ -85,6 +85,9 @@ benchmark fc/1024x1024x512.json "FC 1024x1024x512"
 benchmark fc/1024x352x512.json "FC 1024x352x512"
 benchmark fc/1024x512x256.json "FC 1024x512x256"
 
+# Models Benchmarks
+benchmark models/models.json "MHA self attention full"
+
 # Summary report for all benchmarks
 echo "+++ REPORT"
 if [ "main" = "${BUILDKITE_BRANCH}" ]; then


### PR DESCRIPTION
When converting an MHA block using the IREE importer, operations such as
collapse shapes and expand shapes are emitted to fit the computation to
use `linalg.matmul`. We cannot propagate packing operations through
these operations; thus, this commit attempts to mitigate the problem by
folding `collapse shape` operations with the consumer, increasing the
propagation region. This commit also adds an MHA block to benchmarks
(thanks, Adam).

Co-authored by Adam Siemieniuk <adam.siemieniuk@intel.com>