### PR TITLE
GPU kernel eltwise operation fusion

### DIFF
--- a/benchmarks/config/GPU/cuda.json
+++ b/benchmarks/config/GPU/cuda.json
@@ -50,5 +50,15 @@
       "flags": [ "-n", "100", "--gpu=cuda", "-run-args=-gpu-wmma" ],
       "extensions": [ "(avx2|asimd)" ]
     }
+  }},
+  {
+    "cuda_fc": {
+      "fp32_1024_base_mlir": {
+        "type": "MLIR",
+        "benchmark": "GPU/fc-fp32-1024-base.mlir",
+        "environment": {},
+        "flags": [ "-n", "100", "--gpu=cuda" ],
+        "extensions": [ "(avx2|asimd)" ]
+      }
   }}
 ]

--- a/benchmarks/config/GPU/cuda.json
+++ b/benchmarks/config/GPU/cuda.json
@@ -60,5 +60,15 @@
         "flags": [ "-n", "100", "--gpu=cuda" ],
         "extensions": [ "(avx2|asimd)" ]
       }
+  }},
+  {
+    "cuda_mlp": {
+      "fp32_1024_base_mlir": {
+        "type": "MLIR",
+        "benchmark": "GPU/mlp-fp32-1024-base.mlir",
+        "environment": {},
+        "flags": [ "-n", "100", "--gpu=cuda" ],
+        "extensions": [ "(avx2|asimd)" ]
+      }
   }}
 ]

--- a/benchmarks/mlir/GPU/fc-fp32-1024-base.mlir
+++ b/benchmarks/mlir/GPU/fc-fp32-1024-base.mlir
@@ -23,7 +23,7 @@ module {
     %cst = arith.constant 0.000000e+00 : f32
     %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<256x1024xf32>) {
     ^bb0(%out: f32):
-      %3 = arith.maxf %out, %cst : f32
+      %3 = arith.maximumf %out, %cst : f32
       linalg.yield %3 : f32
     } -> tensor<256x1024xf32>
     return %2 : tensor<256x1024xf32>

--- a/benchmarks/mlir/GPU/fc-fp32-1024-base.mlir
+++ b/benchmarks/mlir/GPU/fc-fp32-1024-base.mlir
@@ -1,0 +1,31 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// BENCH_TOTAL_FLOPS: 537395200
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @entry(%arg0: tensor<256x1024xf32>, %arg1: tensor<1024x1024xf32>, %arg2: tensor<256x1024xf32>, %arg3: tensor<256x1024xf32>) -> tensor<256x1024xf32> {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<256x1024xf32>, tensor<1024x1024xf32>) outs(%arg3 : tensor<256x1024xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %3 = arith.mulf %in, %in_0 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<256x1024xf32>
+    %1 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<256x1024xf32>) outs(%0 : tensor<256x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %3 = arith.addf %in, %out : f32
+      linalg.yield %3 : f32
+    } -> tensor<256x1024xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<256x1024xf32>) {
+    ^bb0(%out: f32):
+      %3 = arith.maxf %out, %cst : f32
+      linalg.yield %3 : f32
+    } -> tensor<256x1024xf32>
+    return %2 : tensor<256x1024xf32>
+  }
+}

--- a/benchmarks/mlir/GPU/mlp-fp32-1024-base.mlir
+++ b/benchmarks/mlir/GPU/mlp-fp32-1024-base.mlir
@@ -1,0 +1,35 @@
+// RUN: tpp-run %s -n 10 \
+// RUN:  -e entry -entry-point-result=void
+
+// BENCH_TOTAL_FLOPS: 537395200
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @entry(%arg0: tensor<256x1024xf32>, %arg1: tensor<256x1024xf32>) -> tensor<256x1024xf32> {
+    %weights = arith.constant dense<1.0> : tensor<1024x1024xf32>
+    %bias = arith.constant dense<1.0> : tensor<256x1024xf32>
+
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %weights : tensor<256x1024xf32>, tensor<1024x1024xf32>) outs(%arg1 : tensor<256x1024xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %3 = arith.mulf %in, %in_0 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<256x1024xf32>
+    %1 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%bias : tensor<256x1024xf32>) outs(%0 : tensor<256x1024xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %3 = arith.addf %in, %out : f32
+      linalg.yield %3 : f32
+    } -> tensor<256x1024xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<256x1024xf32>) {
+    ^bb0(%out: f32):
+      %3 = arith.maximumf %out, %cst : f32
+      linalg.yield %3 : f32
+    } -> tensor<256x1024xf32>
+    %3 = bufferization.materialize_in_destination %2 in %arg1 : tensor<256x1024xf32>
+    return %3 : tensor<256x1024xf32>
+  }
+}

--- a/lib/TPP/GPU/LinalgToGpu.cpp
+++ b/lib/TPP/GPU/LinalgToGpu.cpp
@@ -372,7 +372,7 @@ static LogicalResult gemmToGpuLoops(linalg::LinalgOp linalgOp,
         break;
       }
 
-      rewriter.eraseOp(linalgOp);
+      rewriter.eraseOp(op);
     }
   }
 

