### PR TITLE
Improve pack/unpack generalization

### DIFF
--- a/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
+++ b/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
@@ -11,12 +11,16 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "decompose-pack-unpack-ops"
 
 using namespace mlir;
 
@@ -25,45 +29,110 @@ using namespace mlir;
 
 namespace {
 
+// A warpper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
+// a tensor.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
+struct LowerPackPattern : public OpRewritePattern<tensor::PackOp> {
+  using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PackOp op,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<linalg::LowerPackResult> res = linalg::lowerPack(rewriter, op);
+    if (failed(res)) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot lower to pad + expand + transpose");
+    }
+    return success();
+  }
+};
+
+// A warpper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
+// lowers a tensor.unpack op to tensor.empty + linalg.transpose +
+// tensor.collapse_shape + tensor.extract_slice ops.
+struct LowerUnPackPattern : public OpRewritePattern<tensor::UnPackOp> {
+  using OpRewritePattern<tensor::UnPackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::UnPackOp op,
+                                PatternRewriter &rewriter) const override {
+    if (failed(linalg::lowerUnPack(rewriter, op))) {
+      return rewriter.notifyMatchFailure(
+          op, "cannot lower to empty + transpose + reshape + extract_slice");
+    }
+    return success();
+  }
+};
+
 struct GeneralizeTensorPackAndUnPack
     : public GeneralizeTensorPackAndUnPackBase<GeneralizeTensorPackAndUnPack> {
   GeneralizeTensorPackAndUnPack() = default;
-
   void runOnOperation() override {
-    func::FuncOp func = getOperation();
 
-    IRRewriter rewriter(&getContext());
-    func->walk([&](tensor::UnPackOp unPackOp) {
-      scf::SCFTilingOptions unpackTilingOptions;
-      SmallVector<int64_t> tiles(unPackOp.getDestType().getRank(), 1);
-      unpackTilingOptions.setTileSizes(tiles);
-      FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
-          rewriter, cast<TilingInterface>(unPackOp.getOperation()),
-          unpackTilingOptions);
-      if (failed(tilingResult))
+    MLIRContext *ctx = &getContext();
+    auto funcOp = getOperation();
+
+    // Upstream generalization patterns. Decomposition of tensor.unpack
+    // does not support yet outer dim perm.
+    {
+      RewritePatternSet patterns(ctx);
+      patterns.add<LowerPackPattern, LowerUnPackPattern>(ctx);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        funcOp.emitError(
+            "failed to apply generalization patterns on pack/unpack ops for "
+            "general cases.");
         return signalPassFailure();
-      rewriter.replaceOp(unPackOp, tilingResult->replacements);
-    });
-    func->walk([&](tensor::PackOp packOp) {
-      SmallVector<int64_t> tiles(packOp.getSourceType().getRank(), 1);
-      scf::SCFTilingOptions packTilingOptions;
-      packTilingOptions.setTileSizes(tiles);
-      FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
-          rewriter, cast<TilingInterface>(packOp.getOperation()),
-          packTilingOptions);
-      if (failed(tilingResult))
-        return signalPassFailure();
-      rewriter.replaceOp(packOp, tilingResult->replacements);
-    });
-    RewritePatternSet patterns(&getContext());
-    patterns.add<linalg::GeneralizeOuterUnitDimsUnPackOpPattern,
-                 linalg::GeneralizeOuterUnitDimsPackOpPattern>(&getContext());
-    tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
-      return signalPassFailure();
+      }
     }
