### PR TITLE
Enable linalg-to-xsmm in tpp-run

### DIFF
--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -72,6 +72,11 @@ llvm::cl::opt<bool> tppToLoops("tpp-to-loops",
                                llvm::cl::desc("Lower TPP to loops"),
                                llvm::cl::init(false));
 
+// Lower linalg to XSMM directly.
+llvm::cl::opt<bool> linalgToXsmm("linalg-to-xsmm",
+                                 llvm::cl::desc("Lower linalg to xsmm"),
+                                 llvm::cl::init(false));
+
 // Control parallelism.
 llvm::cl::opt<bool>
     defParallel("def-parallel",
@@ -152,7 +157,8 @@ private:
       pm.addPass(tpp::createGpuPipelinePass(gpuBackend));
     } else {
       // Apply the default preprocessing pass
-      pm.addPass(tpp::createDefaultTppPass(tppToLoops, linalgToLoops));
+      pm.addPass(
+          tpp::createDefaultTppPass(tppToLoops, linalgToLoops, linalgToXsmm));
     }
 
     if (print == PrintStage::Mid)

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -437,15 +437,14 @@ private:
       // Bufferize: tensor->memref.
       pm.addPass(createBufferizePass());
 
-      // Convert forAll to parallel loops should run after bufferization
-      // as scf.parallel does not handle tensor. Fix it upstream or keep the
-      // pass after `createBufferizePass`.
-      pm.addPass(createConvertForAllToParallelOpPass());
-
       // Lower all TPP operations.
       pm.addNestedPass<func::FuncOp>(createTppLoweringPass(tppToLoops));
       pm.addNestedPass<func::FuncOp>(createCleanupPass());
     }
+
+    // Convert forAll to parallel loops should run after bufferization
+    // as scf.parallel does not handle tensor.
+    pm.addPass(createConvertForAllToParallelOpPass());
 
     // Covert all local TPP-related dialects.
     pm.addPass(createLocalDialectsLoweringPass());

--- a/test/Conversion/LinalgToXsmm/linalg-to-binary.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-binary.mlir
@@ -209,3 +209,26 @@ func.func @add_8(%arg0: memref<256x1024xf32>, %arg1: memref<256x1024xf32>) {
 // CHECK: %[[DIS:.+]] = xsmm.binary.dispatch add [256, 1024, 1024, 1024, 1024] 
 // CHECK-SAME:  flags = (none) data_type = f32
 // CHECK: xsmm.binary add(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG0]])
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @add_9(%arg0: memref<256x1024xf32>, %arg1: memref<256x1024xf32>) {
+  linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0 : memref<256x1024xf32>)
+    outs(%arg1 : memref<256x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %6 = arith.addf %in, %out : f32
+      linalg.yield %6 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: add_9
+// CHECK-SAME: %[[ARG0:.+]]: memref<256x1024xf32>, %[[ARG1:.+]]: memref<256x1024xf32>
+// CHECK: %[[DIS:.+]] = xsmm.binary.dispatch add [256, 1024, 1024, 1024, 1024]
+// CHECK-SAME:  flags = (none) data_type = f32
+// CHECK: xsmm.binary add(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG1]])

--- a/test/Integration/tpp-run-xsmm-path.mlir
+++ b/test/Integration/tpp-run-xsmm-path.mlir
@@ -37,8 +37,5 @@ func.func @entry() {
   %v1 = vector.transfer_read %added[%c0, %c0], %d1 : tensor<2x2xf32>, vector<2x2xf32>
   vector.print %v1 : vector<2x2xf32>
   
-  bufferization.dealloc_tensor %arg0 : tensor<2x2xf32>
-  bufferization.dealloc_tensor %arg1 : tensor<2x2xf32>
-
   return
 }

--- a/test/Integration/tpp-run-xsmm-path.mlir
+++ b/test/Integration/tpp-run-xsmm-path.mlir
@@ -22,7 +22,7 @@ func.func @add(%arg0: tensor<2x2xf32>, %arg1: tensor<2x2xf32>) -> tensor<2x2xf32
 
 func.func @entry() {
   %cst_one = arith.constant 1.0 : f32
-  %arg0 = bufferization.alloc_tensor() : tensor<2x2xf32>
+  %arg0 = tensor.empty() : tensor<2x2xf32>
   %fill = linalg.fill ins(%cst_one : f32) outs(%arg0 : tensor<2x2xf32>) -> tensor<2x2xf32>
   
   %cst_two = arith.constant 2.0 : f32

--- a/test/Integration/tpp-run-xsmm-path.mlir
+++ b/test/Integration/tpp-run-xsmm-path.mlir
@@ -1,0 +1,44 @@
+// RUN: tpp-run %s -linalg-to-xsmm -e entry -entry-point-result=void | FileCheck %s
+
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" | \
+// RUN: FileCheck %s -check-prefix=IR
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @add(%arg0: tensor<2x2xf32>, %arg1: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  // IR: xsmm_binary_dispatch
+  // IR: xsmm_binary_invoke
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map, #map], 
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg0, %arg1: tensor<2x2xf32>, tensor<2x2xf32>)
+    outs(%arg1: tensor<2x2xf32>) {
+      ^bb0(%in: f32, %in_1: f32, %out: f32):
+        %0 = arith.addf %in, %in_1 : f32
+        linalg.yield %0 : f32
+  } -> tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
+}
+
+func.func @entry() {
+  %cst_one = arith.constant 1.0 : f32
+  %arg0 = bufferization.alloc_tensor() : tensor<2x2xf32>
+  %fill = linalg.fill ins(%cst_one : f32) outs(%arg0 : tensor<2x2xf32>) -> tensor<2x2xf32>
+  
+  %cst_two = arith.constant 2.0 : f32
+  %arg1 = bufferization.alloc_tensor() : tensor<2x2xf32>
+  %fill_1 = linalg.fill ins(%cst_two : f32) outs(%arg1 : tensor<2x2xf32>) -> tensor<2x2xf32>
+
+  %added = call @add(%fill, %fill_1) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  %c0 = arith.constant 0 : index
+  %d1 = arith.constant -1.0 : f32
+ 
+  // CHECK: ( ( 3, 3 ), ( 3, 3 ) ) 
+  %v1 = vector.transfer_read %added[%c0, %c0], %d1 : tensor<2x2xf32>, vector<2x2xf32>
+  vector.print %v1 : vector<2x2xf32>
+  
+  bufferization.dealloc_tensor %arg0 : tensor<2x2xf32>
+  bufferization.dealloc_tensor %arg1 : tensor<2x2xf32>
+
+  return
+}


### PR DESCRIPTION
Enable `linalg-to-xsmm` in tpp.run and fix mapping issue for binary and unary.
For unary and binary operations we need to use the captured operand and not
the operands of the linalg generic. 