### PR TITLE
Cleanup `getDataType` in XSMM and tile and fuse (NFC)

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmUtils.h
+++ b/include/TPP/Dialect/Xsmm/XsmmUtils.h
@@ -1,0 +1,27 @@
+//===- XsmmUtils.h - --------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef XSMM_DIALECT_XSMM_XSMMUTILS_H
+#define XSMM_DIALECT_XSMM_XSMMUTILS_H
+
+#include "TPP/Dialect/Xsmm/XsmmEnum.h"
+
+namespace mlir {
+class Type;
+class RewriterBase;
+
+namespace xsmm {
+namespace utils {
+
+xsmm::DataTypeAttr getDataType(RewriterBase &rewriter, Type type);
+
+} // namespace utils
+} // namespace xsmm
+} // namespace mlir
+
+#endif // XSMM_DIALECT_XSMM_XSMMUTILS_H

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -218,6 +218,8 @@ def TileConsumerAndFuseProducers : Pass<"tile-consumer-and-fuse-producers",
            "true", "Fuse from the last fusable consumer of the current target">,
     Option<"useForAll", "use-for-all", "bool", "true", "Use parallel forAll">
   ];
+  let dependentDialects = ["linalg::LinalgDialect", "scf::SCFDialect",
+                           "tensor::TensorDialect"];
 }
 
 def RewriteConvToMatmulOrBrgemm : Pass<"rewrite-conv-to-matmul-or-brgemm", 

--- a/lib/TPP/Dialect/Xsmm/CMakeLists.txt
+++ b/lib/TPP/Dialect/Xsmm/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_dialect_library(TPPXsmmDialect
     XsmmEnum.cpp
     XsmmDialect.cpp
     XsmmOps.cpp
+    XsmmUtils.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -1,0 +1,27 @@
+//===- XsmmUtils.cpp ---------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Xsmm/XsmmUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+
+namespace mlir {
+namespace xsmm {
+namespace utils {
+
+xsmm::DataTypeAttr getDataType(RewriterBase &rewriter, Type type) {
+  auto elemType = getElementTypeOrSelf(type);
+  if (elemType.isBF16())
+    return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::BF16);
+  assert(elemType.isF32() && "Element type neither bf16 nor f32");
+  return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::F32);
+}
+
+} // namespace utils
+} // namespace xsmm
+} // namespace mlir

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -668,10 +668,6 @@ struct TileConsumerAndFuseProducers
   TileConsumerAndFuseProducers(ArrayRef<int64_t> tileSizes) {
     this->tileSizes = tileSizes;
   }
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<scf::SCFDialect>();
-    linalg::registerTilingInterfaceExternalModels(registry);
-  }
   void runOnOperation() override {
     auto &ctx = getContext();
 


### PR DESCRIPTION
- `getDataType` is now an utils. Need as utils for later patches.

- Use .td to specify dialects deps for tile and fuse.