-    return;
+
+    // Fall back on tile by one + generalization patterns.
+    {
+      IRRewriter rewriter(&getContext());
+      funcOp->walk([&](tensor::UnPackOp unPackOp) {
+        scf::SCFTilingOptions unpackTilingOptions;
+        SmallVector<int64_t> tiles(unPackOp.getDestType().getRank(), 1);
+        unpackTilingOptions.setTileSizes(tiles);
+        FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
+            rewriter, cast<TilingInterface>(unPackOp.getOperation()),
+            unpackTilingOptions);
+        if (failed(tilingResult))
+          return signalPassFailure();
+        rewriter.replaceOp(unPackOp, tilingResult->replacements);
+      });
+      funcOp->walk([&](tensor::PackOp packOp) {
+        SmallVector<int64_t> tiles(packOp.getSourceType().getRank(), 1);
+        scf::SCFTilingOptions packTilingOptions;
+        packTilingOptions.setTileSizes(tiles);
+        FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForOp(
+            rewriter, cast<TilingInterface>(packOp.getOperation()),
+            packTilingOptions);
+        if (failed(tilingResult))
+          return signalPassFailure();
+        rewriter.replaceOp(packOp, tilingResult->replacements);
+      });
+      RewritePatternSet patterns(&getContext());
+      patterns.add<linalg::GeneralizeOuterUnitDimsUnPackOpPattern,
+                   linalg::GeneralizeOuterUnitDimsPackOpPattern>(&getContext());
+      tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                              std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Canonicalize tiled ops.
+    {
+      RewritePatternSet patterns(ctx);
+      linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
+      ctx->getOrLoadDialect<tensor::TensorDialect>()
+          ->getCanonicalizationPatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After canonicalizing tiled ops ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
   }
 };
 

