### PR TITLE
Disable code format as dependency for check-all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,5 +166,5 @@ add_custom_target(check-python ${CI_DIR}/lint-python.sh)
 add_custom_target(check-clang  ${CI_DIR}/lint-clang.sh)
 add_custom_target(check-format DEPENDS check-clang check-python)
 
-# Check-all
-add_custom_target(check-all DEPENDS check check-format)
+# Check-all is just check, for now
+add_custom_target(check-all DEPENDS check)


### PR DESCRIPTION
Still keeps the targets and scripts to help formatting, but the version issue in clang-format is non-trivial, so disable from the default target for CI builds.

Policy changes to "format only the part of the code you change", similar to LLVM upstream. Then you can use any format tool that makes the code look "ok".