### PR TITLE
Benchmarks generic runner

### DIFF
--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -305,6 +305,30 @@ class IrGeneratorRun(BaseRun):
         self.teardown()
         return True
 
+class GenericRun(BaseRun):
+    """ Generic cli runs """
+
+    def __init__(self, name, args, env, json, loglevel):
+        self.logger = Logger("driver.generic", loglevel)
+        BaseRun.__init__(self, name, args, env, json, loglevel)
+        cmd = list()
+        cmd.append(os.path.join(env.bin_dir, self.benchmark[0]))
+        # Split all extra arguments into separate items
+        for val in self.benchmark[1:]:
+            cmd.extend(val.split(" "))
+        self.benchmark = cmd
+
+    def run(self):
+        self.setup()
+        gen_cmd = list()
+        # Generate benchmarking code
+        gen_cmd.extend(self.benchmark)
+        res = self.runner.run(gen_cmd)
+        self.stdout = res.stdout
+        self.stderr = res.stderr
+        self.teardown()
+        return True
+
 class Benchmark(object):
     """ A collection of runs """
 
@@ -324,6 +348,8 @@ class Benchmark(object):
             self.runs.append(XSMMDNNRun(name, self.args, self.env, json, loglevel))
         elif runType == "IR-GEN":
             self.runs.append(IrGeneratorRun(name, self.args, self.env, json, loglevel))
+        elif runType == "GENERIC":
+            self.runs.append(GenericRun(name, self.args, self.env, json, loglevel))
         else:
             self.logger.error(f"Unknown runner type '{runType}'")
             return False

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -313,7 +313,7 @@ class IrGeneratorRun(BaseRun):
         return True
 
 class GenericRun(BaseRun):
-    """ Generic cli runs """
+    """ Generic cli runs - NOTE: user must ensure output correctness """
 
     def __init__(self, name, args, env, json, loglevel):
         self.logger = Logger("driver.generic", loglevel)

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -40,7 +40,14 @@
                  "environment": { "OMP_NUM_THREADS": "32" },
                  "flags": [ "-n", "100" ],
                  "extensions": [ "(avx2|asimd)" ]
-             }
+             },
+             "generic": {
+                 "type": "GENERIC",
+                 "benchmark": [ "binary", "--flag1 --flag2=value -n 100" ],
+                 "environment": {},
+                 "flags": {},
+                 "extensions": [ "(avx2|asimd)" ]
+             },
          },
          "128x256x512":  {
              ...
@@ -321,7 +328,6 @@ class GenericRun(BaseRun):
     def run(self):
         self.setup()
         gen_cmd = list()
-        # Generate benchmarking code
         gen_cmd.extend(self.benchmark)
         res = self.runner.run(gen_cmd)
         self.stdout = res.stdout

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -47,7 +47,7 @@
                  "environment": {},
                  "flags": {},
                  "extensions": [ "(avx2|asimd)" ]
-             },
+             }
          },
          "128x256x512":  {
              ...
@@ -329,6 +329,7 @@ class GenericRun(BaseRun):
         self.setup()
         gen_cmd = list()
         gen_cmd.extend(self.benchmark)
+        # Expects the command to produce correctly formatted output
         res = self.runner.run(gen_cmd)
         self.stdout = res.stdout
         self.stderr = res.stderr


### PR DESCRIPTION
Adds a generic CLI runner to the benchmarks driver.

The new runner allows benchmarks to execute a generic arbitrary command without any extra wrappers.
No postprocessing is applied on the output, the invoked command is expected ensure that the produced output is in correct format.