### PR TITLE
[mlir-gen] Refactor all kernels into a single generator

### DIFF
--- a/benchmarks/config/fc/1024x1024x512.json
+++ b/benchmarks/config/fc/1024x1024x512.json
@@ -37,14 +37,14 @@
   "fc_1024x1024x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x1024x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x1024x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x2560x1024.json
+++ b/benchmarks/config/fc/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "fc_1024x2560x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x2560x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x2560x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x352x512.json
+++ b/benchmarks/config/fc/1024x352x512.json
@@ -37,14 +37,14 @@
   "fc_1024x352x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x352x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x352x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x512x256.json
+++ b/benchmarks/config/fc/1024x512x256.json
@@ -37,14 +37,14 @@
   "fc_1024x512x256_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x512x256_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x512x256_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x1024.json
+++ b/benchmarks/config/fc/128x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_128x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x4096.json
+++ b/benchmarks/config/fc/128x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_128x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x3072x768.json
+++ b/benchmarks/config/fc/128x3072x768.json
@@ -37,14 +37,14 @@
   "fc_128x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x4096x1024.json
+++ b/benchmarks/config/fc/128x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_128x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x2304.json
+++ b/benchmarks/config/fc/128x768x2304.json
@@ -37,14 +37,14 @@
   "fc_128x768x2304_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x2304_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x2304_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x3072.json
+++ b/benchmarks/config/fc/128x768x3072.json
@@ -37,14 +37,14 @@
   "fc_128x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x768.json
+++ b/benchmarks/config/fc/128x768x768.json
@@ -37,14 +37,14 @@
   "fc_128x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x1024.json
+++ b/benchmarks/config/fc/256x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_256x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x4096.json
+++ b/benchmarks/config/fc/256x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_256x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x3072x768.json
+++ b/benchmarks/config/fc/256x3072x768.json
@@ -37,14 +37,14 @@
   "fc_256x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x4096x1024.json
+++ b/benchmarks/config/fc/256x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_256x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x3072.json
+++ b/benchmarks/config/fc/256x768x3072.json
@@ -37,14 +37,14 @@
   "fc_256x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x768.json
+++ b/benchmarks/config/fc/256x768x768.json
@@ -37,14 +37,14 @@
   "fc_256x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=32 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=2 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=fc --float-width=16 --vnni=4 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x1024x512.json
+++ b/benchmarks/config/matmul/1024x1024x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x1024x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x1024x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x1024x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x2560x1024.json
+++ b/benchmarks/config/matmul/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "matmul_1024x2560x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x2560x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x2560x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x352x512.json
+++ b/benchmarks/config/matmul/1024x352x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x352x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x352x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x352x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x512x256.json
+++ b/benchmarks/config/matmul/1024x512x256.json
@@ -37,14 +37,14 @@
   "matmul_1024x512x256_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x512x256_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x512x256_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x1024.json
+++ b/benchmarks/config/matmul/128x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x3072x768.json
+++ b/benchmarks/config/matmul/128x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_128x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x4096x1024.json
+++ b/benchmarks/config/matmul/128x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x2304.json
+++ b/benchmarks/config/matmul/128x768x2304.json
@@ -37,14 +37,14 @@
   "matmul_128x768x2304_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x2304_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x2304_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x3072.json
+++ b/benchmarks/config/matmul/128x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_128x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x768.json
+++ b/benchmarks/config/matmul/128x768x768.json
@@ -37,14 +37,14 @@
   "matmul_128x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x1024.json
