### PR TITLE
Follow-up after 3d1d0b372a6befe664969b0a16c2ebc73ecbc7cf

### DIFF
--- a/lib/TPP/MatcherUtils.cpp
+++ b/lib/TPP/MatcherUtils.cpp
@@ -50,8 +50,8 @@ static bool isTppOp(linalg::LinalgOp linalgOp) {
       .output(MatchAll(), HasStaticShape())
       .input(MatchAll(), HasStaticShape())
       .operation(NumRegions(EqualsTo(1)))
-      .output(MatchAll(), HasStaticShape())
-      .input(MatchAll(), HasStaticShape())
+      .output(MatchAll(), HasStaticStrides())
+      .input(MatchAll(), HasStaticStrides())
       .operation(VerifyOpProperty(hasEqualOperandTypes));
   // clang-format on
   return tppMatcher.match(linalgOp);


### PR DESCRIPTION
Fix small typo in `isTppOp`.