--- a/lib/TPP/GPU/LinalgToGpu.cpp
+++ b/lib/TPP/GPU/LinalgToGpu.cpp
@@ -199,7 +199,7 @@ static std::optional<Operation *> scalarFusion(linalg::LinalgOp rootOp,
   SmallVector<Value> operands;
   if (structured_match::utils::isTwoDAddOp(consumer, &operands)) {
     // Get the value to be added. Load the element first, if necessary.
-    auto addValue = operands[0] != rootOutput ? operands[0] : operands[1];
+    auto addValue = (operands[0] != rootOutput) ? operands[0] : operands[1];
     if (addValue.getType().isa<ShapedType>()) {
       addValue = rewriter.create<memref::LoadOp>(loc, addValue, storeIndices)
                      .getResult();

--- a/lib/TPP/GPU/LinalgToGpu.cpp
+++ b/lib/TPP/GPU/LinalgToGpu.cpp
@@ -8,8 +8,8 @@
 
 #include "TPP/Passes.h"
 
-#include "TPP/ValueUtils.h"
 #include "TPP/MatcherUtils.h"
+#include "TPP/ValueUtils.h"
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -509,7 +509,8 @@ static LogicalResult gemmToGpuLoops(linalg::LinalgOp linalgOp,
   }
 
   // Write back the total sum to the output buffer.
-  auto storeOp = rewriter.create<memref::StoreOp>(loc, result, matC, parallelIvs);
+  auto storeOp =
+      rewriter.create<memref::StoreOp>(loc, result, matC, parallelIvs);
 
   (void)fuseEltwiseConsumers(linalgOp, storeOp, parallelIvs, rewriter);
 

--- a/test/GPU/CUDA/Integration/linalg-fc.mlir
+++ b/test/GPU/CUDA/Integration/linalg-fc.mlir
@@ -1,0 +1,33 @@
+// RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
+// RUN: tpp-run %s -gpu=cuda -print \
+// RUN:  -entry-point-result=void -e entry 2>&1 | \
+// RUN: FileCheck %s
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @entry(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<64x64xf32>, %arg3: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%arg3 : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %3 = arith.mulf %in, %in_0 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<64x64xf32>
+    %1 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<64x64xf32>) outs(%0 : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %3 = arith.addf %in, %out : f32
+      linalg.yield %3 : f32
+    } -> tensor<64x64xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<64x64xf32>) {
+    ^bb0(%out: f32):
+      %3 = arith.maxf %out, %cst : f32
+      linalg.yield %3 : f32
+    } -> tensor<64x64xf32>
+    return %2 : tensor<64x64xf32>
+  }
+}
+
+// CHECK-COUNT-64: 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66

--- a/test/GPU/CUDA/Integration/linalg-fc.mlir
+++ b/test/GPU/CUDA/Integration/linalg-fc.mlir
@@ -23,7 +23,7 @@ module {
     %cst = arith.constant 0.000000e+00 : f32
     %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<64x64xf32>) {
     ^bb0(%out: f32):
-      %3 = arith.maxf %out, %cst : f32
+      %3 = arith.maximumf %out, %cst : f32
       linalg.yield %3 : f32
     } -> tensor<64x64xf32>
     return %2 : tensor<64x64xf32>

--- a/test/GPU/CUDA/Integration/linalg-mlp.mlir
+++ b/test/GPU/CUDA/Integration/linalg-mlp.mlir
@@ -39,26 +39,17 @@ module {
   }
 }
 
-// At the moment, each linalg.generic is lowered into a separate kernel.
+// linalg.generic ops are fused into a single kernel.
 // CHECK-LABEL: func.func @_entry
-// CHECK: gpu.launch_func
-// CHECK: gpu.launch_func
-// CHECK: gpu.launch_func
-
-// matmul kernel
+// CHECK-COUNT-1: gpu.launch_func
 // CHECK: gpu.module @_entry_kernel
 // CHECK: llvm.func @_entry_kernel
+// matmul kernel
 // CHECK: llvm.fmul
 // CHECK: llvm.fadd
-
 // bias kernel
-// CHECK: gpu.module @_entry_kernel
-// CHECK: llvm.func @_entry_kernel
 // CHECK: llvm.fadd
-
 // relu kernel
-// CHECK: gpu.module @_entry_kernel
-// CHECK: llvm.func @_entry_kernel
 // CHECK: llvm.fcmp
 // CHECK: llvm.select
 

--- a/test/GPU/Vulkan/Integration/linalg-fc.mlir
+++ b/test/GPU/Vulkan/Integration/linalg-fc.mlir
@@ -23,7 +23,7 @@ module {
     %cst = arith.constant 0.000000e+00 : f32
     %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<64x64xf32>) {
     ^bb0(%out: f32):
-      %3 = arith.maxf %out, %cst : f32
+      %3 = arith.maximumf %out, %cst : f32
       linalg.yield %3 : f32
     } -> tensor<64x64xf32>
     return %2 : tensor<64x64xf32>

