### PR TITLE
Script to source LLVM-runtime environment

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+#
+# Setup runtime environment based on build_tools/llvm_version.txt
+
+if [ ! "${TPP_LLVM}" ] && [ -d /nfs_home/buildkite-slurm/builds/tpp ]; then
+  source /nfs_home/buildkite-slurm/builds/tpp/enable-tpp
+fi
+
+if [ "${TPP_LLVM}" ]; then
+  # basic utilities functions (git_root, llvm_version)
+  source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/ci/common.sh"
+
+  # LLVM version used to build TPP-mlir
+  TPP_LLVM_VERSION=$(llvm_version)
+
+  if [ "${TPP_LLVM_VERSION}" ]; then
+    # setup environment
+    export TPP_LLVM_VERSION
+    export TPP_LLVM_DIR=${TPP_LLVM}/${TPP_LLVM_VERSION}
+    # avoid overriding PATH/LD_LIBRARY_PATH of initial environment (append)
+    export PATH=${PATH}:${TPP_LLVM_DIR}/bin
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${TPP_LLVM_DIR}/lib
+
+    # setup additional/legacy envronment variables
+    export CUSTOM_LLVM_ROOT=${TPP_LLVM_DIR}
+    export LLVM_VERSION=${TPP_LLVM_VERSION}
+  else
+    echo "ERROR: Cannot determine LLVM-version!"
+  fi
+else
+  echo "ERROR: Please source the TPP-environment first!"
+fi


### PR DESCRIPTION
Added script to source the runtime environment namely the LLVM-build used to build TPP-mlir. This enables the following:

```bash
cd tpp-mlir
source scripts/env.sh

mlir-vulkan-runner ~/llvm-project/mlir/test/mlir-vulkan-runner/addf.mlir -e main -entry-point-result=void \
  -shared-libs=$TPP_LLVM_DIR/lib/libvulkan-runtime-wrappers.so \
  -shared-libs=$TPP_LLVM_DIR/lib/libmlir_c_runner_utils.so \
  -shared-libs=$TPP_LLVM_DIR/lib/libmlir_runner_utils.so
```

As shown, no path to `mlir-vulkan-runner` must be specified and one can refer to `$TPP_LLVM_DIR` (or `$CUSTOM_LLVM_ROOT`). Source'ing `scripts/env.sh` sources `enable-tpp` automatically (or refers to the one already sourced).