### PR TITLE
Upload artifacts using TPP-scripts and cleanup pipeline descriptions

### DIFF
--- a/scripts/buildkite/tpp-benchmark.yml
+++ b/scripts/buildkite/tpp-benchmark.yml
@@ -17,8 +17,7 @@ steps:
   - wait
 
   - label: "TPP-MLIR-bench"
-    command: "${SRUN} --partition=clx --time=0:30:00 -- 'KIND=Release COMPILER=clang LINKER=lld CHECK=1 BENCH=1 scripts/buildkite/build_tpp.sh'; \
-        buildkite-agent artifact upload \"$(cd \"$${BUILDKITE_BUILD_PATH}/../artifacts/${BUILDKITE_PIPELINE_SLUG}/$${BUILDKITE_BUILD_NUMBER}\" && pwd)/*\""
+    command: "${SRUN} --partition=clx --time=0:30:00 -- 'KIND=Release COMPILER=clang LINKER=lld CHECK=1 BENCH=1 scripts/buildkite/build_tpp.sh'"
     env:
       LOGRPTSUM: "mlir"
       LOGRPTFMT: "svg pdf"

--- a/scripts/buildkite/tpp-performance.yml
+++ b/scripts/buildkite/tpp-performance.yml
@@ -17,8 +17,7 @@ steps:
   - wait
 
   - label: "TPP-MLIR-performance"
-    command: "${SRUN} --partition=clxtrb --time=1:30:00 -- 'KIND=Release COMPILER=clang LINKER=lld scripts/buildkite/benchmark.sh'; \
-        buildkite-agent artifact upload \"$(cd \"$${BUILDKITE_BUILD_PATH}/../artifacts/${BUILDKITE_PIPELINE_SLUG}/$${BUILDKITE_BUILD_NUMBER}\" && pwd)/*\""
+    command: "${SRUN} --partition=clxtrb --time=1:30:00 -- 'KIND=Release COMPILER=clang LINKER=lld scripts/buildkite/benchmark.sh'"
     env:
       LOGRPTSUM: "mlir"
       LOGRPTBND: "-"


### PR DESCRIPTION
Remove artifact upload command from YAML-pipeline descriptions. Uploading artifacts is handled by TPP-scripts (srun.sh).