### PR TITLE
[Runtime] Expose `stride_a` and `stride_b`

### DIFF
--- a/lib/TPP/ConvertTppToXsmm.cpp
+++ b/lib/TPP/ConvertTppToXsmm.cpp
@@ -136,9 +136,18 @@ getSizesAndLeadingDimsForGemmLikeOp(RewriterBase &rewriter, OpTy opTy) {
   }
   int64_t ldc = *ldcDim;
 
-  DenseI64ArrayAttr dims = DenseI64ArrayAttr::get(
-      rewriter.getContext(), ArrayRef<int64_t>{m, n, k, lda, ldb, ldc});
-  return dims;
+  // If we are dealing with a BRGEMM we need to pass two extra dimensions:
+  // - strideA and strideB that represent the stride between different GEMM
+  // in BRGEMM.
+  if (isBrgemm) {
+    int64_t strideA = lda * m;
+    int64_t strideB = ldb * k;
+    return DenseI64ArrayAttr::get(
+        rewriter.getContext(),
+        ArrayRef<int64_t>{m, n, k, lda, ldb, ldc, strideA, strideB});
+  }
+  return DenseI64ArrayAttr::get(rewriter.getContext(),
+                                ArrayRef<int64_t>{m, n, k, lda, ldb, ldc});
 }
 
 template <typename OpTy>

--- a/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
@@ -309,8 +309,12 @@ static LogicalResult verifyInputs(OpTy op, size_t expected) {
 }
 
 template <typename OpTy> static LogicalResult verifyGemmLikeOp(OpTy op) {
-  // 'inputs' = [m, n, k, lda, ldb, ldc]
-  if (failed(verifyInputs(op, /*expected=*/6)))
+  // 'inputs' = [m, n, k, lda, ldb, ldc] for GEMM.
+  // 'inputs' = [m, n, k, lda, ldb, ldc, stride_a, stride_b] for BRGEMM.
+  bool isBrgemm = isa<BrgemmDispatchOp>(op.getOperation()) ||
+                  isa<FusedBrgemmDispatchOp>(op.getOperation());
+  size_t expected = (isBrgemm) ? 8 : 6;
+  if (failed(verifyInputs(op, expected)))
     return failure();
   return verifyGemmFlags(op.getFlags(), op.getDataType(), op, FLAGS_NAME);
 }

--- a/runtime/XsmmRunnerUtils.h
+++ b/runtime/XsmmRunnerUtils.h
@@ -31,13 +31,14 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_binary_dispatch(
     const libxsmm_meltw_binary_type, const libxsmm_datatype, int64_t, int64_t,
     int64_t, int64_t, int64_t, const libxsmm_meltw_binary_flags);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT int64_t