--- a/test/GPU/Vulkan/Integration/linalg-fc.mlir
+++ b/test/GPU/Vulkan/Integration/linalg-fc.mlir
@@ -1,0 +1,33 @@
+// RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
+// RUN: tpp-run %s -gpu=vulkan -print \
+// RUN:  -entry-point-result=void -e entry 2>&1 | \
+// RUN: FileCheck %s
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map3 = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @entry(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf32>, %arg2: tensor<64x64xf32>, %arg3: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%arg3 : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %3 = arith.mulf %in, %in_0 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<64x64xf32>
+    %1 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<64x64xf32>) outs(%0 : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %3 = arith.addf %in, %out : f32
+      linalg.yield %3 : f32
+    } -> tensor<64x64xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = linalg.generic {indexing_maps = [#map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<64x64xf32>) {
+    ^bb0(%out: f32):
+      %3 = arith.maxf %out, %cst : f32
+      linalg.yield %3 : f32
+    } -> tensor<64x64xf32>
+    return %2 : tensor<64x64xf32>
+  }
+}
+
+// CHECK-COUNT-64: 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66

--- a/test/GPU/linalg-to-gpu-wmma.mlir
+++ b/test/GPU/linalg-to-gpu-wmma.mlir
@@ -156,7 +156,7 @@ func.func @matmul_add_relu(%arg0: memref<16x16xf16>, %arg1: memref<16x16xf16>, %
   }
   linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%arg3 :memref<16x16xf16>) {
   ^bb0(%out: f16):
-    %0 = arith.maxf %out, %cst : f16
+    %0 = arith.maximumf %out, %cst : f16
     linalg.yield %0 : f16
   }
   return

--- a/test/GPU/linalg-to-gpu.mlir
+++ b/test/GPU/linalg-to-gpu.mlir
@@ -107,7 +107,7 @@ func.func @matmul_add_relu(%arg0: memref<256x1024xf32>, %arg1: memref<1024x1024x
     }
     linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%subview_2 : memref<32x32xf32, strided<[1024, 1], offset: ?>>) {
     ^bb0(%out: f32):
-      %0 = arith.maxf %out, %cst : f32
+      %0 = arith.maximumf %out, %cst : f32
       linalg.yield %0 : f32
     }
     scf.yield
@@ -136,7 +136,7 @@ func.func @matmul_add_relu(%arg0: memref<256x1024xf32>, %arg1: memref<1024x1024x
 // CHECK-NOT:         linalg.generic
 // CHECK:             %[[elemBias:.+]] = memref.load
 // CHECK:             %[[biasAdd:.+]] = arith.addf %[[sum]], %[[elemBias]]
-// CHECK:             %[[reluRes:.+]] = arith.maxf %[[biasAdd]], %[[zero]]
+// CHECK:             %[[reluRes:.+]] = arith.maximumf %[[biasAdd]], %[[zero]]
 // CHECK:             memref.store %[[reluRes]], %[[outTile]]
 // CHECK:             scf.yield
 // CHECK:           }

--- a/test/GPU/linalg-to-gpu.mlir
+++ b/test/GPU/linalg-to-gpu.mlir
@@ -88,7 +88,7 @@ func.func @brgemm_dynamic_shapes(%arg0: memref<?x?x?xf32>,
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-func.func @tiled_fc(%arg0: memref<256x1024xf32>, %arg1: memref<1024x1024xf32>, %arg2: memref<256x1024xf32>, %arg3: memref<256x1024xf32>) {
+func.func @matmul_add_relu(%arg0: memref<256x1024xf32>, %arg1: memref<1024x1024xf32>, %arg2: memref<256x1024xf32>, %arg3: memref<256x1024xf32>) {
   %c0 = arith.constant 0 : index
   %c256 = arith.constant 256 : index
   %c1024 = arith.constant 1024 : index
@@ -115,8 +115,8 @@ func.func @tiled_fc(%arg0: memref<256x1024xf32>, %arg1: memref<1024x1024xf32>, %
   return
 }
 
-// CHECK-LABEL: func.func @tiled_fc(
-// CHECK-SAME:  %[[A:.+]]: memref<256x1024xf32>, %[[B:.+]]: memref<1024x1024xf32>, %[[bias:.+]]: memref<256x1024xf32>, %[[C:.+]]: memref<256x1024xf32>
+// CHECK-LABEL: func.func @matmul_add_relu(
+// CHECK-SAME:  %[[A:.+]]: memref<256x1024xf32>, %[[B:.+]]: memref<1024x1024xf32>, %[[BIAS:.+]]: memref<256x1024xf32>, %[[C:.+]]: memref<256x1024xf32>
 // CHECK-DAG:     %[[m:.+]] = arith.constant 256 : index
 // CHECK-DAG:     %[[n:.+]] = arith.constant 1024 : index
 // CHECK-DAG:     %[[tile:.+]] = arith.constant 32 : index


### PR DESCRIPTION
Extends linalg to GPU lowering with a simple fusion strategy to allow efficient GPU kernel generation by combining matmul computation with following element wise operations.
Adds a fully connected kernel to GPU benchmarks.

The fusion is added for both scalar and WMMA lowering.