### PR TITLE
Improve GPU-related build flags

### DIFF
--- a/lib/TPP/GPU/CMakeLists.txt
+++ b/lib/TPP/GPU/CMakeLists.txt
@@ -14,7 +14,7 @@ add_mlir_library(TPPGPU
     MLIRGPUToNVVMTransforms
 )
 
-if (NOT TPP_GPU STREQUAL "")
+if (TPP_GPU MATCHES "cuda")
   target_compile_definitions(obj.TPPGPU
     PRIVATE
     TPP_GPU_ENABLE=1

--- a/lib/TPP/GPU/CMakeLists.txt
+++ b/lib/TPP/GPU/CMakeLists.txt
@@ -17,6 +17,6 @@ add_mlir_library(TPPGPU
 if (TPP_GPU MATCHES "cuda")
   target_compile_definitions(obj.TPPGPU
     PRIVATE
-    TPP_GPU_ENABLE=1
+    TPP_CUDA_ENABLE=1
   )
 endif()

--- a/lib/TPP/GPU/GpuToCuda.cpp
+++ b/lib/TPP/GPU/GpuToCuda.cpp
@@ -70,7 +70,7 @@ private:
   void constructPipeline() override {
     pm.clear();
 
-#ifdef TPP_GPU_ENABLE
+#ifdef TPP_CUDA_ENABLE
     // Preprocess and lower standard ops.
     pm.addPass(memref::createExpandStridedMetadataPass());
     pm.addPass(arith::createArithExpandOpsPass());
@@ -86,7 +86,7 @@ private:
     // Cleanup IR.
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createCSEPass());
-#endif // TPP_GPU_ENABLE
+#endif // TPP_CUDA_ENABLE
   }
 };
 

--- a/lib/TPP/GPU/Utils.cpp
+++ b/lib/TPP/GPU/Utils.cpp
@@ -16,12 +16,12 @@ namespace mlir {
 namespace tpp {
 
 void initializeGpuTargets() {
-#ifdef TPP_GPU_ENABLE
+#ifdef TPP_CUDA_ENABLE
   LLVMInitializeNVPTXTarget();
   LLVMInitializeNVPTXTargetInfo();
   LLVMInitializeNVPTXTargetMC();
   LLVMInitializeNVPTXAsmPrinter();
-#endif // TPP_GPU_ENABLE
+#endif // TPP_CUDA_ENABLE
 }
 
 } // namespace tpp


### PR DESCRIPTION
Ensures that CUDA dependencies are not required without explicit CMake `TPP_GPU=cuda` flag.