### PR TITLE
Descend linalgToXsmm decision into TPP passes

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -130,7 +130,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPostprocessingPass();
 std::unique_ptr<OperationPass<ModuleOp>> createTppMappingPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createTppConversionPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
-createTppLoweringPass(bool loops = false);
+createTppLoweringPass(bool tppToLoops = false, bool linalgToXsmm = false);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertForAllToParallelOpPass();
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -385,6 +385,9 @@ def TppLowering : Pass<"tpp-lowering", "func::FuncOp"> {
     Option<"tppToLoops", "tpp-to-loops",
            "bool", /*default=*/"0",
            "By default TPP ops are lowered to XSMM. Lower TPP to loops instead.">,
+    Option<"linalgToXsmm", "linalg-to-xsmm",
+           "bool", /*default=*/"0",
+           "By default Linalg ops are lowered to TPP. Lower Linalg to XSMM instead.">,
   ];
   let constructor = "mlir::tpp::createTppLoweringPass()";
 }


### PR DESCRIPTION
This allows us to combine the existing TPP passes to the Linalg-to-XSMM path without the need to re-write all the pipeline for both. The decision to lower to TPP at Tensor level or not is accompanied by the decision to lower either TPP or Linalg to XSMM, respectively.