### PR TITLE
Fix `createConvertMemRefToTppPass` in tpp lowering

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -346,7 +346,7 @@ private:
       pm.addPass(createConvertTppToLoopsPass());
     else {
       // Memref to tpp conversion patterns.
-      pm.addNestedPass<func::FuncOp>(createConvertMemRefToTppPass());
+      pm.addPass(createConvertMemRefToTppPass());
       // Tpp to Xsmm conversion patterns.
       pm.addPass(createConvertTppToXsmmPass());
     }

--- a/test/Passes/DefaultPipeline/tpp-lowering.mlir
+++ b/test/Passes/DefaultPipeline/tpp-lowering.mlir
@@ -31,9 +31,10 @@ func.func @tpp_ops(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>, %arg2: me
 // LOOPS:   arith.mulf
 // LOOPS:   arith.addf
 
-// CHECK-LABEL: copy
+// XSMM-LABEL: copy
 func.func @copy(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
-  // CHECK: tpp.identity
+  // XSMM: xsmm.unary.dispatch identity
+  // XSMM-NEXT: xsmm.unary identity
   memref.copy %arg0, %arg1 : memref<2x2xf32> to memref<2x2xf32>
   return
 }


### PR DESCRIPTION
Commit
https://github.com/plaidml/tpp-mlir/commit/0a0af3a8cc421283ae31503c5864af3f32755bfc introduced `createConvertMemRefToTppPass` in `TppLoweringPass` as a function pass, but `TppLoweringPass` is already working on fuction on thus the pass was silently failing.