### PR TITLE
Check TPP and XSMM element types

### DIFF
--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -186,9 +186,7 @@ struct HasRank {
 // Callable object to verify `operand` to have an element type `T`.
 template <typename T> struct HasElementType {
   bool operator()(OpOperand *operand, Operation *op) const {
-    auto operandType = operand->get().getType();
-    if (auto shapedType = dyn_cast_or_null<ShapedType>(operandType))
-      operandType = shapedType.getElementType();
+    auto operandType = getElementTypeOrSelf(operand->get().getType());
     return isa<T>(operandType);
   }
 };

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -183,6 +183,16 @@ struct HasRank {
   std::vector<int64_t> ranks;
 };
 
+// Callable object to verify `operand` to have an element type `T`.
+template <typename T> struct HasElementType {
+  bool operator()(OpOperand *operand, Operation *op) const {
+    auto operandType = operand->get().getType();
+    if (auto shapedType = dyn_cast_or_null<ShapedType>(operandType))
+      operandType = shapedType.getElementType();
+    return isa<T>(operandType);
+  }
+};
+
 // Callable object to check if the input is equal to specified `value`.
 template <typename T> struct EqualsTo {
   EqualsTo() = delete;

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -174,7 +174,7 @@ struct ConvertFillToTpp : public OpRewritePattern<linalg::FillOp> {
     auto outType = dyn_cast_or_null<ShapedType>(output.getType());
     if (!outType || !isa<FloatType>(outType.getElementType()))
       return rewriter.notifyMatchFailure(fillOp, "Expect shaped float type");
-    auto outputRank = output.getType().cast<ShapedType>().getRank();
+    auto outputRank = outType.getRank();
     if (outputRank != 2)
       return rewriter.notifyMatchFailure(fillOp, "Expect output rank 2");
 

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -115,7 +115,7 @@ struct ConvertBrgemmToTpp
     SmallVector<Value> inputs = brMatmulOp.getDpsInputs();
     inputs.push_back(brMatmulOp.getDpsInits()[0]);
     Value output = brMatmulOp.getDpsInits()[0];
-    auto outType = dyn_cast_or_null<ShapedType>(output.getType());
+    auto outType = dyn_cast<ShapedType>(output.getType());
     if (!outType || !isa<FloatType>(outType.getElementType())) {
       return rewriter.notifyMatchFailure(brMatmulOp,
                                          "Expect shaped float type");
@@ -143,7 +143,7 @@ struct ConvertMatmulToTpp : public OpRewritePattern<linalg::MatmulOp> {
     SmallVector<Value> inputs = matmulOp.getDpsInputs();
     inputs.push_back(matmulOp.getDpsInits()[0]);
     Value output = matmulOp.getDpsInits()[0];
-    auto outType = dyn_cast_or_null<ShapedType>(output.getType());
+    auto outType = dyn_cast<ShapedType>(output.getType());
     if (!outType || !isa<FloatType>(outType.getElementType()))
       return rewriter.notifyMatchFailure(matmulOp, "Expect shaped float type");
 
@@ -172,7 +172,7 @@ struct ConvertFillToTpp : public OpRewritePattern<linalg::FillOp> {
       return rewriter.notifyMatchFailure(fillOp, "Unsupported fill type");
 
     auto output = fillOp.getOutputs()[0];
-    auto outType = dyn_cast_or_null<ShapedType>(output.getType());
+    auto outType = dyn_cast<ShapedType>(output.getType());
     if (!outType || !isa<FloatType>(outType.getElementType()))
       return rewriter.notifyMatchFailure(fillOp, "Expect shaped float type");
     auto outputRank = outType.getRank();

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -116,9 +116,10 @@ struct ConvertBrgemmToTpp
     inputs.push_back(brMatmulOp.getDpsInits()[0]);
     Value output = brMatmulOp.getDpsInits()[0];
     auto outType = dyn_cast_or_null<ShapedType>(output.getType());
-    if (!outType || !isa<FloatType>(outType.getElementType()))
+    if (!outType || !isa<FloatType>(outType.getElementType())) {
       return rewriter.notifyMatchFailure(brMatmulOp,
                                          "Expect shaped float type");
+    }
 
     rewriter.replaceOpWithNewOp<tpp::BrgemmOp>(brMatmulOp, inputs, outType);
     return success();

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -20,7 +20,6 @@ DataTypeAttr getDataType(RewriterBase &rewriter, Type type) {
   auto elemType = getElementTypeOrSelf(type);
   if (elemType.isBF16())
     return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::BF16);
-  assert(elemType.isF32() && "Element type neither bf16 nor f32");
   return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::F32);
 }
 
@@ -47,8 +46,10 @@ FailureOr<UnaryInfo> getUnaryInfo(Value input, Value output) {
 
   assert(isa<ShapedType>(outputType));
   auto outputShapedType = output.getType().cast<ShapedType>();
-  if (outputShapedType.getRank() != 2 || !outputShapedType.hasStaticShape())
+  if (outputShapedType.getRank() != 2 || !outputShapedType.hasStaticShape() ||
+      !isa<FloatType>(outputShapedType.getElementType())) {
     return failure();
+  }
 
   UnaryInfo unaryInfo;
   unaryInfo.m = outputShapedType.getShape()[0];

--- a/lib/TPP/MatcherUtils.cpp
+++ b/lib/TPP/MatcherUtils.cpp
@@ -50,6 +50,7 @@ static bool isTppOp(linalg::LinalgOp linalgOp) {
       .input(MatchAll(), HasStaticShape())
       .operation(NumRegions(EqualsTo(1)))
       .output(MatchAll(), HasStaticStrides())
+      .output(MatchAll(), HasElementType<FloatType>())
       .input(MatchAll(), HasStaticStrides())
       .operation(VerifyOpProperty(hasEqualOperandTypes));
   // clang-format on

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -863,3 +863,14 @@ func.func @linalg_zero_gemm_fused_bias_relu_no_chain(%arg0: tensor<128x256xf32>,
   return %1 : tensor<128x512xf32>
 }
 
+// -----
+
+// CHECK-LABEL: func.func @linalg_matmul_i32
+func.func @linalg_matmul_i32(%arg0: tensor<16x16xi32>, %arg1: tensor<16x16xi32>,
+                             %arg2: tensor<16x16xi32>) -> (tensor<16x16xi32>) {
+  // CHECK-NOT: tpp.gemm
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<16x16xi32>, tensor<16x16xi32>)
+                     outs(%arg2 : tensor<16x16xi32>) -> tensor<16x16xi32>
+
+  return %0 : tensor<16x16xi32>
+}

--- a/test/Passes/DefaultPipeline/linalg-to-xsmm.mlir
+++ b/test/Passes/DefaultPipeline/linalg-to-xsmm.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" | FileCheck %s
+// RUN: tpp-opt %s -default-tpp-passes="linalg-to-xsmm" -split-input-file | FileCheck %s
 
 func.func @fill_op(%arg0: memref<3x3xf32>) {
   %cst = arith.constant 0.0 : f32
@@ -19,3 +19,14 @@ func.func @fill_op(%arg0: memref<3x3xf32>) {
 // CHECK: %[[PTR_TO_INT:.+]] = arith.index_cast %[[PTR]] : index to i64
 // CHECK: %[[LLVM_PTR:.+]] = llvm.inttoptr %[[PTR_TO_INT]] : i64 to !llvm.ptr<f32>
 // CHECK: call @xsmm_unary_scalar_invoke(%[[C1]], %[[DIS]], %[[CST]], %[[LLVM_PTR]], %[[C0]])
+
+// -----
+
+func.func @fill_op_i32(%arg0: memref<3x3xi32>) {
+  %cst = arith.constant 0 : i32
+  linalg.fill ins(%cst : i32) outs(%arg0 : memref<3x3xi32>)
+  return
+}
+
+// CHECK-LABEL: fill_op_i32
+// CHECK-NOT: xsmm


### PR DESCRIPTION
Adds operand element type checking to TPP and XSMM operation matcher.

Removes XSMM assert for better debug quality - it lets operation verifier return readable and traceable error.

Fixes #743 