### PR TITLE
Enable GPU threading through tiling

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -110,7 +110,10 @@ createPackConv2DNchwFchwPass(ArrayRef<int64_t> blockingFactors = {});
 std::unique_ptr<OperationPass<func::FuncOp>>
 createPackConv2DNhwcHwcfPass(ArrayRef<int64_t> blockingFactors = {});
 std::unique_ptr<OperationPass<func::FuncOp>>
-createTileConsumerAndFuseProducersPass();
+createTileConsumerAndFuseProducersPass(ArrayRef<int64_t> tileSizes = {},
+                                       int maxDepth = 5,
+                                       bool startFromLastFusableConsumer = true,
+                                       bool useForAll = true);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createRewriteConvToMatmulOrBrgemmPass();
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -109,6 +109,16 @@ private:
   void constructPipeline() override {
     pm.clear();
 
+    // Typically there max number of threads per block is 1024.
+    // For 2D tiles, use max 32 threads per dimension.
+    constexpr int maxNumThreadsPerDim = 32;
+
+    // Tile to split the kernel into threads and blocks
+    pm.addPass(createCleanupPass());
+    pm.addPass(createTileConsumerAndFuseProducersPass(
+        /*tileSizes=*/{maxNumThreadsPerDim, maxNumThreadsPerDim}));
+    pm.addPass(createCleanupPass());
+
     // Preprocess and bufferize as further conversion requires memref
     // abstraction.
     pm.addPass(createGeneralizeTensorPackAndUnPackPass());

--- a/lib/TPP/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/TileConsumerAndFuseProducers.cpp
@@ -666,8 +666,13 @@ static Operation *getLastFusableEltWiseConsumer(
 struct TileConsumerAndFuseProducers
     : TileConsumerAndFuseProducersBase<TileConsumerAndFuseProducers> {
   TileConsumerAndFuseProducers() = default;
-  TileConsumerAndFuseProducers(ArrayRef<int64_t> tileSizes) {
+  TileConsumerAndFuseProducers(ArrayRef<int64_t> tileSizes, int maxDepth,
+                               bool startFromLastFusableConsumer,
+                               bool useForAll) {
     this->tileSizes = tileSizes;
+    this->maxDepth = maxDepth;
+    this->startFromLastFusableConsumer = startFromLastFusableConsumer;
+    this->useForAll = useForAll;
   }
 
   void runOnOperation() override {
@@ -815,8 +820,11 @@ struct ElementWiseFusion : ElementWiseFusionBase<ElementWiseFusion> {
 } // end namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::tpp::createTileConsumerAndFuseProducersPass() {
-  return std::make_unique<TileConsumerAndFuseProducers>();
+mlir::tpp::createTileConsumerAndFuseProducersPass(
+    ArrayRef<int64_t> tileSizes, int maxDepth,
+    bool startFromLastFusableConsumer, bool useForAll) {
+  return std::make_unique<TileConsumerAndFuseProducers>(
+      tileSizes, maxDepth, startFromLastFusableConsumer, useForAll);
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>


### PR DESCRIPTION
Adds tiling to the GPU pipeline to allow kernel outlining to create more optimal kernel split into blocks and threads.