### PR TITLE
Linalg to XSMM: BrgemmOp conversion

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -63,7 +63,8 @@ def ConvertLinalgToXsmm : Pass<"convert-linalg-to-xsmm", "func::FuncOp"> {
   let dependentDialects = ["func::FuncDialect",
                            "memref::MemRefDialect",
                            "linalg::LinalgDialect",
-                           "xsmm::XsmmDialect"];
+                           "xsmm::XsmmDialect", 
+                           "tensor::TensorDialect"];
 }
 
 def ConvertXsmmToFunc : Pass<"convert-xsmm-to-func", "ModuleOp"> {

--- a/lib/TPP/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/ConvertLinalgToXsmm.cpp
@@ -37,6 +37,19 @@ struct ConvertLinalgToXsmm
 };
 
 namespace {
+struct BrgemmInfo {
+  unsigned m;
+  unsigned n;
+  unsigned k;
+  unsigned batch;
+
+  int64_t lda;
+  int64_t ldb;
+  int64_t ldc;
+  int64_t strideA;
+  int64_t strideB;
+};
+
 struct UnaryInfo {
   unsigned m;
   unsigned n;
@@ -54,6 +67,14 @@ struct BinaryInfo {
   int64_t ldo;
 };
 } // namespace
+
+// Return the position of `dim` in the codomain of `operand`.
+std::optional<unsigned> getPosInCodomain(unsigned dim, OpOperand *operand,
+                                         linalg::LinalgOp linalgOp) {
+  assert(operand->getOwner() == linalgOp);
+  return linalgOp.getMatchingIndexingMap(operand).getResultPosition(
+      getAffineDimExpr(dim, linalgOp.getContext()));
+}
 
 // Get UnaryInfo from input and output. The output must be of rank 2, while
 // the input can be constant, 1d or 2d. Additionally verify that the innermost
@@ -399,6 +420,190 @@ struct ConvertGenericToBinaryAdd : public OpRewritePattern<linalg::GenericOp> {
   }
 };
 
