### PR TITLE
tpp-run - replace warmup call with extra iteration

### DIFF
--- a/test/Integration/result-out-arg.mlir
+++ b/test/Integration/result-out-arg.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -print -n 10 \
+// RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/result-out-return.mlir
+++ b/test/Integration/result-out-return.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -print -n 10 \
+// RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -149,11 +149,16 @@ func.func @entry(%A: tensor<4x8xf32>,
 
 // BENCH_STATS-LABEL: @entry
 // BENCH_STATS-NOT: call @_entry
-// BENCH_STATS: %[[deltas:.+]] = memref.alloc() : memref<11xf64>
+// BENCH_STATS: %[[deltas:.+]] = memref.alloc() : memref<15xf64>
 // BENCH_STATS: perf.bench
 // BENCH_STATS: call @_entry
 // BENCH_STATS-NOT: call @_entry
 // BENCH_STATS: %[[subview:.+]] = memref.subview %[[deltas]]
-// BENCH_STATS: perf.mean(%[[subview]]
+// BENCH_STATS: %[[subDeltas:.+]] = memref.alloc
+// BENCH_STATS: memref.copy %[[subview]], %[[subDeltas]]
+// BENCH_STATS: perf.mean(%[[subDeltas]]
+// BENCH_STATS: perf.stdev(%[[subDeltas]]
 // BENCH_STATS-NOT: call @_entry
+// BENCH_STATS-DAG: memref.dealloc %[[deltas]]
+// BENCH_STATS-DAG: memref.dealloc %[[subDeltas]]
 // BENCH_STATS: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -149,7 +149,7 @@ func.func @entry(%A: tensor<4x8xf32>,
 
 // BENCH_STATS-LABEL: @entry
 // BENCH_STATS-NOT: call @_entry
-// BENCH_STATS: %[[deltas:.+]] = memref.alloc() : memref<15xf64>
+// BENCH_STATS: %[[deltas:.+]] = memref.alloc()
 // BENCH_STATS: perf.bench
 // BENCH_STATS: call @_entry
 // BENCH_STATS-NOT: call @_entry

--- a/test/Integration/tpp-run.mlir
+++ b/test/Integration/tpp-run.mlir
@@ -10,7 +10,10 @@
 
 // Benchmark options
 // RUN: tpp-run %s -e entry -entry-point-result=void -print -print-mlir=early 2>&1 | FileCheck %s --check-prefix=BENCH_PRINT
-// RUN: tpp-run %s -e entry -entry-point-result=void -n 10 -print-mlir=early 2>&1 | FileCheck %s --check-prefix=BENCH_STATS
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 10 -print-mlir=late 2>&1 | FileCheck %s --check-prefix=BENCH_STATS
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 2 -print-mlir=late 2>&1 | FileCheck %s --check-prefix=BENCH_STATS_2
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 100 -print-mlir=late 2>&1 | FileCheck %s --check-prefix=BENCH_STATS_100
+// RUN: tpp-run %s -e entry -entry-point-result=void -n 2000 -print-mlir=late 2>&1 | FileCheck %s --check-prefix=BENCH_STATS_2000
 
 // CPU options can't be tested as even the LLVM IR is identical
 // Splat and init options in tpp-run-splat-* tests