--- a/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
+++ b/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
@@ -28,7 +28,7 @@ using namespace mlir;
 
 namespace {
 
-// A warpper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
+// A wrapper pattern that calls linalg::lowerPack on tensor::PackOp. It lowers
 // a tensor.pack op to tensor.pad + tensor.expand_shape + linalg.transpose ops.
 struct LowerPackPattern : public OpRewritePattern<tensor::PackOp> {
   using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
@@ -44,7 +44,7 @@ struct LowerPackPattern : public OpRewritePattern<tensor::PackOp> {
   }
 };
 
-// A warpper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
+// A wrapper pattern that calls linalg::lowerUnPack on tensor::UnPackOp. It
 // lowers a tensor.unpack op to tensor.empty + linalg.transpose +
 // tensor.collapse_shape + tensor.extract_slice ops.
 struct LowerUnPackPattern : public OpRewritePattern<tensor::UnPackOp> {

--- a/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
+++ b/lib/TPP/GeneralizeTensorPackAndUnPack.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
@@ -69,8 +68,6 @@ struct GeneralizeTensorPackAndUnPack
     MLIRContext *ctx = &getContext();
     auto funcOp = getOperation();
 
-    // Upstream generalization patterns. Decomposition of tensor.unpack
-    // does not support yet outer dim perm.
     {
       RewritePatternSet patterns(ctx);
       patterns.add<LowerPackPattern, LowerUnPackPattern>(ctx);

--- a/test/Conversion/TensorToXsmm/tensor-to-unary.mlir
+++ b/test/Conversion/TensorToXsmm/tensor-to-unary.mlir
@@ -32,12 +32,8 @@ func.func @pack3(%in: tensor<8x2x2x2xf32>, %out: tensor<2x2x1x4x2x2xf32>)-> tens
   return %2: tensor<2x2x1x4x2x2xf32>
 }
 
-// CHECK: func.func @pack3(%[[ARG0:.+]] memref<8x2x2x2xf32>, %[[ARG1:.+]] memref<2x2x1x4x2x2xf32>) -> memref<2x2x1x4x2x2xf32> {
-// CHECK: scf.for
-// CHECK:   scf.for
-// CHECK:     scf.for
-// CHECK:       memref.subview
-// CHECK:       linalg.transpose
-// CHECK:       memref.subview
-// CHECK:       %[[DISPATCH:.+]] = xsmm.unary.dispatch identity [2, 2, 2, 2] flags = (none) data_type = f32 
-// CHECK:       xsmm.unary identity(data_type = f32, %{{[^:]+}}, {{[^:]+}}, {{[^:]+}}) : (i64, memref<2x2xf32>, memref<2x2xf32, strided<[2, 1], offset: ?>>) -> ()
+// CHECK-LABEL: @pack3
+// CHECK-SAME: %[[ARG0:.+]]: memref<8x2x2x2xf32>, %[[ARG1:.+]]: memref<2x2x1x4x2x2xf32>
+// CHECK: %[[EXP:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1], [2, 3], [4], [5]] : memref<8x2x2x2xf32> into memref<4x2x1x2x2x2xf32>
+// CHECK: linalg.transpose ins(%[[EXP]] : memref<4x2x1x2x2x2xf32>) outs(%[[ARG1]] : memref<2x2x1x4x2x2xf32>) 
+// CHECK-SAME:  permutation = [5, 4, 2, 0, 3, 1] 

--- a/test/Passes/pass-generalize-pack-and-unpack.mlir
+++ b/test/Passes/pass-generalize-pack-and-unpack.mlir
@@ -7,25 +7,13 @@ func.func @pack_matmul_operand_b(%in: tensor<512x1024xf32>) -> tensor<32x16x32x3
   return %1 : tensor<32x16x32x32xf32>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
 // CHECK-LABEL: pack_matmul_operand_b
 // CHECK-SAME: %[[ARG0:.+]]: tensor<512x1024xf32>
-// CHECK: %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK: %[[PACKED:.+]] = tensor.empty() : tensor<32x16x32x32xf32>
-// CHECK: %[[LOOP:.+]] = scf.for %[[I:.+]] = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[PACKED]])
-// CHECK-NEXT: %[[LOOP1:.+]] = scf.for %[[J:.+]] = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[ARG2]])
-// CHECK: %[[APPLY:.+]] = affine.apply #[[MAP]](%[[J]])
-// CHECK: %[[APPLY1:.+]] = affine.apply #[[MAP]](%[[I]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice 
-// CHECK-SAME:  %[[ARG0]][%[[APPLY]], %[[APPLY1]]] [32, 32] [1, 1] : tensor<512x1024xf32> to tensor<32x32xf32
-// CHECK: %[[BUFF:.+]] = tensor.empty() : tensor<32x32xf32>
-// CHECK: %[[TRANS:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<32x32xf32>) 
-// CHECK-SAME:  outs(%[[BUFF]] : tensor<32x32xf32>) permutation = [0, 1]
-// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] 
-// CHECK-SAME:  into %[[ARG4]][%[[I]], %[[J]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<32x16x32x32xf32>
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<32x16x32x32xf32>
+// CHECK: %[[EXP:.+]] = tensor.expand_shape %arg0 {{\[}}[0, 1], [2, 3]] : tensor<512x1024xf32> 
+// CHECK-SAME:  into tensor<16x32x32x32xf32>
+// CHECK: %[[T:.+]] = linalg.transpose ins(%expanded : tensor<16x32x32x32xf32>) outs(%[[EMPTY]] : tensor<32x16x32x32xf32>) 
+// CHECK-SAME:  permutation = [2, 0, 1, 3]
 
 // -----
 
@@ -36,27 +24,13 @@ func.func @pack_matmul_operand_a(%in: tensor<256x512xf32>) -> tensor<8x16x32x32x
   return %1 : tensor<8x16x32x32xf32>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
 // CHECK-LABEL: pack_matmul_operand_a
 // CHECK-SAME: %[[ARG0:.+]]: tensor<256x512xf32>
-// CHECK: %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK: %[[PACKED:.+]] = tensor.empty() : tensor<8x16x32x32xf32>
-// CHECK: %{{.+}} = scf.for %[[I:.+]] = %[[C0]] to %[[C8]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[PACKED]])
-// CHECK-NEXT: %{{.+}} = scf.for %[[J:.+]] = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[ARG2]])
-// CHECK: %[[APPLY:.+]] = affine.apply #[[MAP]](%[[I]])
-// CHECK: %[[APPLY1:.+]] = affine.apply #[[MAP]](%[[J]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice 
-// CHECK-SAME:  %[[ARG0]][%[[APPLY]], %[[APPLY1]]] [32, 32] [1, 1] : tensor<256x512xf32> to tensor<32x32xf32
-// CHECK: %[[BUFF:.+]] = tensor.empty() : tensor<32x32xf32>
-// CHECK: %[[TRANS:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<32x32xf32>) 
-// CHECK-SAME:  outs(%[[BUFF]] : tensor<32x32xf32>) permutation = [0, 1]
-// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] 
-// CHECK-SAME:  into %[[ARG4]][%[[I]], %[[J]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<8x16x32x32xf32>
-
-
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<8x16x32x32xf32>
+// CHECK: %[[EXP:.+]] = tensor.expand_shape %arg0 {{\[}}[0, 1], [2, 3]] : tensor<256x512xf32> 
+// CHECK-SAME:  into tensor<8x32x16x32xf32> 
+// CHECK: %[[T:.+]] = linalg.transpose ins(%[[EXP]] : tensor<8x32x16x32xf32>) outs(%[[EMPTY]] : tensor<8x16x32x32xf32>) 
+// CHECK-SAME:  permutation = [0, 2, 1, 3]
 
 // -----
 
@@ -68,19 +42,8 @@ func.func @unpack_matmul(%in: tensor<8x32x32x32xf32>) -> tensor<256x1024xf32> {
 }
 
 // CHECK-LABEL: unpack_matmul
-// CHECK-SAME:  %[[ARG0:.+]]: tensor<8x32x32x32xf32>
-// CHECK: %[[C32:.+]] = arith.constant 32 : index
-// CHECK-DAG: %[[C1024:.+]] = arith.constant 1024 : index
-// CHECK-DAG: %[[C256:.+]] = arith.constant 256 : index
-// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CHECK: %[[UNPACKED:.+]] = tensor.empty() : tensor<256x1024xf32>
-// CHECK: %{{.+}} = scf.for %[[I:.+]] = %[[C0]] to %[[C256]] step %[[C1]] iter_args(%[[ARG2:.+]] = %[[UNPACKED]])
-// CHECK-NEXT: %{{.+}} = scf.for %[[J:.+]] = %[[C0]] to %[[C1024]] step %[[C1]] iter_args(%[[ARG4:.+]] = %[[ARG2]])
-// CHECK: %[[APPLY:.+]] = affine.apply #map1(%arg1)
-// CHECK: %[[APPLY1:.+]] = affine.apply #map1(%arg3)
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice 
-// CHECK-SAME:  %[[ARG0]][%[[APPLY]], %[[APPLY1]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<8x32x32x32xf32> to tensor<32x32xf32>
-// CHECK: %[[BUFF:.+]] = tensor.empty() : tensor<32x32xf32>
-// CHECK: %[[TRANS:.+]] = linalg.transpose ins(%[[SLICE]] : tensor<32x32xf32>) outs(%[[BUFF]] : tensor<32x32xf32>) permutation = [0, 1]
-// CHECK: %[[INSERT:.+]] = tensor.insert_slice %{{.+}} into %[[ARG4]][%[[I]], %[[J]]] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<256x1024xf32>
+// CHECK-SAME: %[[ARG0:.+]]: tensor<8x32x32x32xf32>
+// CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<8x32x32x32xf32>
+// CHECK: %[[T:.+]] = linalg.transpose ins(%[[ARG0]] : tensor<8x32x32x32xf32>) outs(%[[EMPTY]] : tensor<8x32x32x32xf32>) 
+// CHECK-SAME:  permutation = [0, 2, 1, 3]
+// CHECK: %[[CLP:.+]] = tensor.collapse_shape %[[T]] {{\[}}[0, 1], [2, 3]] : tensor<8x32x32x32xf32> into tensor<256x1024xf32>

--- a/test/Passes/tpp-mapping.mlir
+++ b/test/Passes/tpp-mapping.mlir
@@ -194,7 +194,8 @@ func.func @pack_matmul(
 // CHECK:        tensor.insert_slice %[[EXTRACT]] into %[[ARG6]][%[[ARG3]], %[[ARG5]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xf32> into tensor<4x4x32x32xf32>
 // Packed matmul
 // CHECK:    %{{.+}} = scf.forall (%{{.+}}, %{{.+}}) in (4, 4)
-// CHECK:     linalg.batch_reduce_matmul
+// CHECK:     %{{.+}} = linalg.batch_reduce_matmul ins(%{{.+}}, %{{.+}} : tensor<4x32x32xf32>, tensor<4x32x32xf32>) 
+// CHECK-SAME:          outs(%{{.+}} : tensor<32x32xf32>) -> tensor<32x32xf32>
 
 // -----
 


### PR DESCRIPTION
Update pack and unpack generalization to use upstream decomposition. Since upstream decomposition does not cover all the cases (i.e., fails if the unpack has dynamic tiles), keep the current generalization as a fallback.