### PR TITLE
Add pass to decompose aggregated operations

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -157,6 +157,7 @@ createSetSPIRVAbiAttributePass(StringRef api = "vulkan");
 std::unique_ptr<OperationPass<ModuleOp>>
 createGpuVulkanAbiPass(bool use64bitIndex = false);
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertLinalgToXsmmPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createDecomposeAggregatedOpsPass();
 
 // Testing passes.
 void registerTestStructuralMatchers();

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -509,4 +509,12 @@ def GpuVulkanAbi : Pass<"gpu-vulkan-abi", "ModuleOp"> {
   ];
 }
 
+def DecomposeAggregatedOps : Pass<"decompose-aggregated-ops", "func::FuncOp"> {
+  let summary = "Decompose aggregated operations.";
+  let description = [{
+    Decompose operations that implement the `AggregatedOpInterface`.
+  }];
+  let constructor = "mlir::tpp::createDecomposeAggregatedOpsPass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_library(MLIRTPP
     ConvertMemRefToTpp.cpp
     DefaultPipeline.cpp
     ConvertLinalgToXsmm.cpp
+    DecomposeAggregatedOps.cpp
 
   # Utils
     MatcherUtils.cpp

--- a/lib/TPP/DecomposeAggregatedOps.cpp
+++ b/lib/TPP/DecomposeAggregatedOps.cpp
@@ -1,0 +1,53 @@
+//===- DecomposeAggregatedOps.cpp --------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+#define GEN_PASS_CLASSES
+#include "TPP/Passes.h.inc"
+
+namespace {
+
+struct DecomposeAggregateOpsImpl : public OpRewritePattern<linalg::SoftmaxOp> {
+  using OpRewritePattern<linalg::SoftmaxOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::SoftmaxOp softmaxOp,
+                                PatternRewriter &rewriter) const override {
+    auto decomposableOp =
+        cast<linalg::AggregatedOpInterface>(softmaxOp.getOperation());
+    if (!decomposableOp)
+      return failure();
+    FailureOr<SmallVector<Value>> maybeNewResult =
+        decomposableOp.decomposeOperation(rewriter);
+    if (failed(maybeNewResult))
+      return failure();
+    rewriter.replaceOp(softmaxOp, *maybeNewResult);
+    return success();
+  }
+};
+
+struct DecomposeAggregatedOps
+    : public DecomposeAggregatedOpsBase<DecomposeAggregatedOps> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(getOperation().getContext());
+    patterns.add<DecomposeAggregateOpsImpl>(patterns.getContext());
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::tpp::createDecomposeAggregatedOpsPass() {
+  return std::make_unique<DecomposeAggregatedOps>();
+}

--- a/lib/TPP/DecomposeAggregatedOps.cpp
+++ b/lib/TPP/DecomposeAggregatedOps.cpp
@@ -25,8 +25,6 @@ struct DecomposeAggregateOpsImpl : public OpRewritePattern<linalg::SoftmaxOp> {
                                 PatternRewriter &rewriter) const override {
     auto decomposableOp =
         cast<linalg::AggregatedOpInterface>(softmaxOp.getOperation());
-    if (!decomposableOp)
-      return failure();
     FailureOr<SmallVector<Value>> maybeNewResult =
         decomposableOp.decomposeOperation(rewriter);
     if (failed(maybeNewResult))

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -405,6 +405,7 @@ private:
       // Skip all TPP transformations.
       // Generalize tensor.pack and tensor.unpack.
       pm.addPass(createGeneralizeTensorPackAndUnPackPass());
+      pm.addNestedPass<func::FuncOp>(createDecomposeAggregatedOpsPass());
       pm.addPass(createBufferizePass());
       pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
@@ -429,6 +430,12 @@ private:
       pm.addNestedPass<func::FuncOp>(createTppConversionPass());
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
+      // Decompose Aggregated operations. These ops currently do not
+      // bufferize. Once this is possible we can move this pass after
+      // bufferization.
+      pm.addNestedPass<func::FuncOp>(createDecomposeAggregatedOpsPass());
+
+      // Bufferize: tensor->memref.
       pm.addPass(createBufferizePass());
 
       // Convert forAll to parallel loops should run after bufferization

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -426,14 +426,14 @@ private:
       pm.addPass(createTppMappingPass());
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
-      // Lower operations to TPP.
-      pm.addNestedPass<func::FuncOp>(createTppConversionPass());
-      pm.addNestedPass<func::FuncOp>(createCleanupPass());
-
       // Decompose Aggregated operations. These ops currently do not
       // bufferize. Once this is possible we can move this pass after
       // bufferization.
       pm.addNestedPass<func::FuncOp>(createDecomposeAggregatedOpsPass());
+
+      // Lower operations to TPP.
+      pm.addNestedPass<func::FuncOp>(createTppConversionPass());
+      pm.addNestedPass<func::FuncOp>(createCleanupPass());
 
       // Bufferize: tensor->memref.
       pm.addPass(createBufferizePass());

--- a/test/Passes/DefaultPipeline/linalg-tensor.mlir
+++ b/test/Passes/DefaultPipeline/linalg-tensor.mlir
@@ -209,3 +209,14 @@ func.func @mlp(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
 
   return %3 : tensor<128x512xf32>
 }
+
+// -----
+
+// CHECK-LABEL: softmax
+func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // CHECK-NOT: linalg.softmax
+  // CHECK-COUNT-4: linalg.generic
+  %softmax = linalg.softmax dimension(3) 
+    ins(%arg0: tensor<2x2x2x2xf32>) outs(%arg1: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32>
+  return %softmax : tensor<2x2x2x2xf32>
+}

--- a/test/Passes/DefaultPipeline/linalg-to-loops.mlir
+++ b/test/Passes/DefaultPipeline/linalg-to-loops.mlir
@@ -210,3 +210,13 @@ func.func @mlp(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
 
   return %3 : tensor<128x512xf32>
 }
+
+// -----
+
+// CHECK-LABEL: softmax
+func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // CHECK-NOT: linalg.softmax
+  %softmax = linalg.softmax dimension(3) 
+    ins(%arg0: tensor<2x2x2x2xf32>) outs(%arg1: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32>
+  return %softmax : tensor<2x2x2x2xf32>
+}

--- a/test/Passes/DefaultPipeline/tpp.mlir
+++ b/test/Passes/DefaultPipeline/tpp.mlir
@@ -310,44 +310,42 @@ func.func @conv2d_1x1(%arg0: memref<1x7x7x2048xf32>) -> memref<1x7x7x512xf32> {
 // CHECK-SAME:  %[[ARG1:.+]]: memref<256x512xf32>,
 // CHECK-SAME:  %[[ARG2:.+]]: memref<512xf32>,
 // CHECK-SAME:  %[[ARG3:.+]]: memref<128x512xf32>)
-module @predict_function  {
-  func.func @mlp(%arg0: memref<128x256xf32>, %arg1: memref<256x512xf32>,
-    %arg2: memref<512xf32>,  %arg3: memref<128x512xf32>) {
+func.func @mlp(%arg0: memref<128x256xf32>, %arg1: memref<256x512xf32>,
+  %arg2: memref<512xf32>,  %arg3: memref<128x512xf32>) {
 
-    // CHECK: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK: %[[C0:.*]] = arith.constant 0 : index
 
-    // Identity
-    // CHECK: call @xsmm_unary_dispatch
-    // CHECK: %[[ptr0:.*]] = memref.extract_aligned_pointer_as_index %[[ARG2]]
-    // CHECK-NEXT: %[[ptr_cast0:.*]] = arith.index_cast %[[ptr0]] : index to i64
-    // CHECK-NEXT: %[[llvm_ptr0:.*]] = llvm.inttoptr %[[ptr_cast0]] : i64 to !llvm.ptr<f32>
+  // Identity
+  // CHECK: call @xsmm_unary_dispatch
+  // CHECK: %[[ptr0:.*]] = memref.extract_aligned_pointer_as_index %[[ARG2]]
+  // CHECK-NEXT: %[[ptr_cast0:.*]] = arith.index_cast %[[ptr0]] : index to i64
+  // CHECK-NEXT: %[[llvm_ptr0:.*]] = llvm.inttoptr %[[ptr_cast0]] : i64 to !llvm.ptr<f32>
 
-    // CHECK: %[[ptr1:.*]] = memref.extract_aligned_pointer_as_index %[[ARG3]]
-    // CHECK-NEXT: %[[ptr_cast1:.*]] = arith.index_cast %[[ptr1]] : index to i64
-    // CHECK-NEXT: %[[llvm_ptr1:.*]] = llvm.inttoptr %[[ptr_cast1]] : i64 to !llvm.ptr<f32>
+  // CHECK: %[[ptr1:.*]] = memref.extract_aligned_pointer_as_index %[[ARG3]]
+  // CHECK-NEXT: %[[ptr_cast1:.*]] = arith.index_cast %[[ptr1]] : index to i64
+  // CHECK-NEXT: %[[llvm_ptr1:.*]] = llvm.inttoptr %[[ptr_cast1]] : i64 to !llvm.ptr<f32>
 
-    // CHECK: call @xsmm_unary_invoke({{.*}}%[[llvm_ptr0]], %[[C0]], %[[llvm_ptr1]], %[[C0]]
-    tpp.identity ins(%arg2 : memref<512xf32>) outs(%arg3 : memref<128x512xf32>)
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[llvm_ptr0]], %[[C0]], %[[llvm_ptr1]], %[[C0]]
+  tpp.identity ins(%arg2 : memref<512xf32>) outs(%arg3 : memref<128x512xf32>)
 
-    // Matmul
-    // CHECK: call @xsmm_gemm_dispatch
-    // CHECK: %[[ptr2:.*]] = memref.extract_aligned_pointer_as_index %[[ARG0]]
-    // CHECK-NEXT: %[[ptr_cast2:.*]] = arith.index_cast %[[ptr2]] : index to i64
-    // CHECK-NEXT: %[[llvm_ptr2:.*]] = llvm.inttoptr %[[ptr_cast2]] : i64 to !llvm.ptr<f32>
+  // Matmul
+  // CHECK: call @xsmm_gemm_dispatch
+  // CHECK: %[[ptr2:.*]] = memref.extract_aligned_pointer_as_index %[[ARG0]]
+  // CHECK-NEXT: %[[ptr_cast2:.*]] = arith.index_cast %[[ptr2]] : index to i64
+  // CHECK-NEXT: %[[llvm_ptr2:.*]] = llvm.inttoptr %[[ptr_cast2]] : i64 to !llvm.ptr<f32>
     
-    // CHECK: %[[ptr3:.*]] = memref.extract_aligned_pointer_as_index %[[ARG1]]
-    // CHECK-NEXT: %[[ptr_cast3:.*]] = arith.index_cast %[[ptr3]] : index to i64
-    // CHECK-NEXT: %[[llvm_ptr3:.*]] = llvm.inttoptr %[[ptr_cast3]] : i64 to !llvm.ptr<f32>
+  // CHECK: %[[ptr3:.*]] = memref.extract_aligned_pointer_as_index %[[ARG1]]
+  // CHECK-NEXT: %[[ptr_cast3:.*]] = arith.index_cast %[[ptr3]] : index to i64
+  // CHECK-NEXT: %[[llvm_ptr3:.*]] = llvm.inttoptr %[[ptr_cast3]] : i64 to !llvm.ptr<f32>
 
-    // CHECK: call @xsmm_gemm_invoke({{.*}}%[[llvm_ptr2]], %[[C0]], %[[llvm_ptr3]], %[[C0]], %[[llvm_ptr1]], %[[C0]]
-    tpp.gemm ins(%arg0 : memref<128x256xf32>, %arg1 : memref<256x512xf32>, %arg3 : memref<128x512xf32>) 
-               outs(%arg3 : memref<128x512xf32>)
+  // CHECK: call @xsmm_gemm_invoke({{.*}}%[[llvm_ptr2]], %[[C0]], %[[llvm_ptr3]], %[[C0]], %[[llvm_ptr1]], %[[C0]]
+  tpp.gemm ins(%arg0 : memref<128x256xf32>, %arg1 : memref<256x512xf32>, %arg3 : memref<128x512xf32>) 
+           outs(%arg3 : memref<128x512xf32>)
 
-    // Relu
-    // CHECK: call @xsmm_unary_dispatch
-    // CHECK: call @xsmm_unary_invoke({{.*}}%[[llvm_ptr1]], %[[C0]], %[[llvm_ptr1]], %[[C0]]
-    tpp.relu ins(%arg3 : memref<128x512xf32>) outs(%arg3 : memref<128x512xf32>)
+  // Relu
+  // CHECK: call @xsmm_unary_dispatch
+  // CHECK: call @xsmm_unary_invoke({{.*}}%[[llvm_ptr1]], %[[C0]], %[[llvm_ptr1]], %[[C0]]
+  tpp.relu ins(%arg3 : memref<128x512xf32>) outs(%arg3 : memref<128x512xf32>)
 
-    return
-  }
+  return
 }

--- a/test/Passes/decompose-aggregated-ops.mlir
+++ b/test/Passes/decompose-aggregated-ops.mlir
@@ -1,0 +1,10 @@
+// RUN: tpp-opt %s -decompose-aggregated-ops | FileCheck %s
+
+// CHECK-LABEL: softmax
+func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32> {
+  // CHECK-NOT: linalg.softmax
+  // CHECK-COUNT-4: linalg.generic
+  %softmax = linalg.softmax dimension(3)
+    ins(%arg0: tensor<2x2x2x2xf32>) outs(%arg1: tensor<2x2x2x2xf32>) -> tensor<2x2x2x2xf32>
+  return %softmax : tensor<2x2x2x2xf32>
+}


### PR DESCRIPTION
Needed for softmax. Remove module from the mlp test in `tpp.mlir`.