### PR TITLE
Adjusted Python linter script

### DIFF
--- a/scripts/ci/lint-python.sh
+++ b/scripts/ci/lint-python.sh
@@ -15,7 +15,11 @@ LINTER=$(command -v black)
 if [ "${LINTER}" ]; then
   FLAKE8=$(command -v flake8)
   FLAKE8_IGNORE="--ignore=E402,E501,F821"
-  COUNT=0; OK=0
+
+  # Check if Flake8 actually works
+  if [ "${FLAKE8}" ] && ! ${FLAKE8} 2>/dev/null; then
+    unset FLAKE8
+  fi
 
   # If -i is passed, format all files according to type/pattern.
   if [ "-i" != "$1" ]; then
@@ -24,6 +28,7 @@ if [ "${LINTER}" ]; then
     LINTER_FLAGS="-l 79 -q"
   fi
 
+  COUNT=0; OK=0
   echo -n "Linting Python files... "
   cd "${REPOROOT}" || exit 1
   for FILE in $(eval "git ls-files ${PATTERN}"); do

--- a/scripts/ci/lint-python.sh
+++ b/scripts/ci/lint-python.sh
@@ -56,7 +56,7 @@ if [ "${LINTER}" ]; then
     echo "${WARNINGS}"
     echo
   else
-    echo "OK (${OK} files)"
+    echo "OK (${OK} files processed)"
   fi
 else  # soft error (exit normally)
   echo "ERROR: missing Python-linter (${LINTER})."


### PR DESCRIPTION
The issue solved by the PR may not only apply to the optional Flake8 validation package (Python linter script), but other Python packages installed into user's local environment. Apparently some Python package rely on a hard-coded Shebang line (Python interpreter) instead of using `#!/usr/bin/env python3` (like Flake8). When source'ing a different Python interpreter/version, such user-installed package can end up complaining about missing components and require to be reinstalled.