### PR TITLE
Avoid to include src/template/libxsmm_version.h and fix #566

### DIFF
--- a/cmake/modules/xsmm.cmake
+++ b/cmake/modules/xsmm.cmake
@@ -34,13 +34,10 @@ set(XSMM_INCLUDE_DIRS ${LIBXSMMROOT}/include)
 
 add_library(xsmm STATIC ${XSMM_SRCS})
 target_include_directories(xsmm PUBLIC ${XSMM_INCLUDE_DIRS})
-target_compile_definitions(xsmm PUBLIC
-  LIBXSMM_DEFAULT_CONFIG
-)
 target_compile_definitions(xsmm PRIVATE
   __BLAS=0
 )
-add_definitions(-U_DEBUG)
+add_definitions(-DLIBXSMM_DEFAULT_CONFIG -U_DEBUG)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/cmake/modules/xsmm.cmake
+++ b/cmake/modules/xsmm.cmake
@@ -13,8 +13,8 @@ else()
 
   FetchContent_Declare(
     xsmm
-    URL https://github.com/libxsmm/libxsmm/archive/a05271bb302deecd59ddff2360237b4058a39283.tar.gz
-    URL_HASH SHA256=219f25fabbf179d203b7c32edcc7262d7afe20de63533a08958d2150b9996ac3
+    URL https://github.com/libxsmm/libxsmm/archive/087c91435cdf0fa8aa023c2e19fe7ae55d04808e.tar.gz
+    URL_HASH SHA256=d5047880a29bd2367cd7c65e45cfcc2652d2c6548af3deaab8fad5c0fe80c679
   )
 
   FetchContent_GetProperties(xsmm)

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -69,7 +69,6 @@ add_mlir_library(MLIRTPP
 target_include_directories(MLIRTPP
   PUBLIC
     $<BUILD_INTERFACE:${XSMM_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${XSMM_INCLUDE_DIRS}/../src/template>
     $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
 )


### PR DESCRIPTION
Addressed #566. Including src/template/libxsmm_version.h is wrong since the header file is not valid C/C++ code.

The issue seems to stem from `target_compile_definitions` like `-DLIBXSMM_DEFAULT_CONFIG` not being propagated to code using LIBXSMM (even when this definition was marked as `PUBLIC`). Apparently, `-DLIBXSMM_DEFAULT_CONFIG` previously only applied when compiling LIBXSMM's code (separate static library). The issue might be a wrong perception of how to reuse code compiled into a separate library.