@@ -148,17 +151,73 @@ func.func @entry(%A: tensor<4x8xf32>,
 // BENCH_PRINT: ( 10, 10, 10, 10 )
 
 // BENCH_STATS-LABEL: @entry
+// BENCH_STATS-DAG: %[[c11:.+]] = arith.constant 11 : index
 // BENCH_STATS-NOT: call @_entry
-// BENCH_STATS: %[[deltas:.+]] = memref.alloc()
-// BENCH_STATS: perf.bench
+// BENCH_STATS: %[[deltas:.+]] = memref.alloc() : memref<11xf64>
+// BENCH_STATS: scf.for{{.*}}to %[[c11]]
 // BENCH_STATS: call @_entry
 // BENCH_STATS-NOT: call @_entry
-// BENCH_STATS: %[[subview:.+]] = memref.subview %[[deltas]]
-// BENCH_STATS: %[[subDeltas:.+]] = memref.alloc
+// BENCH_STATS: %[[subview:.+]] = memref.reinterpret_cast %[[deltas]] to offset: [1], sizes: [10], strides: [1]
+// BENCH_STATS: %[[subDeltas:.+]] = memref.alloc() : memref<10xf64>
 // BENCH_STATS: memref.copy %[[subview]], %[[subDeltas]]
-// BENCH_STATS: perf.mean(%[[subDeltas]]
-// BENCH_STATS: perf.stdev(%[[subDeltas]]
+// BENCH_STATS: %[[viewCast:.+]] = memref.cast %[[subDeltas]]
+// BENCH_STATS: call @perf_mean(%[[viewCast]]
+// BENCH_STATS: call @perf_stdev(%[[viewCast]]
 // BENCH_STATS-NOT: call @_entry
 // BENCH_STATS-DAG: memref.dealloc %[[deltas]]
 // BENCH_STATS-DAG: memref.dealloc %[[subDeltas]]
 // BENCH_STATS: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
+
+// BENCH_STATS_2-LABEL: @entry
+// BENCH_STATS_2-DAG: %[[c3:.+]] = arith.constant 3 : index
+// BENCH_STATS_2-NOT: call @_entry
+// BENCH_STATS_2: %[[deltas:.+]] = memref.alloc() : memref<3xf64>
+// BENCH_STATS_2: scf.for{{.*}}to %[[c3]]
+// BENCH_STATS_2: call @_entry
+// BENCH_STATS_2-NOT: call @_entry
+// BENCH_STATS_2: %[[subview:.+]] = memref.reinterpret_cast %[[deltas]] to offset: [1], sizes: [2], strides: [1]
+// BENCH_STATS_2: %[[subDeltas:.+]] = memref.alloc() : memref<2xf64>
+// BENCH_STATS_2: memref.copy %[[subview]], %[[subDeltas]]
+// BENCH_STATS_2: %[[viewCast:.+]] = memref.cast %[[subDeltas]]
+// BENCH_STATS_2: call @perf_mean(%[[viewCast]]
+// BENCH_STATS_2: call @perf_stdev(%[[viewCast]]
+// BENCH_STATS_2-NOT: call @_entry
+// BENCH_STATS_2-DAG: memref.dealloc %[[deltas]]
+// BENCH_STATS_2-DAG: memref.dealloc %[[subDeltas]]
+// BENCH_STATS_2: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
+
+// BENCH_STATS_100-LABEL: @entry
+// BENCH_STATS_100-DAG: %[[c110:.+]] = arith.constant 110 : index
+// BENCH_STATS_100-NOT: call @_entry
+// BENCH_STATS_100: %[[deltas:.+]] = memref.alloc() : memref<110xf64>
+// BENCH_STATS_100: scf.for{{.*}}to %[[c110]]
+// BENCH_STATS_100: call @_entry
+// BENCH_STATS_100-NOT: call @_entry
+// BENCH_STATS_100: %[[subview:.+]] = memref.reinterpret_cast %[[deltas]] to offset: [10], sizes: [100], strides: [1]
+// BENCH_STATS_100: %[[subDeltas:.+]] = memref.alloc() : memref<100xf64>
+// BENCH_STATS_100: memref.copy %[[subview]], %[[subDeltas]]
+// BENCH_STATS_100: %[[viewCast:.+]] = memref.cast %[[subDeltas]]
+// BENCH_STATS_100: call @perf_mean(%[[viewCast]]
+// BENCH_STATS_100: call @perf_stdev(%[[viewCast]]
+// BENCH_STATS_100-NOT: call @_entry
+// BENCH_STATS_100-DAG: memref.dealloc %[[deltas]]
+// BENCH_STATS_100-DAG: memref.dealloc %[[subDeltas]]
+// BENCH_STATS_100: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
+
+// BENCH_STATS_2000-LABEL: @entry
+// BENCH_STATS_2000-DAG: %[[c2100:.+]] = arith.constant 2100 : index
+// BENCH_STATS_2000-NOT: call @_entry
+// BENCH_STATS_2000: %[[deltas:.+]] = memref.alloc() : memref<2100xf64>
+// BENCH_STATS_2000: scf.for{{.*}}to %[[c2100]]
+// BENCH_STATS_2000: call @_entry
+// BENCH_STATS_2000-NOT: call @_entry
+// BENCH_STATS_2000: %[[subview:.+]] = memref.reinterpret_cast %[[deltas]] to offset: [100], sizes: [2000], strides: [1]
+// BENCH_STATS_2000: %[[subDeltas:.+]] = memref.alloc() : memref<2000xf64>
+// BENCH_STATS_2000: memref.copy %[[subview]], %[[subDeltas]]
+// BENCH_STATS_2000: %[[viewCast:.+]] = memref.cast %[[subDeltas]]
+// BENCH_STATS_2000: call @perf_mean(%[[viewCast]]
+// BENCH_STATS_2000: call @perf_stdev(%[[viewCast]]
+// BENCH_STATS_2000-NOT: call @_entry
+// BENCH_STATS_2000-DAG: memref.dealloc %[[deltas]]
+// BENCH_STATS_2000-DAG: memref.dealloc %[[subDeltas]]
+// BENCH_STATS_2000: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )

--- a/test/Models/multi-head-attention.mlir
+++ b/test/Models/multi-head-attention.mlir
@@ -1,9 +1,9 @@
 // RUN: tpp-run %s -linalg-to-loops \
-// RUN:         -n 10 -print -e multi_head_attention -entry-point-result=void | \
+// RUN:         -print -e multi_head_attention -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXEC
 
 // RUN: tpp-run %s \
-// RUN:         -n 10 -print -e multi_head_attention -entry-point-result=void | \
+// RUN:         -print -e multi_head_attention -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXEC
 
 //////////////////////////////////////////////////////////////////////////////
@@ -263,6 +263,3 @@ func.func @multi_head_attention(
 // Output
 // EXEC:      ( 35651.7, 35651.7, 35651.7, 35651.7,
 // EXEC-SAME:   35651.7, 35651.7, 35651.7, 35651.7 )
-//
-// Stats
-// EXEC: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )

--- a/test/Models/resnet50-bottleneck-block.mlir
+++ b/test/Models/resnet50-bottleneck-block.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -n 10 \
+// RUN: tpp-run %s \
 // RUN:         -print -e resnet50_bottleneck_block -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXEC
 
@@ -278,6 +278,3 @@ func.func @resnet50_bottleneck_block(%input : !first_conv1x1_input_tensor_t, %ou
 
 // Output
 // EXEC: ( 75.2923, 75.2923, 75.2923, 75.2923, 75.2923, 75.2923, 75.2923, 75.2923 )
-//
-// Stats
-// EXEC: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -311,7 +311,7 @@ Value MLIRBench::getTimerStats(Value accBuf) {
   // The offset is slightly inaccurate as the buffer lenght already includes
   // the warmup iters. However, the difference is negligible for the chosen
   // max iters and only a few more deltas will be skipped in the worst case
-  // does not impact the overall stats.
+  // which does not impact the overall stats.
   auto offset = getNumWarmupIters(len);
   auto size = builder.create<arith::SubIOp>(unkLoc, len, offset);
   auto stride = builder.create<arith::ConstantIndexOp>(unkLoc, 1);

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -39,8 +39,8 @@
 #include "TPP/TensorInitInt.h"
 #include "mlir/Transforms/Passes.h"
 
-#include <string>
 #include <algorithm>
+#include <string>
 
 using namespace mlir;
 

--- a/tools/tpp-run/MLIRBench.h
+++ b/tools/tpp-run/MLIRBench.h
@@ -51,7 +51,7 @@ struct MLIRBenchConfig {
 /// inteface is a bit weird, but it will get better once we clear the
 /// API design, with time.
 class MLIRBench {
-  static constexpr int numWarmupLoops = 1;
+  static constexpr int numWarmupLoops = 5;
 
   /// MLIR OpBulder
   OpBuilder builder;

--- a/tools/tpp-run/MLIRBench.h
+++ b/tools/tpp-run/MLIRBench.h
@@ -51,6 +51,8 @@ struct MLIRBenchConfig {
 /// inteface is a bit weird, but it will get better once we clear the
 /// API design, with time.
 class MLIRBench {
+  static constexpr int numWarmupLoops = 1;
+
   /// MLIR OpBulder
   OpBuilder builder;
 

--- a/tools/tpp-run/MLIRBench.h
+++ b/tools/tpp-run/MLIRBench.h
@@ -51,7 +51,14 @@ struct MLIRBenchConfig {
 /// inteface is a bit weird, but it will get better once we clear the
 /// API design, with time.
 class MLIRBench {
-  static constexpr int numWarmupLoops = 5;
+  /// Min number of warmup loops
+  static unsigned constexpr minIters = 1;
+
+  /// Max number of warmup loops
+  static unsigned constexpr maxIters = 100;
+
+  /// Target ratio of warmup loops: ( total iterations / warmupRatio )
+  static unsigned constexpr warmupRatio = 10;
 
   /// MLIR OpBulder
   OpBuilder builder;
@@ -125,6 +132,12 @@ public:
   /// Returns the result of a kernel call, which is either
   /// the return value (if any) or the last argument (outs).
   Value getKernelResult(Operation *kernelCall);
+
+  /// Computes compile-time number of warmup iters
+  unsigned getNumWarmupIters(unsigned iters);
+
+  /// Computes runtime number of warmup iters
+  Value getNumWarmupIters(Value iters);
 
   /// Create a benchmarking region around the kernel call
   /// Returns the memref containing measured time deltas

--- a/tools/tpp-run/MLIRBench.h
+++ b/tools/tpp-run/MLIRBench.h
@@ -44,6 +44,24 @@ struct MLIRBenchConfig {
   TensorInitType initType = TensorInitType::Auto;
 };
 
+struct MLIRBenchTimerLoop {
+  MLIRBenchTimerLoop(Value deltas, int numBenchIters, int numWarmupIters)
+      : deltas(deltas), numBenchIters(numBenchIters),
+        numWarmupIters(numWarmupIters), valid(true) {}
+
+  /// Buffer that holds measured time deltas
+  Value deltas;
+
+  /// Number of benchmark iterations
+  int numBenchIters;
+
+  /// Number of warmup iterations
+  int numWarmupIters;
+
+  /// True if the stored buffer is accessible.
+  bool valid;
+};
+
 /// MLIRBench - Creates wrapper for calling kernel methods.
 ///
 /// Note: This class is a mix between a utility class and a driver
@@ -83,6 +101,9 @@ class MLIRBench {
 
   /// Global variables for all arguments (in order)
   llvm::SmallVector<llvm::StringRef> globals;
+
+  /// Benchmarking loops
+  llvm::SmallVector<MLIRBenchTimerLoop> benchLoops;
 
   /// Seed for the random tensor filling
   int seed;
@@ -136,15 +157,13 @@ public:
   /// Computes compile-time number of warmup iters
   unsigned getNumWarmupIters(unsigned iters);
 
-  /// Computes runtime number of warmup iters
-  Value getNumWarmupIters(Value iters);
-
   /// Create a benchmarking region around the kernel call
-  /// Returns the memref containing measured time deltas
-  Value createTimerLoop(unsigned);
+  /// Returns the ID of the created benchmarking loop
+  unsigned createTimerLoop(unsigned);
 
-  /// Get the timer average/deviation
-  Value getTimerStats(Value);
+  /// Get the timer average/deviation of the specified benchmarking loop
+  /// The stored deltas get invalidated afterwards
+  Value getTimerStats(unsigned);
 
   /// Prints a float value (used for mean/dev)
   void printVector(Value);

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -196,17 +196,16 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   if (failed(bench.createKernelArgs()))
     return bench.emitError("Cannot create kernel inputs");
 
-  // Call kernel once, to bootstrap (JIT compile, warm up caches)
-  auto *call = bench.callKernel();
-  if (!call)
-    return bench.emitError("Cannot generate a call to the kernel");
-
-  // Print the result of the warming up, should be the same as any other
-  if (printKernelResult && failed(bench.printResult(call)))
-    return bench.emitError("Cannot print result memref");
-
-  // This is the main loop, if N > 1
-  if (benchNumLoops > 1) {
+  if (benchNumLoops == 1) {
+    // Call kernel once
+    auto *call = bench.callKernel();
+    if (!call)
+      return bench.emitError("Cannot generate a call to the kernel");
+    // Print the result
+    if (printKernelResult && failed(bench.printResult(call)))
+      return bench.emitError("Cannot print result memref");
+  } else {
+    // This is the main loop, if N > 1
     auto acc = bench.createTimerLoop(benchNumLoops);
     if (!acc)
       return bench.emitError("Cannot create timer loop");

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -207,8 +207,6 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   } else {
     // This is the main loop, if N > 1
     auto acc = bench.createTimerLoop(benchNumLoops);
-    if (!acc)
-      return bench.emitError("Cannot create timer loop");
     auto stats = bench.getTimerStats(acc);
     if (!stats)
       return bench.emitError("Cannot get timer stats");


### PR DESCRIPTION
Replaces the initial warmup call with an extra timer loop iteration. This approach simplifies kernel wrapper logic and ensures no extra allocs or copies are required to handle the output of the separate warmup call.

Output printing is disabled for runs with 'n > 1' as the output buffer gets reused on each timer without any guarantees to produce stable results on every iteration. And, in general, there is no need to get both timing results and print output in a single command. This also simplifies generated wrapper code.