+static void replaceOpWithBrgemm(RewriterBase &rewriter,
+                                linalg::LinalgOp linalgOp,
+                                BrgemmInfo brgemmInfo) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  auto loops = linalgOp.computeStaticLoopSizes();
+  unsigned m = brgemmInfo.m;
+  unsigned n = brgemmInfo.n;
+  unsigned k = brgemmInfo.k;
+  unsigned batch = brgemmInfo.batch;
+  int64_t lda = brgemmInfo.lda;
+  int64_t ldb = brgemmInfo.ldb;
+  int64_t ldc = brgemmInfo.ldc;
+  int64_t strideA = brgemmInfo.strideA;
+  int64_t strideB = brgemmInfo.strideB;
+
+  DenseI64ArrayAttr dims = DenseI64ArrayAttr::get(
+      rewriter.getContext(),
+      ArrayRef<int64_t>{loops[m], loops[n], loops[k], lda, ldb, ldc, strideA,
+                        strideB});
+  auto dtype = xsmm::utils::getDataType(
+      rewriter, linalgOp.getDpsInitOperands()[0]->get().getType());
+  IntegerType integer64 = IntegerType::get(rewriter.getContext(), 64);
+  Location loc = linalgOp.getLoc();
+  auto flags = rewriter.getArrayAttr(
+      xsmm::GemmFlagsAttr::get(rewriter.getContext(), xsmm::GemmFlags::NONE));
+  Value dispatched = rewriter.create<xsmm::BrgemmDispatchOp>(
+      loc, integer64, dims, flags, dtype);
+
+  unsigned batchVal = 1;
+  if (batch != std::numeric_limits<unsigned>::max())
+    batchVal = loops[batch];
+  Value batchDim = rewriter.create<arith::ConstantOp>(
+      loc, integer64, rewriter.getIntegerAttr(integer64, batchVal));
+  SmallVector<Value> invokeOperands;
+  invokeOperands.push_back(dispatched);
+  invokeOperands.append(linalgOp->getOperands().begin(),
+                        linalgOp->getOperands().end());
+  invokeOperands.push_back(batchDim);
+  rewriter.replaceOpWithNewOp<xsmm::BrgemmOp>(linalgOp, dtype, invokeOperands);
+}
+
+// Structural matcher.
+static FailureOr<linalg::ContractionDimensions>
+checkStructure(linalg::LinalgOp linalgOp) {
+  // clang-format off
+  using namespace structured_match;
+  auto maybeBrgemmMatcher =
+    StructuredOpMatcher::make<linalg::GenericOp>()
+      .output(MatchAll(), HasStaticShape())
+      .input(MatchAll(), HasStaticShape())
+      .output(MatchAll(), HasStaticStrides())
+      .input(MatchAll(), HasStaticStrides())
+      .operation(NumOfLoops(GreaterThanOrEqualTo(3)));
+  // clang-format on
+  if (!maybeBrgemmMatcher.match(linalgOp))
+    return failure();
+
+  auto contractionDims = linalgx::utils::isContraction(linalgOp);
+  if (failed(contractionDims)) {
+    LLVM_DEBUG(llvm::dbgs() << "[checkStructure] Not a contraction\n");
+    return failure();
+  }
+  if (contractionDims->m.size() != 1 || contractionDims->n.size() != 1 ||
+      (contractionDims->k.size() != 2 && contractionDims->k.size() != 1) ||
+      contractionDims->batch.size() != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "[checkStructure] Wrong dimensions\n");
+    return failure();
+  }
+  unsigned classifiedLoops =
+      contractionDims->m.size() + contractionDims->n.size() +
+      contractionDims->k.size() + contractionDims->batch.size();
+  if (linalgOp.getNumLoops() != classifiedLoops) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "[checkStructure] Not all loops are classified\n");
+    return failure();
+  }
+  return contractionDims;
+}
+
+// Access matcher.
+static FailureOr<BrgemmInfo> checkAccess(linalg::LinalgOp linalgOp, unsigned m,
+                                         unsigned n, unsigned k,
+                                         unsigned batch) {
+  assert(linalgOp.getNumDpsInputs() == 2 && linalgOp.getNumDpsInits() == 1);
+  OpOperand *operandA = linalgOp.getDpsInputOperands()[0];
+  OpOperand *operandB = linalgOp.getDpsInputOperands()[1];
+  OpOperand *operandC = linalgOp.getDpsInitOperands()[0];
+
+  auto checkStridesAndGetLda = [&](unsigned minorDim, unsigned majorDim,
+                                   OpOperand *operand) -> FailureOr<int64_t> {
+    auto minorDimPosInCodomain = getPosInCodomain(minorDim, operand, linalgOp);
+    auto majorDimPosInCodomain = getPosInCodomain(majorDim, operand, linalgOp);
+    if (!minorDimPosInCodomain || !majorDimPosInCodomain)
+      return failure();
+    auto stridesOnOperand = utils::getStaticStrides(operand->get());
+    if (failed(stridesOnOperand) ||
+        (*stridesOnOperand)[*minorDimPosInCodomain] != 1)
+      return failure();
+    return (*stridesOnOperand)[*majorDimPosInCodomain];
+  };
+
+  // A(m, k)
+  auto lda = checkStridesAndGetLda(k, m, operandA);
+  if (failed(lda))
+    return failure();
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] Strides on A: OK\n");
+
+  // B(k, n)
+  auto ldb = checkStridesAndGetLda(n, k, operandB);
+  if (failed(ldb))
+    return failure();
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] Strides on B: OK\n");
+
+  // C(m, n)
+  auto ldc = checkStridesAndGetLda(n, m, operandC);
+  if (failed(ldc))
+    return failure();
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] Strides on C: OK\n");
+
+  auto batchPosCodomainA = getPosInCodomain(batch, operandA, linalgOp);
+  auto batchPosCodomainB = getPosInCodomain(batch, operandB, linalgOp);
+  int64_t strideA = 1;
+  if (batchPosCodomainA) {
+    auto stridesOnA = utils::getStaticStrides(operandA->get());
+    strideA = (*stridesOnA)[*batchPosCodomainA];
+  }
+  int64_t strideB = 1;
+  if (batchPosCodomainB) {
+    auto stridesOnB = utils::getStaticStrides(operandB->get());
+    strideB = (*stridesOnB)[*batchPosCodomainB];
+  }
+
+  BrgemmInfo info{m, n, k, batch, *lda, *ldb, *ldc, strideA, strideB};
+  return info;
+}
+
+// Check if the given generic is mappable to a brgemm xsmm op.
+// - It is a contraction, with:
+// -- 1 m and 1 n and 2 k dimensions.
+// -- m appears on the LHS and OUT but not in RHS.
+// -- n appears on the RHS and OUT but not in LHS.
+// -- k and k' appear on the RHS and LHS but not OUT.
+// -- the stride of the minor dimension for A, k is 1.
+// -- the stride of the minor dimension for B, j is 1.
+// -- the stride of the minor dimension for C, j is 1.
+static FailureOr<BrgemmInfo> isMappableToBrgemm(linalg::LinalgOp linalgOp) {
+  auto contractionDims = checkStructure(linalgOp);
+  if (failed(contractionDims)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "[isMappableToBrgemm] Failed on checkStructure\n");
+    return failure();
+  }
+
+  unsigned m = contractionDims->m[0];
+  unsigned n = contractionDims->n[0];
+  unsigned k = contractionDims->k.back();
+  unsigned batch = (contractionDims->k.size() == 2)
+                       ? contractionDims->k.front()
+                       : std::numeric_limits<unsigned>::max();
+
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] Candidate dims: "
+                          << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] m: " << m << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] n: " << n << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] k: " << k << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "[isMappableToBrgemm] batch: " << batch << "\n");
+
+  return checkAccess(linalgOp, m, n, k, batch);
+}
+
+// Check if we can map `genericOp` to a BRGEMM and rewrite it to XSMM brgemm op.
+struct ConvertGenericToBrgemm : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
+                                PatternRewriter &rewriter) const override {
+    auto brgemmInfo = isMappableToBrgemm(genericOp);
+    if (failed(brgemmInfo))
+      return failure();
+    replaceOpWithBrgemm(rewriter, genericOp, *brgemmInfo);
+    return success();
+  }
+};
+
 void ConvertLinalgToXsmm::runOnOperation() {
   MLIRContext *ctx = &getContext();
   RewritePatternSet patterns(ctx);
@@ -410,8 +615,8 @@ void ConvertLinalgToXsmm::runOnOperation() {
 
 void mlir::tpp::populateLinalgToXsmmPatterns(RewritePatternSet &patterns) {
   patterns.add<ConvertFillOpToUnaryZero, ConvertTransposeOpToUnaryTranspose,
-               ConvertGenericToUnaryRelu, ConvertGenericToBinaryAdd>(
-      patterns.getContext());
+               ConvertGenericToUnaryRelu, ConvertGenericToBinaryAdd,
+               ConvertGenericToBrgemm>(patterns.getContext());
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/lib/TPP/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/ConvertLinalgToXsmm.cpp
@@ -565,8 +565,8 @@ static FailureOr<BrgemmInfo> checkAccess(linalg::LinalgOp linalgOp, unsigned m,
 // -- n appears on the RHS and OUT but not in LHS.
 // -- k and k' appear on the RHS and LHS but not OUT.
 // -- the stride of the minor dimension for A, k is 1.
-// -- the stride of the minor dimension for B, j is 1.
-// -- the stride of the minor dimension for C, j is 1.
+// -- the stride of the minor dimension for B, n is 1.
+// -- the stride of the minor dimension for C, n is 1.
 static FailureOr<BrgemmInfo> isMappableToBrgemm(linalg::LinalgOp linalgOp) {
   auto contractionDims = checkStructure(linalgOp);
   if (failed(contractionDims)) {

--- a/lib/TPP/MatcherUtils.cpp
+++ b/lib/TPP/MatcherUtils.cpp
@@ -16,8 +16,8 @@ namespace mlir {
 namespace structured_match {
 namespace utils {
 
-// Return true if all the operand have the same type. No implicit conversion in
-// the linalgOp.
+// Return true if all the operand have the same type, i.e., no implicit
+// conversion in the linalgOp.
 static LogicalResult hasEqualOperandTypes(Operation *operation) {
   if (!isa<linalg::LinalgOp>(operation))
     return failure();

--- a/test/Conversion/LinalgToXsmm/linalg-to-brgemm.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-brgemm.mlir
@@ -1,0 +1,180 @@
+// RUN: tpp-opt %s -convert-linalg-to-xsmm -split-input-file | FileCheck %s
+
+#map = affine_map<(i, k, kk, j) -> (i, k, kk)>
+#map1 = affine_map<(i, k, kk, j) -> (k, kk, j)>
+#map2 = affine_map<(i, k, kk, j) -> (i, j)>
+
+func.func @brgemm(%arg0: memref<2x2x2x4xf32>, %arg1: memref<2x4x8x2xf32>, 
+                  %arg2: memref<2x2x8x2xf32>) {
+  scf.forall (%arg3, %arg4) in (2, 8) {
+    %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 2, 2, 4] [1, 1, 1, 1] 
+      : memref<2x2x2x4xf32> to memref<2x2x4xf32, strided<[8, 4, 1], offset: ?>>
+    %subview_2 = memref.subview %arg1[0, 0, %arg4, 0] [2, 4, 1, 2] [1, 1, 1, 1] 
+      : memref<2x4x8x2xf32> to memref<2x4x2xf32, strided<[64, 16, 1], offset: ?>>
+    %subview_3 = memref.subview %arg2[%arg3, 0, %arg4, 0] [1, 2, 1, 2] [1, 1, 1, 1] 
+      : memref<2x2x8x2xf32> to memref<2x2xf32, strided<[16, 1], offset: ?>>
+    linalg.generic {
+      indexing_maps = [#map, #map1, #map2], 
+      iterator_types = ["parallel", "reduction", "reduction", "parallel"]} 
+      ins(%subview, %subview_2 : memref<2x2x4xf32, strided<[8, 4, 1], offset: ?>>, memref<2x4x2xf32, strided<[64, 16, 1], offset: ?>>) 
+      outs(%subview_3 : memref<2x2xf32, strided<[16, 1], offset: ?>>) {
+    ^bb0(%in: f32, %in_4: f32, %out: f32):
+      %1 = arith.mulf %in, %in_4 : f32
+      %2 = arith.addf %out, %1 : f32
+      linalg.yield %2 : f32
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: brgemm
+// CHECK-SAME: %[[ARG0:.+]]: memref<2x2x2x4xf32>, %[[ARG1:.+]]: memref<2x4x8x2xf32>, %[[ARG2:.+]]: memref<2x2x8x2xf32>
+// CHECK: %[[C2:.+]] = arith.constant 2 : i64
+// CHECK: scf.forall (%[[ARG3:.+]], %[[ARG4:.+]]) in (2, 8) {
+// CHECK: %[[SUB:.+]] = memref.subview %[[ARG0]][%[[ARG3]], 0, 0, 0] [1, 2, 2, 4] [1, 1, 1, 1] 
+// CHECK-SAME:  : memref<2x2x2x4xf32> to memref<2x2x4xf32, strided<[8, 4, 1], offset: ?>>
+// CHECK: %[[SUB_0:.+]] = memref.subview %[[ARG1]][0, 0, %[[ARG4]], 0] [2, 4, 1, 2] [1, 1, 1, 1] 
+// CHECK-SAME:  : memref<2x4x8x2xf32> to memref<2x4x2xf32, strided<[64, 16, 1], offset: ?>>
+// CHECK: %[[SUB_1:.+]] = memref.subview %[[ARG2]][%[[ARG3]], 0, %[[ARG4]], 0] [1, 2, 1, 2] [1, 1, 1, 1] 
+// CHECK-SAME:  : memref<2x2x8x2xf32> to memref<2x2xf32, strided<[16, 1], offset: ?>>
+// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [2, 2, 4, 8, 16, 16, 4, 64] flags = (none) data_type = f32
+// CHECK: xsmm.brgemm(data_type = f32, %[[DIS]], %[[SUB]], %[[SUB_0]], %[[SUB_1]], %[[C2]])
+
+// m = 2
+// n = 2
+// k = 4
+// lda = 8
+// ldb = 16
+// ldc = 16
+// stride_a = 4
+// stride_b = 64
+
+// -----
+
+#map = affine_map<(i, j, kk, k) -> (kk, i, k)>
+#map1 = affine_map<(i, j, kk, k) -> (kk, k, j)>
+#map2 = affine_map<(i, j, kk, k) -> (i, j)>
+
+func.func @brgemm_1(%arg0: memref<9x4x5xf32>, %arg1: memref<9x5x8xf32>, %arg2: memref<4x8xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+    ins(%arg0, %arg1 : memref<9x4x5xf32>, memref<9x5x8xf32>)
+    outs(%arg2: memref<4x8xf32>) {
+      ^bb0(%in: f32, %in_8: f32, %out: f32):
+        %5 = arith.mulf %in, %in_8 : f32
+        %6 = arith.addf %out, %5 : f32
+        linalg.yield %6 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: brgemm_1
+// CHECK-SAME: %[[ARG0:.+]]: memref<9x4x5xf32>, %[[ARG1:.+]]: memref<9x5x8xf32>, %[[ARG2:.+]]: memref<4x8xf32>
+// CHECK: %[[C9:.+]] = arith.constant 9 : i64
+// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [4, 8, 5, 5, 8, 8, 20, 40] flags = (none) data_type = f32
+// CHECK: xsmm.brgemm(data_type = f32, %0, %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[C9]])
+
+// -----
+
+#map = affine_map<(kk, k, i, j) -> (kk, i, k)>
+#map1 = affine_map<(kk, k, i, j) -> (kk, k, j)>
+#map2 = affine_map<(kk, k, i, j) -> (i, j)>
+
+func.func @brgemm_2(%arg0: memref<9x4x5xf32>, %arg1: memref<9x5x8xf32>, %arg2: memref<4x8xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "reduction", "parallel", "parallel"]}
+    ins(%arg0, %arg1 : memref<9x4x5xf32>, memref<9x5x8xf32>)
+    outs(%arg2: memref<4x8xf32>) {
+      ^bb0(%in: f32, %in_8: f32, %out: f32):
+        %5 = arith.mulf %in, %in_8 : f32
+        %6 = arith.addf %out, %5 : f32
+        linalg.yield %6 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: brgemm_2
+// CHECK-SAME: %[[ARG0:.+]]: memref<9x4x5xf32>, %[[ARG1:.+]]: memref<9x5x8xf32>, %[[ARG2:.+]]: memref<4x8xf32>
+// CHECK: %[[C9:.+]] = arith.constant 9 : i64
+// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [4, 8, 5, 5, 8, 8, 20, 40] flags = (none) data_type = f32
+// CHECK: xsmm.brgemm(data_type = f32, %0, %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[C9]])
+
+// -----
+
+#map = affine_map<(kk, k, i, j) -> (kk, i, k)>
+#map1 = affine_map<(kk, k, i, j) -> (kk, k, j)>
+#map2 = affine_map<(kk, k, i, j) -> (i, j)>
+
+// non unit stride.
+func.func @brgemm_3(%arg0: memref<9x4x5xf32>, %arg1: memref<9x5x8xf32, strided<[40, 8, 2], offset: ?>>, %arg2: memref<4x8xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "reduction", "parallel", "parallel"]}
+    ins(%arg0, %arg1 : memref<9x4x5xf32>, memref<9x5x8xf32, strided<[40, 8, 2], offset: ?>>)
+    outs(%arg2: memref<4x8xf32>) {
+      ^bb0(%in: f32, %in_8: f32, %out: f32):
+        %5 = arith.mulf %in, %in_8 : f32
+        %6 = arith.addf %out, %5 : f32
+        linalg.yield %6 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: brgemm_3
+// CHECK-NOT: xsmm.brgemm
+// CHECK: linalg.generic
+
+// -----
+
+#map = affine_map<(i, j, k) -> (i, k)>
+#map1 = affine_map<(i, j, k) -> (k, j)>
+#map2 = affine_map<(i, j, k) -> (i, j)>
+
+func.func @gemm_1(%arg0: memref<64x32xf32>, %arg1: memref<32x64xf32>, %arg2: memref<64x64xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["parallel", "parallel", "reduction"]} 
+    ins(%arg0, %arg1: memref<64x32xf32>, memref<32x64xf32>)
+    outs(%arg2: memref<64x64xf32>) {
+  ^bb0(%in: f32, %in_4: f32, %out: f32):
+      %1 = arith.mulf %in, %in_4 : f32
+      %2 = arith.addf %out, %1 : f32
+      linalg.yield %2 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: gemm_1
+// CHECK-SAME: %[[ARG0:.+]]: memref<64x32xf32>, %[[ARG1:.+]]: memref<32x64xf32>, %[[ARG2:.+]]: memref<64x64xf32>
+// CHECK: %[[C1:.+]] = arith.constant 1 : i64
+// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [64, 64, 32, 32, 64, 64, 1, 1] flags = (none) data_type = f32
+// CHECK: xsmm.brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[C1]])
+
+// -----
+
+#map = affine_map<(k, i, j) -> (i, k)>
+#map1 = affine_map<(k, i, j) -> (k, j)>
+#map2 = affine_map<(k, i, j) -> (i, j)>
+
+// permutation on outerloop is not relevant.
+func.func @gemm_2(%arg0: memref<64x32xf32>, %arg1: memref<32x64xf32>, %arg2: memref<64x64xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "parallel", "parallel"]} 
+    ins(%arg0, %arg1: memref<64x32xf32>, memref<32x64xf32>)
+    outs(%arg2: memref<64x64xf32>) {
+  ^bb0(%in: f32, %in_4: f32, %out: f32):
+      %1 = arith.mulf %in, %in_4 : f32
+      %2 = arith.addf %out, %1 : f32
+      linalg.yield %2 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: gemm_2
+// CHECK-SAME: %[[ARG0:.+]]: memref<64x32xf32>, %[[ARG1:.+]]: memref<32x64xf32>, %[[ARG2:.+]]: memref<64x64xf32>
+// CHECK: %[[C1:.+]] = arith.constant 1 : i64
+// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [64, 64, 32, 32, 64, 64, 1, 1] flags = (none) data_type = f32
+// CHECK: xsmm.brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[C1]])

--- a/test/Integration/xsmm-strided-brgemm.mlir
+++ b/test/Integration/xsmm-strided-brgemm.mlir
@@ -1,0 +1,110 @@
+// RUN: tpp-run %s -linalg-to-xsmm -e entry -entry-point-result=void | FileCheck %s
+// RUN: tpp-run %s -linalg-to-loops -e entry -entry-point-result=void | FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" | \
+// RUN: FileCheck %s -check-prefix=IR
+
+!A_tensor_t = tensor<4x8xf32>
+!B_tensor_t = tensor<8x16xf32>
+!C_tensor_t = tensor<4x16xf32>
+!D_tensor_t = tensor<4x16xf32>
+
+#map = affine_map<(i, ii, k, kk, j, jj) -> (i, ii, k, kk)>
+#map1 = affine_map<(i, ii, k, kk, j, jj) -> (k, kk, j, jj)>
+#map2 = affine_map<(i, ii, k, kk, j, jj) -> (i, ii, j, jj)>
+#map3 = affine_map<(i, ii, j, jj) -> (i, ii, j, jj)>
+
+func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t, %D : !D_tensor_t) {
+  %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
+    !A_tensor_t into tensor<2x2x2x4xf32> 
+  %B_exp = tensor.expand_shape %B [[0, 1], [2, 3]] :
+    !B_tensor_t into tensor<2x4x8x2xf32>
+  %C_exp = tensor.expand_shape %C [[0, 1], [2, 3]] :
+    !C_tensor_t into tensor<2x2x8x2xf32>
+  %D_exp = tensor.expand_shape %D [[0, 1], [2, 3]] :
+    !D_tensor_t into tensor<2x2x8x2xf32>
+
+  // IR: %[[C1:.+]] = arith.constant 1 : i64      
+  // IR-DAG: %[[C2:.+]] = arith.constant 2 : i64  
+  // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
+  // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
+  // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
+  // IR-DAG: %[[C64:.+]] = arith.constant 64 : i64
+  // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // IR: xsmm_brgemm_dispatch(%[[C1]], %[[C2]], %[[C2]], %[[C4]], %[[C8]], %[[C16]], %[[C2]], %[[C4]], %[[C64]], %[[C0]])
+  // Parameters:
+  // 1) kind 
+  // 2) m = 2
+  // 3) n = 2
+  // 4) k = 4
+  // 5) lda = 8
+  // 6) ldb = 16
+  // 7) ldc = 2
+  // 8) stride on A = 4
+  // 9) stride on B = 64
+  // 10) data type
+  %gemm = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel"]} 
+    ins(%A_exp, %B_exp : tensor<2x2x2x4xf32>, tensor<2x4x8x2xf32>) 
+    outs(%C_exp : tensor<2x2x8x2xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %4 = arith.mulf %in, %in_2 : f32
+      %5 = arith.addf %out, %4 : f32
+      linalg.yield %5 : f32
+  } -> tensor<2x2x8x2xf32>
+
+  %bias = linalg.generic {
+    indexing_maps = [#map3, #map3],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%gemm : tensor<2x2x8x2xf32>)
+    outs(%D_exp : tensor<2x2x8x2xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %4 = arith.addf %in, %out : f32
+      linalg.yield %4 : f32
+    } -> tensor<2x2x8x2xf32>
+
+  %bias_clps = tensor.collapse_shape %bias [[0, 1], [2, 3]] :
+    tensor<2x2x8x2xf32> into !D_tensor_t
+  %cst = arith.constant 0 : index
+  %d1 = arith.constant -1.0 : f32
+  %v0 = vector.transfer_read %bias_clps[%cst, %cst], %d1 : tensor<4x16xf32>, vector<4x16xf32>
+
+  //
+  // CHECK:     ( ( 59.46, 97.26, 135.06, 172.86, 210.66, 248.46, 286.26, 324.06, 361.86, 399.66, 437.46, 475.26, 513.06, 550.86, 588.66, 626.46 ),
+  // CHECK-SAME:  ( 60.62, 99.22, 137.82, 176.42, 215.02, 253.62, 292.22, 330.82, 369.42, 408.02, 446.62, 485.22, 523.82, 562.42, 601.02, 639.62 ),
+  // CHECK-SAME:  ( 61.78, 101.18, 140.58, 179.98, 219.38, 258.78, 298.18, 337.58, 376.98, 416.38, 455.78, 495.18, 534.58, 573.98, 613.38, 652.78 ),
+  // CHECK-SAME:  ( 62.94, 103.14, 143.34, 183.54, 223.74, 263.94, 304.14, 344.34, 384.54, 424.74, 464.94, 505.14, 545.34, 585.54, 625.74, 665.94 ) )
+  //
+  vector.print %v0 : vector<4x16xf32>
+
+  return
+}
+
+func.func @entry() {
+  %C = arith.constant dense<0.0> : !C_tensor_t
+  %D = arith.constant dense<[
+        [ 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9, 9.9, 10.9, 11.9, 12.9, 13.9, 14.9, 15.9, 16.9 ],
+        [ 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9, 9.9, 10.9, 11.9, 12.9, 13.9, 14.9, 15.9, 16.9 ],
+        [ 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9, 9.9, 10.9, 11.9, 12.9, 13.9, 14.9, 15.9, 16.9 ],
+        [ 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9, 9.9, 10.9, 11.9, 12.9, 13.9, 14.9, 15.9, 16.9 ]
+  ]> : !D_tensor_t
+  %A = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4 ]
+  ]> : !A_tensor_t
+  %B = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 15.1, 16.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2, 10.2, 11.2, 12.2, 13.2, 14.2, 15.2, 16.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3, 9.3, 10.3, 11.3, 12.3, 13.3, 14.3, 15.3, 16.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4, 9.4, 10.4, 11.4, 12.4, 13.4, 14.4, 15.4, 16.4 ],
+        [ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5 ],
+        [ 1.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6, 9.6, 10.6, 11.6, 12.6, 13.6, 14.6, 15.6, 16.6 ],
+        [ 1.7, 2.7, 3.7, 4.7, 5.7, 6.7, 7.7, 8.7, 9.7, 10.7, 11.7, 12.7, 13.7, 14.7, 15.7, 16.7 ],
+        [ 1.8, 2.8, 3.8, 4.8, 5.8, 6.8, 7.8, 8.8, 9.8, 10.8, 11.8, 12.8, 13.8, 14.8, 15.8, 16.8 ]
+  ]> : !B_tensor_t
+  call @matmul_static(%A, %B, %C, %D) : (!A_tensor_t, !B_tensor_t, !C_tensor_t, !D_tensor_t) -> ()
+  return
+}

--- a/test/Integration/xsmm-strided-brgemm1.mlir
+++ b/test/Integration/xsmm-strided-brgemm1.mlir
@@ -1,0 +1,94 @@
+// RUN: tpp-run %s -linalg-to-xsmm -e entry -entry-point-result=void | FileCheck %s
+// RUN: tpp-run %s -linalg-to-loops -e entry -entry-point-result=void | FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" | \
+// RUN: FileCheck %s -check-prefix=IR
+
+!A_tensor_t = tensor<16x8xf32>
+!B_tensor_t = tensor<8x16xf32>
+!C_tensor_t = tensor<4x16xf32>
+
+#map = affine_map<(b, i, h, k, j) -> (b, h, i, k)>
+#map1 = affine_map<(b, i, h, k, j) -> (b, k, h, j)>
+#map2 = affine_map<(b, i, h, k, j) -> (b, i, h, j)>
+
+func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
+  %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
+    !A_tensor_t into tensor<2x8x2x4xf32>
+  %B_exp = tensor.expand_shape %B [[0, 1], [2, 3]] :
+    !B_tensor_t into tensor<2x4x8x2xf32>
+  %C_exp = tensor.expand_shape %C [[0, 1], [2, 3]] :
+    !C_tensor_t into tensor<2x2x8x2xf32>
+
+  %cst_fill = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<2x2x8x2xf32>
+  %fill = linalg.fill ins(%cst_fill : f32) outs(%empty: tensor<2x2x8x2xf32>) -> tensor<2x2x8x2xf32>
+
+  // IR: %[[C2:.+]] = arith.constant 2 : i64
+  // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
+  // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
+  // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
+  // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
+  // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // IR: xsmm_brgemm_dispatch(%[[C1]], %[[C2]], %[[C2]], %[[C4]], %[[C4]], %[[C16]], %[[C16]], %[[C1]], %[[C1]], %[[C0]])
+  %gemm = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel"]} 
+    ins(%A_exp, %B_exp : tensor<2x8x2x4xf32>, tensor<2x4x8x2xf32>) 
+    outs(%fill : tensor<2x2x8x2xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %4 = arith.mulf %in, %in_2 : f32
+      %5 = arith.addf %out, %4 : f32
+      linalg.yield %5 : f32
+  } -> tensor<2x2x8x2xf32>
+
+  %gemm_clps = tensor.collapse_shape %gemm [[0, 1], [2, 3]] :
+    tensor<2x2x8x2xf32> into !C_tensor_t
+  %cst = arith.constant 0 : index
+  %d1 = arith.constant -1.0 : f32
+  %v0 = vector.transfer_read %gemm_clps[%cst, %cst], %d1 : tensor<4x16xf32>, vector<4x16xf32>
+
+  //
+  // CHECK:     ( ( 13.5, 23.9, 35.6, 46.4, 59.3, 70.5, 84.6, 96.2, 111.5, 123.5, 140, 152.4, 170.1, 182.9, 201.8, 215 ), 
+  // CHECK-SAME:  ( 33.5, 59.9, 87.6, 114.4, 143.3, 170.5, 200.6, 228.2, 259.5, 287.5, 320, 348.4, 382.1, 410.9, 445.8, 475 ), 
+  // CHECK-SAME:  ( 22.94, 36.54, 38.46, 48.86, 59.486, 69.926, 80.672, 91.152, 102.018, 112.538, 123.524, 134.084, 145.19, 155.79, 167.016, 177.656 ), 
+  // CHECK-SAME:  ( 49.34, 78.94, 96.86, 123.26, 149.886, 176.326, 203.072, 229.552, 256.418, 282.938, 309.924, 336.484, 363.59, 390.19, 417.416, 444.056 ) ) 
+  //
+  vector.print %v0 : vector<4x16xf32>
+
+  return
+}
+
+func.func @entry() {
+  %C = arith.constant dense<0.0> : !C_tensor_t
+  %A = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4 ],
+        [ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 ],
+        [ 1.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6 ],
+        [ 1.7, 2.7, 3.7, 4.7, 5.7, 6.7, 7.7, 8.7 ],
+        [ 1.8, 2.8, 3.8, 4.8, 5.8, 6.8, 7.8, 8.8 ],
+        [ 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9 ],
+        [ 1.10, 2.10, 3.10, 4.10, 5.10, 6.10, 7.10, 8.10 ],
+        [ 1.11, 2.11, 3.11, 4.11, 5.11, 6.11, 7.11, 8.11 ],
+        [ 1.12, 2.12, 3.12, 4.12, 5.12, 6.12, 7.12, 8.12 ],
+        [ 1.13, 2.13, 3.13, 4.13, 5.13, 6.13, 7.13, 8.13 ],
+        [ 1.14, 2.14, 3.14, 4.14, 5.14, 6.14, 7.14, 8.14 ],
+        [ 1.15, 2.15, 3.15, 4.15, 5.15, 6.15, 7.15, 8.15 ],
+        [ 1.16, 2.16, 3.16, 4.16, 5.16, 6.16, 7.16, 8.16 ]
+  ]> : !A_tensor_t
+  %B = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 15.1, 16.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2, 10.2, 11.2, 12.2, 13.2, 14.2, 15.2, 16.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3, 9.3, 10.3, 11.3, 12.3, 13.3, 14.3, 15.3, 16.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4, 9.4, 10.4, 11.4, 12.4, 13.4, 14.4, 15.4, 16.4 ],
+        [ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5 ],
+        [ 1.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6, 9.6, 10.6, 11.6, 12.6, 13.6, 14.6, 15.6, 16.6 ],
+        [ 1.7, 2.7, 3.7, 4.7, 5.7, 6.7, 7.7, 8.7, 9.7, 10.7, 11.7, 12.7, 13.7, 14.7, 15.7, 16.7 ],
+        [ 1.8, 2.8, 3.8, 4.8, 5.8, 6.8, 7.8, 8.8, 9.8, 10.8, 11.8, 12.8, 13.8, 14.8, 15.8, 16.8 ] 
+  ]> : !B_tensor_t
+  call @matmul_static(%A, %B, %C) : (!A_tensor_t, !B_tensor_t, !C_tensor_t) -> ()
+  return
+}

--- a/test/Integration/xsmm-strided-brgemm2.mlir
+++ b/test/Integration/xsmm-strided-brgemm2.mlir
@@ -1,0 +1,82 @@
+// RUN: tpp-run %s -linalg-to-xsmm -e entry -entry-point-result=void | FileCheck %s
+// RUN: tpp-run %s -linalg-to-loops -e entry -entry-point-result=void | FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" | \
+// RUN: FileCheck %s -check-prefix=IR
+
+!A_tensor_t = tensor<4x8xf32>
+!B_tensor_t = tensor<8x16xf32>
+!C_tensor_t = tensor<4x16xf32>
+
+#map = affine_map<(b, i, h, k, j) -> (b, i, h, k)>
+#map1 = affine_map<(b, i, h, k, j) -> (b, k, h, j)>
+#map2 = affine_map<(b, i, h, k, j) -> (b, h, i, j)>
+
+func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
+  %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
+    !A_tensor_t into tensor<2x2x2x4xf32> 
+  %B_exp = tensor.expand_shape %B [[0, 1], [2, 3]] :
+    !B_tensor_t into tensor<2x4x2x8xf32>
+  %C_exp = tensor.expand_shape %C [[0, 1], [2, 3]] :
+    !C_tensor_t into tensor<2x2x2x8xf32>
+
+  %cst_fill = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<2x2x2x8xf32>
+  %fill = linalg.fill ins(%cst_fill : f32) outs(%empty: tensor<2x2x2x8xf32>) -> tensor<2x2x2x8xf32>
+
+  // IR: %[[C2:.+]] = arith.constant 2 : i64
+  // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
+  // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
+  // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
+  // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
+  // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // IR: xsmm_brgemm_dispatch(%[[C1]], %[[C2]], %[[C8]], %[[C4]], %[[C8]], %[[C16]], %[[C8]], %[[C1]], %[[C1]], %[[C0]])
+  %gemm = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel"]} 
+    ins(%A_exp, %B_exp : tensor<2x2x2x4xf32>, tensor<2x4x2x8xf32>) 
+    outs(%fill : tensor<2x2x2x8xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %4 = arith.mulf %in, %in_2 : f32
+      %5 = arith.addf %out, %4 : f32
+      linalg.yield %5 : f32
+  } -> tensor<2x2x2x8xf32>
+
+  %gemm_clps = tensor.collapse_shape %gemm [[0, 1], [2, 3]] :
+    tensor<2x2x2x8xf32> into !C_tensor_t
+  %cst = arith.constant 0 : index
+  %d1 = arith.constant -1.0 : f32
+  %v0 = vector.transfer_read %gemm_clps[%cst, %cst], %d1 : tensor<4x16xf32>, vector<4x16xf32>
+
+  //
+  // CHECK:     ( ( 13.5, 23.9, 34.3, 44.7, 55.1, 65.5, 75.9, 86.3, 14, 24.8, 35.6, 46.4, 57.2, 68, 78.8, 89.6 ), 
+  // CHECK-SAME:  ( 244.7, 271.1, 297.5, 323.9, 350.3, 376.7, 403.1, 429.5, 248.4, 275.2, 302, 328.8, 355.6, 382.4, 409.2, 436 ), 
+  // CHECK-SAME:  ( 18.98, 30.18, 41.38, 52.58, 63.78, 74.98, 86.18, 97.38, 19.64, 31.24, 42.84, 54.44, 66.04, 77.64, 89.24, 100.84 ), 
+  // CHECK-SAME:  ( 262.98, 290.18, 317.38, 344.58, 371.78, 398.98, 426.18, 453.38, 266.84, 294.44, 322.04, 349.64, 377.24, 404.84, 432.44, 460.04 ) )
+  //
+  vector.print %v0 : vector<4x16xf32>
+
+  return
+}
+
+func.func @entry() {
+  %C = arith.constant dense<0.0> : !C_tensor_t
+  %A = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4 ]
+  ]> : !A_tensor_t
+  %B = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 15.1, 16.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2, 10.2, 11.2, 12.2, 13.2, 14.2, 15.2, 16.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3, 9.3, 10.3, 11.3, 12.3, 13.3, 14.3, 15.3, 16.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4, 9.4, 10.4, 11.4, 12.4, 13.4, 14.4, 15.4, 16.4 ],
+        [ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5 ],
+        [ 1.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6, 9.6, 10.6, 11.6, 12.6, 13.6, 14.6, 15.6, 16.6 ],
+        [ 1.7, 2.7, 3.7, 4.7, 5.7, 6.7, 7.7, 8.7, 9.7, 10.7, 11.7, 12.7, 13.7, 14.7, 15.7, 16.7 ],
+        [ 1.8, 2.8, 3.8, 4.8, 5.8, 6.8, 7.8, 8.8, 9.8, 10.8, 11.8, 12.8, 13.8, 14.8, 15.8, 16.8 ]
+  ]> : !B_tensor_t
+  call @matmul_static(%A, %B, %C) : (!A_tensor_t, !B_tensor_t, !C_tensor_t) -> ()
+  return
+}

--- a/test/Integration/xsmm-strided-brgemm3.mlir
+++ b/test/Integration/xsmm-strided-brgemm3.mlir
@@ -1,0 +1,89 @@
+// RUN: tpp-run %s -linalg-to-xsmm -e entry -entry-point-result=void | FileCheck %s
+// RUN: tpp-run %s -linalg-to-loops -e entry -entry-point-result=void | FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" | \
+// RUN: FileCheck %s -check-prefix=IR
+
+!A_tensor_t = tensor<4x8xf32>
+!B_tensor_t = tensor<16x8xf32>
+!C_tensor_t = tensor<4x16xf32>
+
+#map = affine_map<(b, i, h, k, j) -> (b, i, h, k)>
+#map1 = affine_map<(b, i, h, k, j) -> (b, j, h, k)>
+#map2 = affine_map<(b, i, h, k, j) -> (b, h, j, i)>
+
+func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
+  %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
+    !A_tensor_t into tensor<2x2x2x4xf32>
+  %B_exp = tensor.expand_shape %B [[0, 1], [2, 3]] :
+    !B_tensor_t into tensor<2x8x2x4xf32>
+  %C_exp = tensor.expand_shape %C [[0, 1], [2, 3]] :
+    !C_tensor_t into tensor<2x2x8x2xf32>
+
+  %cst_fill = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<2x2x8x2xf32>
+  %fill = linalg.fill ins(%cst_fill : f32) outs(%empty: tensor<2x2x8x2xf32>) -> tensor<2x2x8x2xf32>
+
+  // IR: %[[C2:.+]] = arith.constant 2 : i64
+  // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
+  // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
+  // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
+  // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // IR: xsmm_brgemm_dispatch(%[[C1]], %[[C8]], %[[C2]], %[[C4]], %[[C8]], %[[C2]], %[[C2]], %[[C1]], %[[C1]], %[[C0]]) 
+  %gemm = linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel"]} 
+    ins(%A_exp, %B_exp : tensor<2x2x2x4xf32>, tensor<2x8x2x4xf32>) 
+    outs(%fill : tensor<2x2x8x2xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %4 = arith.mulf %in, %in_2 : f32
+      %5 = arith.addf %out, %4 : f32
+      linalg.yield %5 : f32
+  } -> tensor<2x2x8x2xf32>
+
+  %gemm_clps = tensor.collapse_shape %gemm [[0, 1], [2, 3]] :
+    tensor<2x2x8x2xf32> into !C_tensor_t
+  %cst = arith.constant 0 : index
+  %d1 = arith.constant -1.0 : f32
+  %v0 = vector.transfer_read %gemm_clps[%cst, %cst], %d1 : tensor<4x16xf32>, vector<4x16xf32>
+
+  // 
+  // CHECK:     ( ( 32.04, 33.08, 33.08, 34.16, 34.12, 35.24, 35.16, 36.32, 36.2, 37.4, 37.24, 38.48, 38.28, 39.56, 39.32, 40.64 ), 
+  // CHECK-SAME:  ( 179.24, 181.88, 181.88, 184.56, 184.52, 187.24, 187.16, 189.92, 189.8, 192.6, 192.44, 195.28, 195.08, 197.96, 197.72, 200.64 ), 
+  // CHECK-SAME:  ( 43.08, 44.44, 34.12, 35.16, 34.232, 35.276, 34.344, 35.392, 34.456, 35.508, 34.568, 35.624, 34.68, 35.74, 34.792, 35.856 ), 
+  // CHECK-SAME:  ( 206.28, 209.24, 184.52, 187.16, 184.792, 187.436, 185.064, 187.712, 185.336, 187.988, 185.608, 188.264, 185.88, 188.54, 186.152, 188.816 ) )
+  // 
+  vector.print %v0 : vector<4x16xf32>
+
+  return
+}
+
+func.func @entry() {
+  %C = arith.constant dense<0.0> : !C_tensor_t
+  %A = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4 ]
+  ]> : !A_tensor_t
+  %B = arith.constant dense<[
+        [ 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1 ],
+        [ 1.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2 ],
+        [ 1.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3 ],
+        [ 1.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4 ],
+        [ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 ],
+        [ 1.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6 ],
+        [ 1.7, 2.7, 3.7, 4.7, 5.7, 6.7, 7.7, 8.7 ],
+        [ 1.8, 2.8, 3.8, 4.8, 5.8, 6.8, 7.8, 8.8 ],
+        [ 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9 ],
+        [ 1.10, 2.10, 3.10, 4.10, 5.10, 6.10, 7.10, 8.10 ],
+        [ 1.11, 2.11, 3.11, 4.11, 5.11, 6.11, 7.11, 8.11 ],
+        [ 1.12, 2.12, 3.12, 4.12, 5.12, 6.12, 7.12, 8.12 ],
+        [ 1.13, 2.13, 3.13, 4.13, 5.13, 6.13, 7.13, 8.13 ],
+        [ 1.14, 2.14, 3.14, 4.14, 5.14, 6.14, 7.14, 8.14 ],
+        [ 1.15, 2.15, 3.15, 4.15, 5.15, 6.15, 7.15, 8.15 ],
+        [ 1.16, 2.16, 3.16, 4.16, 5.16, 6.16, 7.16, 8.16 ]
+  ]> : !B_tensor_t
+  call @matmul_static(%A, %B, %C) : (!A_tensor_t, !B_tensor_t, !C_tensor_t) -> ()
+  return
+}


### PR DESCRIPTION
Allows mapping generic contractions to BRGEMM. The idea is to find a contraction operation with at least two parallel dimensions (m and n) and, at most, two reduction dimensions (k and k'). The m dimension should appear on the LHS and the OUT operand but not the RHS, while the n dimension should appear on the RHS and the OUT operand but not the LHS. k and k' should appear only on the OUT. m, n, and k are selected as minor dimensions for the GEMM and must have an innermost stride of 1, while the k' is chosen as batch reduction dimension.