+++ b/benchmarks/config/matmul/256x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x4096.json
+++ b/benchmarks/config/matmul/256x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x3072x768.json
+++ b/benchmarks/config/matmul/256x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_256x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x4096x1024.json
+++ b/benchmarks/config/matmul/256x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x3072.json
+++ b/benchmarks/config/matmul/256x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_256x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x768.json
+++ b/benchmarks/config/matmul/256x768x768.json
@@ -37,14 +37,14 @@
   "matmul_256x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=32 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=4 --mini-batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -36,7 +36,7 @@
              },
              "irgen": {
                  "type": "IR-GEN",
-                 "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
+                 "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
                  "environment": { "OMP_NUM_THREADS": "32" },
                  "flags": [ "-n", "100" ],
                  "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -36,7 +36,7 @@
              },
              "irgen": {
                  "type": "IR-GEN",
-                 "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --mini-batch=64 --layers=64,64 --tiles=32,32,32" ],
+                 "benchmark": [ "mlir-gen", "--kernel=matmul --float-width=16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
                  "environment": { "OMP_NUM_THREADS": "32" },
                  "flags": [ "-n", "100" ],
                  "extensions": [ "(avx2|asimd)" ]

--- a/test/BF16/Integration/mlir-gen-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-bf16.mlir
@@ -1,22 +1,18 @@
 // MLP without softmax (can't print packed version for now)
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --bias-acc --float-width=16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CHECK-BF16
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
 
 // Matmul only
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL-BF16
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=matmul --seed=123 --float-width=16 --mini-batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
+// RUN: mlir-gen --kernel=layer --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=fc --seed=123 --float-width=16 --mini-batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
 
 // BF16/VNNI execution
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-
-// CHECK-BF16:  ( 1.43{{.*}}, 1.58{{.*}}, 1.26{{.*}}, 1.60{{.*}}, 2.29{{.*}}, 1.87{{.*}}, 1.27{{.*}}, 1.13{{.*}}, 1.96{{.*}}, 1.53{{.*}} )
-
-// MATMUL-BF16: ( 1.32{{.*}}, 2.10{{.*}}, 1.73{{.*}}, 1.71{{.*}}, 1.92{{.*}}, 2.15{{.*}}, 1.35{{.*}}, 1.64{{.*}}, 1.35{{.*}}, 1.43{{.*}} )
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
 // GEN-MATMUL-BF16: ( 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 )
 

--- a/test/BF16/Integration/mlir-gen-fc-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-fc-bf16.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=16 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=16 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=16 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/BF16/Integration/mlir-gen-matmul-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-matmul-bf16.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=16 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=16 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=16 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen-fc.mlir
+++ b/test/Integration/mlir-gen-fc.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=32 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen-flops.mlir
+++ b/test/Integration/mlir-gen-flops.mlir
@@ -1,29 +1,29 @@
 // Unit sizes
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=32 --mini-batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=32 --mini-batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
-// RUN: mlir-gen --kernel=mlp --seed=0 --float-width=32 --mini-batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
+// RUN: mlir-gen --kernel=model --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
 // Small sizes
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=32 --mini-batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=32 --mini-batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
-// RUN: mlir-gen --kernel=mlp --seed=0 --float-width=32 --mini-batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
+// RUN: mlir-gen --kernel=model --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
 // Large sizes + no tiling
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=32 --mini-batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=32 --mini-batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --kernel=mlp --seed=0 --float-width=32 --mini-batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --kernel=model --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
 // Large sizes + tiling
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=32 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --kernel=fc --seed=0 --float-width=32 --mini-batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --kernel=mlp --seed=0 --float-width=32 --mini-batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --kernel=model --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
 
 // Validate that flops are computed correctly
 // MATMUL-UNIT: // BENCH_TOTAL_FLOPS: 2
 // FC-UNIT: // BENCH_TOTAL_FLOPS: 4
-// MLP-UNIT: // BENCH_TOTAL_FLOPS: 2
+// MLP-UNIT: // BENCH_TOTAL_FLOPS: 4
 
 // MATMUL-SMALL: // BENCH_TOTAL_FLOPS: 1024
 // FC-SMALL: // BENCH_TOTAL_FLOPS: 1280
-// MLP-SMALL: // BENCH_TOTAL_FLOPS: 2688
+// MLP-SMALL: // BENCH_TOTAL_FLOPS: 2944
 
 // MATMUL-LARGE: // BENCH_TOTAL_FLOPS: 1073741824
 // FC-LARGE: // BENCH_TOTAL_FLOPS: 1074790400
-// MLP-LARGE: // BENCH_TOTAL_FLOPS: 537133056
+// MLP-LARGE: // BENCH_TOTAL_FLOPS: 537395200

--- a/test/Integration/mlir-gen-matmul.mlir
+++ b/test/Integration/mlir-gen-matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --kernel=matmul --seed=0 --float-width=32 --mini-batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=layer --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen.mlir
+++ b/test/Integration/mlir-gen.mlir
@@ -1,36 +1,27 @@
-// MLP with Softmax version (only unpacked for now)
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --bias-acc --softmax | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=SOFTMAX
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --softmax | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=SOFTMAX
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --softmax | tpp-run -e entry -entry-point-result=void -print --tpp-to-loops | FileCheck %s --check-prefix=SOFTMAX
+// MLP with Softmax version
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 --softmax | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 --softmax | tpp-run -e entry -entry-point-result=void --tpp-to-loops
 
-// MLP without softmax (can't print packed version for now)
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --bias-acc | tpp-run -e entry -entry-point-result=void -print | FileCheck %s
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void -print --tpp-to-loops | FileCheck %s
+// MLP without softmax
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void --tpp-to-loops
 
-// Matmul only (BF16 tests in BF16 directory)
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
+// Matmul only
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void
 
 // Constant values
-// RUN: mlir-gen --kernel=mlp --mini-batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
+// RUN: mlir-gen --kernel=model --bias --relu --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=matmul --seed=123 --float-width=32 --mini-batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
+// RUN: mlir-gen --kernel=layer --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=fc --seed=123 --float-width=32 --mini-batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
+// RUN: mlir-gen --kernel=layer --bias --relu --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
 
-// Packed versions (can't print for now, so just check that it runs) TODO: Implement softmax, print 4D tensors
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --tiles=2,2,2 --bias-acc | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=mlp --seed=123 --mini-batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 --tpp-to-loops | FileCheck %s --check-prefix=PERF
-
-// SOFTMAX: ( 0.08{{.*}}, 0.09{{.*}}, 0.06{{.*}}, 0.10{{.*}}, 0.19{{.*}}, 0.13{{.*}}, 0.06{{.*}}, 0.06{{.*}}, 0.14{{.*}}, 0.09{{.*}} )
-
-// CHECK:   ( 1.43{{.*}}, 1.58{{.*}}, 1.26{{.*}}, 1.60{{.*}}, 2.29{{.*}}, 1.87{{.*}}, 1.26{{.*}}, 1.13{{.*}}, 1.96{{.*}}, 1.54{{.*}} )
-
-// MATMUL:  ( 1.33{{.*}}, 2.11{{.*}}, 1.73{{.*}}, 1.71{{.*}}, 1.93{{.*}}, 2.15{{.*}}, 1.35{{.*}}, 1.65{{.*}}, 1.35{{.*}}, 1.43{{.*}} )
+// Packed versions
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=model --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 --tpp-to-loops | FileCheck %s --check-prefix=PERF
 
 // CONSTANT:( 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 )
 

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -627,3 +627,4 @@ Value MLIRGenerator::getZeroInitTensor(TensorType type) {
   tensor = builder.create<linalg::FillOp>(loc, zero, tensor).getResult(0);
   return tensor;
 }
+

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -74,10 +74,6 @@ class MLIRGenerator {
   /// Lower softmax at the last layer
   bool enableSoftmax;
 
-  /// Initialize accumulation matrix with bias
-  /// Needs `enableBias` to be true
-  bool biasAcc;
-
   /// List of supported kernel types that can be generated
   ///  * Model: Generates an entire model, with input handling, output creation,
   ///           constant weight and bias, etc. This demonstrates the whole cost
@@ -184,10 +180,6 @@ class MLIRGenerator {
 
   /// Creates the kernel types from layer definitions and options
   void getKernelTypes(KernelArgs &);
-
-  /// Creates the kernel arguments from function args or constants and zero
-  /// tensors, depending on the kernel type (model, layer)
-  void getKernelArgs(KernelArgs &);
 
   /// Creates a layer function, to be called by the kernel
   Value createLayer(LayerArgs &);

--- a/tools/mlir-gen/generate.sh
+++ b/tools/mlir-gen/generate.sh
@@ -126,7 +126,7 @@ debug "Random seed: $SEED"
 # Defaults
 
 # Command line to extract and run
-MLIR_GEN_ARGS="--float-width=$FLOAT_SIZE --seed=$SEED --mini-batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
+MLIR_GEN_ARGS="--float-width=$FLOAT_SIZE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
 ORIG_MLIR="mlir-gen-original.mlir"
 debug "\nCreating the original MLIR model:"
 run "$MLIR_GEN $MLIR_GEN_ARGS" $ORIG_MLIR

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -27,15 +27,13 @@ using namespace mlir;
 
 // Type of kernel to be generated
 llvm::cl::opt<std::string> kernel("kernel",
-                                  llvm::cl::desc("Kernel to be generated"),
-                                  llvm::cl::value_desc("mlp,matmul,fc"),
-                                  llvm::cl::init("mlp"));
+                                  llvm::cl::desc("Kernel type to be generated"),
+                                  llvm::cl::value_desc("model,layer"),
+                                  llvm::cl::init("model"));
 
 // Input layer
-llvm::cl::opt<unsigned> miniBatch("mini-batch",
-                                  llvm::cl::desc("Mini batch size"),
-                                  llvm::cl::value_desc("256"),
-                                  llvm::cl::init(256));
+llvm::cl::opt<unsigned> batch("batch", llvm::cl::desc("Mini batch size"),
+                              llvm::cl::value_desc("256"), llvm::cl::init(256));
 
 // Hidden layers
 llvm::cl::opt<std::string> layers(
@@ -64,15 +62,22 @@ llvm::cl::opt<std::string> filename("o", llvm::cl::desc("Output filename"),
                                     llvm::cl::value_desc("stdout"),
                                     llvm::cl::init("-"));
 
-// Enable softmax at the last layer
-llvm::cl::opt<bool> enableSoftmax("softmax", llvm::cl::desc("Enable softmax"),
-                                  llvm::cl::value_desc("bool"),
-                                  llvm::cl::init(false));
+// Enable bias add on every layer
+llvm::cl::opt<bool> enableBias("bias",
+                               llvm::cl::desc("Enable bias on every layer"),
+                               llvm::cl::value_desc("bool"),
+                               llvm::cl::init(false));
 
-// Initialize accumulation matrix with bias
-llvm::cl::opt<bool> biasAcc("bias-acc", llvm::cl::desc("Accumulate on bias"),
-                            llvm::cl::value_desc("bool"),
-                            llvm::cl::init(false));
+// Enable relu on every layer
+llvm::cl::opt<bool> enableRelu("relu",
+                               llvm::cl::desc("Enable relu on every layer"),
+                               llvm::cl::value_desc("bool"),
+                               llvm::cl::init(false));
+
+// Enable softmax at the last layer
+llvm::cl::opt<bool>
+    enableSoftmax("softmax", llvm::cl::desc("Enable softmax on the last layer"),
+                  llvm::cl::value_desc("bool"), llvm::cl::init(false));
 
 // Set VNNI packing factor for BF16
 llvm::cl::opt<int>
@@ -88,7 +93,7 @@ int main(int argc, char **argv) {
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Generator");
 
-  MLIRGenerator gen(kernel, miniBatch, layers, tiles, floatWidth, seed,
-                    enableSoftmax, biasAcc, vnni);
+  MLIRGenerator gen(kernel, batch, layers, tiles, floatWidth, seed, enableBias,
+                    enableRelu, enableSoftmax, vnni);
   return gen.generate(filename);
 }


### PR DESCRIPTION
Avoid duplicating the logic across `matmul`, `fc` and `mlp` into a single generator that enables/disables features based on command line flags.

Also enables multi-layer for `fc` and `matmul` that previously wasn't possible.

These are the new choices:
 * Kernel = `layer` (operands are arguments), `model` (constants)
 * Enable/disable bias/relu/softmax

The matching is:
 * `matmul` = kernel=layer
 * `fc` = kernel=layer + bias + relu
 * `mlp` = kernel=model + bias + relu

There should be a softmax at the end of MLP, but we're not doing it yet.

All tests pass. All performance benchmarks remained idential and kept their performance profiles.

Changes in tests are due to real (and necessary) output changes.