### PR TITLE
Default pipeline - DCE cleanup

### DIFF
--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -203,6 +203,12 @@ private:
 
     pm.addPass(createConvertVulkanLaunchFuncToVulkanCallsPass());
 
+    // Anything useful has been lowered by now.
+    // Cleanup IR by removing any dead symbols.
+    // This step aims to avoid errors caused by frontend leftovers.
+    // See issue: #704
+    pm.addPass(createSymbolDCEPass());
+
     // Print IR of kernel and main in LLVM dialect
     if (print == PrintStage::LLVM)
       pm.addPass(createPrintIRPass());

--- a/test/Passes/DefaultPipeline/dce.mlir
+++ b/test/Passes/DefaultPipeline/dce.mlir
@@ -1,0 +1,18 @@
+// RUN: tpp-opt %s -default-pipeline -split-input-file | FileCheck %s
+
+module {
+  ml_program.global private mutable @unused_global(dense<0> : tensor<i64>) : tensor<i64>
+  func.func private @unused_func(!llvm.ptr, i64)
+  
+  func.func @entry(%arg0: tensor<8x8xf32>, %arg1: tensor<8x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
+    %0 = linalg.matmul ins(%arg0, %arg1 : tensor<8x8xf32>, tensor<8x8xf32>)
+                      outs(%arg2 : tensor<8x8xf32>) -> tensor<8x8xf32>
+    return %0 : tensor<8x8xf32>
+  }
+}
+
+// CHECK: module
+// CHECK-NOT: @unused_global
+// CHECK-NOT: @unused_func
+// CHECK: @entry
+// CHECK:   llvm.return


### PR DESCRIPTION
Adds DCE cleanup at the end of pipeline to remove any unnecessary ops.

This cleanup is motivated by leftover IR generated by torch-mlir frontend that prevents final lowering to LLVM.
See #704