-xsmm_brgemm_dispatch(const libxsmm_datatype, int64_t, int64_t, int64_t, int64_t,
-                     int64_t, int64_t, const libxsmm_gemm_flags);
+extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_brgemm_dispatch(
+    const libxsmm_datatype, int64_t, int64_t, int64_t, int64_t, int64_t,
+    int64_t, int64_t, int64_t, const libxsmm_gemm_flags);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_fused_brgemm_dispatch(
     const libxsmm_datatype data_type, int64_t m, int64_t n, int64_t k,
-    int64_t lda, int64_t ldb, int64_t ldc, const libxsmm_gemm_flags gemm_flags,
+    int64_t lda, int64_t ldb, int64_t ldc, int64_t stride_a, int64_t stride_b,
+    const libxsmm_gemm_flags gemm_flags,
     const libxsmm_meltw_unary_flags unary_flags,
     const libxsmm_meltw_unary_type unary_op_type,
     const libxsmm_meltw_binary_flags binary_flags,

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-brgemm.mlir
@@ -6,7 +6,7 @@
 func.func @brgemm_to_xsmm(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
                           %arg2: memref<5x5xf32>) {
   // CHECK: %[[BATCH:.+]] = arith.constant 3 : i64
-  // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
+  // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5, 20, 20] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.brgemm(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[BATCH]])
   tpp.brgemm ins(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>, %arg2: memref<5x5xf32>)
              outs(%arg2: memref<5x5xf32>)
@@ -21,7 +21,7 @@ func.func @brgemm_to_xsmm(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
 func.func @vnni_brgemm_to_xsmm(%arg0 : memref<4x256x512xbf16>, %arg1 : memref<4x256x1024x2xbf16>, 
                                %arg2 : memref<256x1024xbf16>) {
   // CHECK: %[[BATCH:.+]] = arith.constant 4 : i64
-  // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [256, 1024, 512, 512, 1024, 1024]  flags = (vnni_b) data_type = bf16
+  // CHECK-NEXT: %[[DISPATCH:.+]] = xsmm.brgemm.dispatch [256, 1024, 512, 512, 1024, 1024, 131072, 524288]  flags = (vnni_b) data_type = bf16
   // CHECK-NEXT: xsmm.brgemm(data_type = bf16, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[BATCH]])
   tpp.brgemm ins(%arg0 : memref<4x256x512xbf16>, %arg1 : memref<4x256x1024x2xbf16>, %arg2 : memref<256x1024xbf16>)
              outs(%arg2 : memref<256x1024xbf16>)
@@ -43,7 +43,7 @@ func.func @brgemm_fused(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
 // CHECK-SAME:  %[[ARG0:.+]]: memref<3x5x4xf32>, %[[ARG1:.+]]: memref<3x4x5xf32>, 
 // CHECK-SAME:  %[[ARG2:.+]]: memref<5x5xf32>, %[[ARG3:.+]]: memref<5x5xf32>
 // CHECK: %[[C3:.+]] = arith.constant 3 : i64
-// CHECK:  %[[DIS:.+]] = xsmm.fused_brgemm.dispatch [5, 5, 4, 4, 5, 5][none,none]  flags = (none)  binary_flags = (none)  unary_flags = (none) data_type = f32
+// CHECK:  %[[DIS:.+]] = xsmm.fused_brgemm.dispatch [5, 5, 4, 4, 5, 5, 20, 20][none,none]  flags = (none)  binary_flags = (none)  unary_flags = (none) data_type = f32
 // CHECK: xsmm.fused_brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[C3]])
 
 // -----
@@ -61,7 +61,7 @@ func.func @brgemm_fused(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>,
 // CHECK-SAME:  %[[ARG0:.+]]: memref<3x5x4xf32>, %[[ARG1:.+]]: memref<3x4x5xf32>, 
 // CHECK-SAME:  %[[ARG2:.+]]: memref<5x5xf32>, %[[ARG3:.+]]: memref<1x5xf32>
 // CHECK: %[[C3:.+]] = arith.constant 3 : i64
-// CHECK: %[[DIS:.+]] = xsmm.fused_brgemm.dispatch [5, 5, 4, 4, 5, 5] 
+// CHECK: %[[DIS:.+]] = xsmm.fused_brgemm.dispatch [5, 5, 4, 4, 5, 5, 20, 20] 
 // CHECK-SAME:  [add,relu]  flags = (none)  binary_flags = (bcast_col_in0)  unary_flags = (none) data_type = f32
 // CHECK: xsmm.fused_brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[C3]])
 
@@ -78,7 +78,7 @@ func.func @brgemm_fused(%arg0 : memref<5x2x2xf32>, %arg1 : memref<5x2x2xf32>,
 
 // TODO remove split after LIBXSMM binary flag is fixed
 // CHECK-LABEL: brgemm_fused
-// CHECK-NOT: xsmm.fused_brgemm.dispatch [2, 2, 2, 2, 2, 2][add,relu]{{.*}}binary_flags = (none)
-// CHECK: xsmm.brgemm.dispatch [2, 2, 2, 2, 2, 2]
+// CHECK-NOT: xsmm.fused_brgemm.dispatch [2, 2, 2, 2, 2, 2, 4, 4][add,relu]{{.*}}binary_flags = (none)
+// CHECK: xsmm.brgemm.dispatch [2, 2, 2, 2, 2, 2, 4, 4]
 // CHECK: xsmm.binary.dispatch add [2, 2, 2, 2, 2]
 // CHECK: xsmm.unary.dispatch relu [2, 2, 2, 2]

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-gemm.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-gemm.mlir
@@ -3,6 +3,12 @@
 // CHECK-LABEL: @gemm_to_xsmm(
 // CHECK-SAME: %[[ARG0:.*]]: memref<3x3xf32>, %[[ARG1:.*]]: memref<3x3xf32>, %[[ARG2:.*]]: memref<3x3xf32>)
 func.func @gemm_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) {
+  // m = 3
+  // n = 3
+  // k = 3
+  // lda = 3
+  // ldb = 3
+  // ldc = 3
   // CHECK: %[[DISPATCH:.*]] = xsmm.gemm.dispatch [3, 3, 3, 3, 3, 3] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.gemm(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]]) 
   tpp.gemm ins(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>) 
@@ -20,5 +26,24 @@ func.func @vnni_gemm_to_xsmm(%arg0: memref<128x1024xbf16>, %arg1: memref<512x204
   // CHECK-NEXT: xsmm.gemm(data_type = bf16, %[[DISPATCH]], %[[ARG0]], %[[ARG1]], %[[ARG2]])
   tpp.gemm ins(%arg0: memref<128x1024xbf16>, %arg1: memref<512x2048x2xbf16>, %arg2: memref<128x2048xbf16>)
            outs(%arg2: memref<128x2048xbf16>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: gemm_to_xsmm_1
+// CHECK-SAME: %[[ARG0:.+]]: memref<4x32xf32>, %[[ARG1:.+]]: memref<4x16xf32>
+// CHECK-SAME: %[[ARG2:.+]]: memref<16x32xf32>
+func.func @gemm_to_xsmm_1(%arg0: memref<4x32xf32>, %arg1: memref<4x16xf32>, %arg2: memref<16x32xf32>) {
+  // m = 4
+  // n = 32
+  // k = 16
+  // lda = 16
+  // ldb = 32
+  // ldc = 32
+  // CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [4, 32, 16, 16, 32, 32] flags = (none) data_type = f32
+  // CHECK-NEXT: xsmm.gemm(data_type = f32, %[[DISPATCH]], %[[ARG1]], %[[ARG2]], %[[ARG0]])  
+  tpp.gemm ins(%arg1: memref<4x16xf32>, %arg2: memref<16x32xf32>, %arg0: memref<4x32xf32>)
+           outs(%arg0: memref<4x32xf32>)
   return
 }

--- a/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
+++ b/test/Conversion/XsmmToFunc/xsmm-to-func.mlir
@@ -16,7 +16,7 @@ func.func @dispatch_unary() -> i64 {
 
 // CHECK-LABEL: dispatch_brgemm
 func.func @dispatch_brgemm() -> i64 {
-  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
+  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5, 5, 5] flags = (none) data_type = f32
   return %0 : i64
 }
 
@@ -24,7 +24,7 @@ func.func @dispatch_brgemm() -> i64 {
 // CHECK-DAG: %[[C5:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
-// CHECK: call @xsmm_brgemm_dispatch(%[[C1]], %[[C5]], %[[C5]], %[[C4]], %[[C4]], %[[C5]], %[[C5]], %[[C0]])
+// CHECK: call @xsmm_brgemm_dispatch(%[[C1]], %[[C5]], %[[C5]], %[[C4]], %[[C4]], %[[C5]], %[[C5]], %[[C5]], %[[C5]], %[[C0]])
 
 // -----
 
@@ -119,7 +119,7 @@ func.func @dispatch_gemm() -> i64 {
 
 func.func @invoke_brgemm(%arg0: memref<2x5x4xf32>, %arg1: memref<2x4x5xf32>,
                            %arg2: memref<4x4xf32>) -> memref<4x4xf32> {
-  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5] flags = (none) data_type = f32
+  %0 = xsmm.brgemm.dispatch [5, 5, 4, 4, 5, 5, 5, 5] flags = (none) data_type = f32
   %c2_i64 = arith.constant 2 : i64
   xsmm.brgemm(data_type = f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x5x4xf32>, memref<2x4x5xf32>, memref<4x4xf32>, i64) -> ()
@@ -226,7 +226,7 @@ func.func @invoke_inplace_relu(%arg0: memref<128x512xbf16>) {
 // -----
 
 func.func @dispatch_fused_brgemm() -> i64 { 
-  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13] [add, relu]
+  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13, 13, 13] [add, relu]
     flags = (vnni_a) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
@@ -239,7 +239,7 @@ func.func @dispatch_fused_brgemm() -> i64 {
 // CHECK-DAG: %[[UNARY_KIND:.+]] = arith.constant 5 : i64
 // CHECK-DAG: %[[BINARY_FLAGS:.+]] = arith.constant 4 : i64
 // CHECK-DAG: %[[BINARY_KIND:.+]] = arith.constant 1 : i64
-// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[DATA_TYPE]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[GEMM_FLAGS]], %[[UNARY_FLAGS]], %[[UNARY_KIND]], %[[BINARY_FLAGS]], %[[BINARY_KIND]])
+// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[DATA_TYPE]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[DIM]], %[[GEMM_FLAGS]], %[[UNARY_FLAGS]], %[[UNARY_KIND]], %[[BINARY_FLAGS]], %[[BINARY_KIND]])
 
 // -----
 
@@ -248,7 +248,7 @@ func.func @dispatch_fused_brgemm() -> i64 {
 // CHECK-LABEL: dispatch_fused_brgemm
 func.func @dispatch_fused_brgemm() -> i64 {
   // CHECK-NOT: xsmm_fused_brgemm.dispatch 
-  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13] [add, relu]
+  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13, 13, 13] [add, relu]
     flags = (vnni_a) binary_flags = (none) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
@@ -256,7 +256,7 @@ func.func @dispatch_fused_brgemm() -> i64 {
 // -----
 
 func.func @dispatch_fused_brgemm() -> i64 { 
-  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13] [add, none]
+  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13, 13, 13] [add, none]
     flags = (vnni_a) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
@@ -268,12 +268,12 @@ func.func @dispatch_fused_brgemm() -> i64 {
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
-// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[C2]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C4096]], %[[C0]], %[[C0]], %[[C4]], %[[C1]])
+// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[C2]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C4096]], %[[C0]], %[[C0]], %[[C4]], %[[C1]])
 
 // -----
 
 func.func @multiple_gemm_flags_fused_brgemm() -> i64 {
-  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13] [add, none]
+  %0 = xsmm.fused_brgemm.dispatch [13, 13, 13, 13, 13, 13, 13, 13] [add, none]
     flags = (vnni_a, vnni_b, vnni_c) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
@@ -286,4 +286,4 @@ func.func @multiple_gemm_flags_fused_brgemm() -> i64 {
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
 // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
-// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[C2]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C14336]], %[[C0]], %[[C0]], %[[C4]], %[[C1]])
+// CHECK: %{{.+}} = call @xsmm_fused_brgemm_dispatch(%[[C2]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C13]], %[[C14336]], %[[C0]], %[[C0]], %[[C4]], %[[C1]])

--- a/test/Dialect/Xsmm/xsmm-invalid.mlir
+++ b/test/Dialect/Xsmm/xsmm-invalid.mlir
@@ -75,7 +75,7 @@ func.func @gemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
   // expected-error@+1 {{VNNI flags but type is not bf16}}
-  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_a) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (vnni_a) data_type = f32
   return %0 : i64
 }
 
@@ -84,7 +84,7 @@ func.func @brgemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
   // expected-error@+1 {{VNNI flags but type is not bf16}}
-  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_b) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (vnni_b) data_type = f32
   return %0 : i64
 }
 
@@ -93,7 +93,7 @@ func.func @brgemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
   // expected-error@+1 {{VNNI flags but type is not bf16}}
-  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_c) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (vnni_c) data_type = f32
   return %0 : i64
 }
 
@@ -102,7 +102,7 @@ func.func @brgemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
   // expected-error@+1 {{VNNI flags but type is not bf16}}
-  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_a, vnni_c) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (vnni_a, vnni_c) data_type = f32
   return %0 : i64
 }
 
@@ -111,7 +111,7 @@ func.func @brgemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
   // expected-error@+1 {{expected flags to be unique}}
-  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_a, vnni_a) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (vnni_a, vnni_a) data_type = f32
   return %0 : i64
 }
 
@@ -120,7 +120,7 @@ func.func @brgemm_dispatch() -> i64 {
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
   // expected-error@+1 {{'none' flags conflicts with others}}
-  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (none, vnni_a) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (none, vnni_a) data_type = f32
   return %0 : i64
 }
 
@@ -128,7 +128,7 @@ func.func @brgemm_dispatch() -> i64 {
 
 // CHECK-LABEL: func.func @brgemm_dispatch
 func.func @brgemm_dispatch() -> i64 {
-  // expected-error@+1 {{expect 6 args but got: 5}}
+  // expected-error@+1 {{expect 8 args but got: 5}}
   %0 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2] flags = (none) data_type = f32
   return %0 : i64
 }
@@ -200,7 +200,7 @@ func.func @ternary_dispatch() -> i64 {
 
 // CHECK-LABEL: func.func @fused_dispatch
 func.func @fused_dispatch() -> i64 {
-  // expected-error@+1 {{op expect 6 args but got: 3}}
+  // expected-error@+1 {{op expect 8 args but got: 3}}
   %0 = xsmm.fused_brgemm.dispatch [3, 2, 1] [add, relu] 
     flags = (none) binary_flags = (none) unary_flags = (none) data_type = f32
   return %0 : i64
@@ -211,7 +211,7 @@ func.func @fused_dispatch() -> i64 {
 // CHECK-LABEL: func.func @fused_dispatch
 func.func @fused_dispatch() -> i64 {
   // expected-error@+1 {{op expected flags to be unique}}
-  %0 = xsmm.fused_brgemm.dispatch [3, 2, 1, 1, 1, 1] [add, relu] 
+  %0 = xsmm.fused_brgemm.dispatch [3, 2, 1, 1, 1, 1, 1, 1] [add, relu] 
     flags = (vnni_a, vnni_a) binary_flags = (none) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
@@ -241,7 +241,7 @@ func.func @fused_dispatch() -> i64 {
 // CHECK-LABEL: func.func @fused_brgemm_none_kind_with_flags
 func.func @fused_brgemm_none_kind_with_flags() -> i64 {
   // expected-error@+1 {{invalid binary flags for kind none}}
-   %0 = xsmm.fused_brgemm.dispatch [3, 2, 1, 1, 1, 1] [none, relu]
+   %0 = xsmm.fused_brgemm.dispatch [3, 2, 1, 1, 1, 1, 1, 1] [none, relu]
     flags = (vnni_a) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = bf16
   return %0 : i64
 }
@@ -251,7 +251,7 @@ func.func @fused_brgemm_none_kind_with_flags() -> i64 {
 // CHECK-LABEL: func.func @fused_brgemm_none_kind_with_flags
 func.func @fused_brgemm_none_kind_with_flags() -> i64 {
   // expected-error@+1 {{invalid unary flags for kind none}}
-   %0 = xsmm.fused_brgemm.dispatch [3, 2, 1, 1, 1, 1] [none, none]
+   %0 = xsmm.fused_brgemm.dispatch [3, 2, 1, 1, 1, 1, 1, 1] [none, none]
     flags = (vnni_a) binary_flags = (none) unary_flags = (bcast_scalar) data_type = bf16
   return %0 : i64
 }

--- a/test/Dialect/Xsmm/xsmm-ops.mlir
+++ b/test/Dialect/Xsmm/xsmm-ops.mlir
@@ -35,13 +35,13 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
   // CHECK-NEXT: xsmm.gemm.dispatch
   %5 = xsmm.gemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_a, vnni_b) data_type = bf16
   // CHECK-NEXT: xsmm.brgemm.dispatch
-  %6 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (vnni_a, vnni_b) data_type = bf16
+  %6 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (vnni_a, vnni_b) data_type = bf16
   // CHECK-NEXT: xsmm.brgemm.dispatch
-  %7 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (beta_0) data_type = bf16
+  %7 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (beta_0) data_type = bf16
   // CHECK-NEXT: xsmm.brgemm.dispatch
-  %8 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (beta_0) data_type = f32
+  %8 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (beta_0) data_type = f32
   // CHECK-NEXT: xsmm.brgemm.dispatch
-  %9 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1] flags = (none) data_type = f32
+  %9 = xsmm.brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] flags = (none) data_type = f32
   // CHECK: xsmm.gemm.dispatch {{.*}} {myAttr = "myattr"}
   %10 = xsmm.gemm.dispatch [3, 2, 1, 3, 2, 1] flags = (none) data_type = f32 {myAttr = "myattr"}
 
@@ -49,7 +49,7 @@ func.func @xsmm_dialect(%arg0: memref<2x2xf32>,
   %11 = xsmm.unary.dispatch zero [2, 2, 2, 2] flags = (none) data_type = f32
   
   // CHECK: xsmm.fused_brgemm.dispatch
-  %12 = xsmm.fused_brgemm.dispatch [3, 2, 1, 3, 2, 1] [add, relu]
+  %12 = xsmm.fused_brgemm.dispatch [3, 2, 1, 3, 2, 1, 1, 1] [add, relu]
     flags = (beta_0) binary_flags = (none) unary_flags = (none) data_type = f32
 
   // CHECK: xsmm.unary zero

--- a/test/Integration/xsmm-quarternary.mlir
+++ b/test/Integration/xsmm-quarternary.mlir
@@ -3,7 +3,7 @@
 
 func.func @entry(%arg0: memref<64x4x4xf32>, %arg1: memref<64x2x4x2xf32>, %arg2: memref<4x4xf32>, %arg3: memref<4xf32>) {
   %c16_i64 = arith.constant 16 : i64
-  %func = xsmm.fused_brgemm.dispatch [4, 4, 4, 4, 4, 4][add, relu]
+  %func = xsmm.fused_brgemm.dispatch [4, 4, 4, 4, 4, 4, 8, 8][add, relu]
     flags = (none) binary_flags = (bcast_col_in0) unary_flags = (none) data_type = f32
   xsmm.fused_brgemm(data_type = f32, %func, %arg0, %arg1, %arg2, %arg3, %c16_i64) : (i64, memref<64x4x4xf32>, memref<64x2x4x2xf32>, memref<4x4xf32>, memref<4xf32>, i64) -> ()
 

--- a/test/Integration/xsmm-ternary.mlir
+++ b/test/Integration/xsmm-ternary.mlir
@@ -4,7 +4,7 @@
 
 func.func @entry(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: memref<3x3xf32>) {
   %c2_i64 = arith.constant 2 : i64
-  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3] flags = (none) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3, 12, 12] flags = (none) data_type = f32
   xsmm.brgemm(data_type = f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 

--- a/test/Passes/DefaultPipeline/xsmm.mlir
+++ b/test/Passes/DefaultPipeline/xsmm.mlir
@@ -202,7 +202,7 @@ func.func @brgemm(%arg0: memref<2x3x4xf32>, %arg1: memref<2x4x3xf32>, %arg2: mem
  
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[llvm_ptr0]], %[[C0]], %[[llvm_ptr1]], %[[C0]], %[[llvm_ptr2]], %[[C0]]
   %c2_i64 = arith.constant 2 : i64
-  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3] flags = (none) data_type = f32
+  %0 = xsmm.brgemm.dispatch [3, 3, 4, 4, 3, 3, 12, 12] flags = (none) data_type = f32
   xsmm.brgemm(data_type = f32, %0, %arg0, %arg1, %arg2, %c2_i64) 
     : (i64, memref<2x3x4xf32>, memref<2x4x3xf32>, memref<3x3xf32>, i64) -> ()
 
@@ -234,7 +234,7 @@ func.func @brgemm_bf16(%arg0: memref<64x4x4xbf16>, %arg1: memref<64x2x4x2xbf16>,
 
   // CHECK: call @xsmm_brgemm_invoke({{.*}}%[[llvm_ptr0]], %[[C0]], %[[llvm_ptr1]], %[[C0]], %[[llvm_ptr2]], %[[C0]]
   %c64_i64 = arith.constant 64 : i64
-  %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4] flags = (vnni_b) data_type = bf16
+  %0 = xsmm.brgemm.dispatch [4, 4, 4, 4, 4, 4, 16, 16] flags = (vnni_b) data_type = bf16
   xsmm.brgemm(data_type = bf16, %0, %arg0, %arg1, %arg2, %c64_i64) 
     : (i64, memref<64x4x4xbf16>, memref<64x2x4x2xbf16>, memref<4x4xbf16>, i64) -> ()
 
@@ -323,7 +323,7 @@ func.func @blocked_matmul(%arg0: memref<4x16x32x32xf32>, %arg1: memref<8x16x32x3
     %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : memref<4x16x32x32xf32> to memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>
     %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : memref<8x16x32x32xf32> to memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>
     %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<4x8x32x32xf32> to memref<32x32xf32, strided<[32, 1], offset: ?>>
-    %0 = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32] flags = (none) data_type = f32
+    %0 = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32, 1024, 1024] flags = (none) data_type = f32
     xsmm.brgemm(data_type = f32, %0, %subview, %subview_0, %subview_1, %c16_i64) 
       : (i64, memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>, 
          memref<16x32x32xf32, strided<[1024, 32, 1], offset: ?>>,


### PR DESCRIPTION
These dimensions represent the "distance" between different GEMMs in the BRGEMM kernel. Until now, in the runtime, we assumed that the BRGEMM dimensions were contiguous for all the operands (i.e., [B][I][K] * [B][K][J]). Relax this restriction and shift the computation into the compiler.