### PR TITLE
CI LLVM GPU build

### DIFF
--- a/scripts/buildkite/benchmark_gpu.sh
+++ b/scripts/buildkite/benchmark_gpu.sh
@@ -22,6 +22,9 @@ fi
 
 # Build
 eval "GPU=${GPU_OPTION} ${SCRIPT_DIR}/buildkite/build_tpp.sh"
+if [ $? != 0 ]; then
+  exit 1
+fi
 
 # Benchmark
 benchmark () {

--- a/scripts/buildkite/benchmark_gpu.sh
+++ b/scripts/buildkite/benchmark_gpu.sh
@@ -50,11 +50,16 @@ benchmark () {
 
 # CUDA Benchmarks
 if [ "${GPU_OPTION}" == "cuda" ]; then
+  source /swtools/cuda/latest/cuda_vars.sh
   benchmark GPU/cuda.json "CUDA kernels"
+  if [ $? != 0 ]; then
+    exit 1
+  fi
 fi
 
 # Vulkan Benchmarks
 if [ "${GPU_OPTION}" == "vulkan" ]; then
+  source /swtools/vulkan/latest/setup-env.sh
   echo "No Vulkan benchmarks"
   exit 1
 fi

--- a/scripts/buildkite/build_llvm.sh
+++ b/scripts/buildkite/build_llvm.sh
@@ -85,7 +85,7 @@ mkdir -p ${LLVM_BUILD_DIR}
 # Env CUDA setup
 if [[ ${GPU,,} =~ "cuda" ]]; then
   echo "Setting up CUDA environment"
-  echo "Hard-coding GCC to a known stable version (12.3)"
+  echo "Hard-coding CUDA-compatible GCC version (12.3)"
   source /swtools/gcc/gcc-12.3.0/gcc_vars.sh
   source /swtools/cuda/latest/cuda_vars.sh
   check_program nvcc

--- a/scripts/buildkite/build_llvm.sh
+++ b/scripts/buildkite/build_llvm.sh
@@ -22,6 +22,7 @@ echo "LLVM version: ${LLVM_VERSION}"
 if [ ! "${LLVM_TAR_DIR}" ]; then
   LLVM_TAR_DIR="/tmp/tpp-llvm-tar"
 fi
+LLVM_TAR_DIR=$(add_device_extensions ${LLVM_TAR_DIR} ${GPU})
 mkdir -p ${LLVM_TAR_DIR}
 
 # Fetch specific LLVM version
@@ -45,16 +46,9 @@ fi
 # Cleanup tar ball to save device space
 rm ${LLVM_TAR_FILE}
 
-# Add LLVM device extensions
-if [[ ${GPU,,} =~ "cuda" ]]; then
-  DEVICE_EXTENSIONS=${DEVICE_EXTENSIONS}-cuda
-fi
-if [[ ${GPU,,} =~ "vulkan" ]]; then
-  DEVICE_EXTENSIONS=${DEVICE_EXTENSIONS}-vulkan
-fi
-
 LLVM_PROJECT_DIR=${LLVM_TAR_DIR}/llvm-project-${LLVM_VERSION}
 LLVM_INSTALL_DIR=${LLVMROOT}/${LLVM_VERSION}
+LLVM_INSTALL_DIR=$(add_device_extensions ${LLVM_INSTALL_DIR} ${GPU})
 
 # Environment setup
 echo "--- ENVIRONMENT"

--- a/scripts/buildkite/build_llvm.sh
+++ b/scripts/buildkite/build_llvm.sh
@@ -82,20 +82,8 @@ LLVM_BUILD_DIR=$(realpath ${LLVM_BUILD_DIR})
 LLVM_BUILD_DIR=${LLVM_BUILD_DIR:-build-${COMPILER}}
 mkdir -p ${LLVM_BUILD_DIR}
 
-# Env CUDA setup
-if [[ ${GPU,,} =~ "cuda" ]]; then
-  echo "Setting up CUDA environment"
-  echo "Hard-coding CUDA-compatible GCC version (12.3)"
-  source /swtools/gcc/gcc-12.3.0/gcc_vars.sh
-  source /swtools/cuda/latest/cuda_vars.sh
-  check_program nvcc
-fi
-
-# Env Vulkan setup
-if [[ ${GPU,,} =~ "vulkan" ]]; then
-  echo "Setting up Vulkan environment"
-  source /swtools/vulkan/latest/setup-env.sh
-  check_program vulkaninfo
+if [ "${GPU}" ]; then
+  source ${SCRIPT_DIR}/ci/setup_gpu_env.sh
 fi
 
 echo "Environment configured successfully"

--- a/scripts/buildkite/build_llvm.sh
+++ b/scripts/buildkite/build_llvm.sh
@@ -91,7 +91,7 @@ if [[ ${GPU,,} =~ "cuda" ]]; then
   check_program nvcc
 fi
 
-# Ebv Vulkan setup
+# Env Vulkan setup
 if [[ ${GPU,,} =~ "vulkan" ]]; then
   echo "Setting up Vulkan environment"
   source /swtools/vulkan/latest/setup-env.sh

--- a/scripts/buildkite/build_llvm.sh
+++ b/scripts/buildkite/build_llvm.sh
@@ -15,6 +15,7 @@ mkdir -p ${LLVMROOT}
 # LLVM setup
 echo "--- LLVM"
 LLVM_VERSION=$(llvm_version)
+
 echo "LLVM version: ${LLVM_VERSION}"
 
 # Destination for tar balls
@@ -43,6 +44,14 @@ fi
 
 # Cleanup tar ball to save device space
 rm ${LLVM_TAR_FILE}
+
+# Add LLVM device extensions
+if [[ ${GPU,,} =~ "cuda" ]]; then
+  DEVICE_EXTENSIONS=${DEVICE_EXTENSIONS}-cuda
+fi
+if [[ ${GPU,,} =~ "vulkan" ]]; then
+  DEVICE_EXTENSIONS=${DEVICE_EXTENSIONS}-vulkan
+fi
 
 LLVM_PROJECT_DIR=${LLVM_TAR_DIR}/llvm-project-${LLVM_VERSION}
 LLVM_INSTALL_DIR=${LLVMROOT}/${LLVM_VERSION}

--- a/scripts/buildkite/build_tpp.sh
+++ b/scripts/buildkite/build_tpp.sh
@@ -53,22 +53,7 @@ fi
 
 if [ "${GPU}" ]; then
   GPU_OPTION="-G ${GPU}"
-fi
-
-# Env CUDA setup
-if [[ ${GPU,,} =~ "cuda" ]]; then
-  echo "Setting up CUDA environment"
-  echo "Hard-coding CUDA-compatible GCC version (12.3)"
-  source /swtools/gcc/gcc-12.3.0/gcc_vars.sh
-  source /swtools/cuda/latest/cuda_vars.sh
-  check_program nvcc
-fi
-
-# Env Vulkan setup
-if [[ ${GPU,,} =~ "vulkan" ]]; then
-  echo "Setting up Vulkan environment"
-  source /swtools/vulkan/latest/setup-env.sh
-  check_program vulkaninfo
+  source ${SCRIPT_DIR}/ci/setup_gpu_env.sh
 fi
 
 if [ "${CLEAN}" ]; then

--- a/scripts/buildkite/build_tpp.sh
+++ b/scripts/buildkite/build_tpp.sh
@@ -17,6 +17,15 @@ fi
 # Find LLVM_VERSION
 echo "--- LLVM"
 LLVM_VERSION=$(llvm_version)
+
+# Add LLVM device extensions
+if [[ ${GPU,,} =~ "cuda" ]]; then
+  LLVM_VERSION=${LLVM_VERSION}-cuda
+fi
+if [[ ${GPU,,} =~ "vulkan" ]]; then
+  LLVM_VERSION=${LLVM_VERSION}-vulkan
+fi
+
 if [ ! -d "${LLVMROOT}/${LLVM_VERSION}" ]; then
   echo "LLVM ${LLVM_VERSION} not found"
   exit 1

--- a/scripts/buildkite/build_tpp.sh
+++ b/scripts/buildkite/build_tpp.sh
@@ -55,6 +55,22 @@ if [ "${GPU}" ]; then
   GPU_OPTION="-G ${GPU}"
 fi
 
+# Env CUDA setup
+if [[ ${GPU,,} =~ "cuda" ]]; then
+  echo "Setting up CUDA environment"
+  echo "Hard-coding CUDA-compatible GCC version (12.3)"
+  source /swtools/gcc/gcc-12.3.0/gcc_vars.sh
+  source /swtools/cuda/latest/cuda_vars.sh
+  check_program nvcc
+fi
+
+# Env Vulkan setup
+if [[ ${GPU,,} =~ "vulkan" ]]; then
+  echo "Setting up Vulkan environment"
+  source /swtools/vulkan/latest/setup-env.sh
+  check_program vulkaninfo
+fi
+
 if [ "${CLEAN}" ]; then
   BUILD_DIR_RM=-R
 fi

--- a/scripts/buildkite/build_tpp.sh
+++ b/scripts/buildkite/build_tpp.sh
@@ -18,15 +18,10 @@ fi
 echo "--- LLVM"
 LLVM_VERSION=$(llvm_version)
 
-# Add LLVM device extensions
-if [[ ${GPU,,} =~ "cuda" ]]; then
-  LLVM_VERSION=${LLVM_VERSION}-cuda
-fi
-if [[ ${GPU,,} =~ "vulkan" ]]; then
-  LLVM_VERSION=${LLVM_VERSION}-vulkan
-fi
+LLVM_INSTALL_DIR=${LLVMROOT}/${LLVM_VERSION}
+LLVM_INSTALL_DIR=$(add_device_extensions ${LLVM_INSTALL_DIR} ${GPU})
 
-if [ ! -d "${LLVMROOT}/${LLVM_VERSION}" ]; then
+if [ ! -d "${LLVM_INSTALL_DIR}" ]; then
   echo "LLVM ${LLVM_VERSION} not found"
   exit 1
 else
@@ -81,7 +76,7 @@ echo "--- CONFIGURE"
 if ! ${SCRIPT_DIR}/ci/cmake.sh \
   -s ${PROJECT_DIR} \
   -b ${BUILD_DIR} ${BUILD_DIR_RM} \
-  -m ${LLVMROOT}/${LLVM_VERSION}/lib/cmake/mlir \
+  -m ${LLVM_INSTALL_DIR}/lib/cmake/mlir \
   ${INSTALL_OPTION} \
   -t ${KIND} \
   ${SANITIZERS} \

--- a/scripts/buildkite/check_llvm.sh
+++ b/scripts/buildkite/check_llvm.sh
@@ -16,15 +16,10 @@ mkdir -p ${LLVMROOT}
 # Find LLVM_VERSION
 LLVM_VERSION=$(llvm_version)
 
-# Add LLVM device extensions
-if [[ ${GPU,,} =~ "cuda" ]]; then
-  LLVM_VERSION=${LLVM_VERSION}-cuda
-fi
-if [[ ${GPU,,} =~ "vulkan" ]]; then
-  LLVM_VERSION=${LLVM_VERSION}-vulkan
-fi
+LLVM_INSTALL_DIR=${LLVMROOT}/${LLVM_VERSION}
+LLVM_INSTALL_DIR=$(add_device_extensions ${LLVM_INSTALL_DIR} ${GPU})
 
-if [ -d "${LLVMROOT}/${LLVM_VERSION}" ]; then
+if [ -d "${LLVM_INSTALL_DIR}" ]; then
   echo "Found $LLVM_VERSION"
   exit 0
 fi

--- a/scripts/buildkite/check_llvm.sh
+++ b/scripts/buildkite/check_llvm.sh
@@ -22,6 +22,8 @@ LLVM_INSTALL_DIR=$(add_device_extensions ${LLVM_INSTALL_DIR} ${GPU})
 if [ -d "${LLVM_INSTALL_DIR}" ]; then
   echo "Found $LLVM_VERSION"
   exit 0
+else
+  echo "Not Found ${LLVM_INSTALL_DIR}"
 fi
 
 # LLVM not found.

--- a/scripts/buildkite/check_llvm.sh
+++ b/scripts/buildkite/check_llvm.sh
@@ -16,6 +16,14 @@ mkdir -p ${LLVMROOT}
 # Find LLVM_VERSION
 LLVM_VERSION=$(llvm_version)
 
+# Add LLVM device extensions
+if [[ ${GPU,,} =~ "cuda" ]]; then
+  LLVM_VERSION=${LLVM_VERSION}-cuda
+fi
+if [[ ${GPU,,} =~ "vulkan" ]]; then
+  LLVM_VERSION=${LLVM_VERSION}-vulkan
+fi
+
 if [ -d "${LLVMROOT}/${LLVM_VERSION}" ]; then
   echo "Found $LLVM_VERSION"
   exit 0

--- a/scripts/buildkite/tpp-gpu.yml
+++ b/scripts/buildkite/tpp-gpu.yml
@@ -4,8 +4,10 @@ env:
   #LIBXSMMFETCH: 1
 
 steps:
-  - label: "LLVM"
-    command: "BUILD=1 scripts/buildkite/check_llvm.sh"
+  - label: "LLVM-cuda"
+    command: "GPU=cuda BUILD=1 scripts/buildkite/check_llvm.sh"
+  - label: "LLVM-vulkan"
+    command: "GPU=vulkan BUILD=1 scripts/buildkite/check_llvm.sh"
   - wait
 
   - label: "GPU-Nvidia-Cuda"

--- a/scripts/buildkite/tpp-gpu.yml
+++ b/scripts/buildkite/tpp-gpu.yml
@@ -11,7 +11,7 @@ steps:
   - wait
 
   - label: "GPU-Nvidia-Cuda"
-    command: "${SRUN} --partition=a100 --time=0:30:00 -- \
+    command: "${SRUN} --partition=v100 --time=0:30:00 -- \
               'KIND=Debug COMPILER=clang LINKER=lld GPU=cuda CHECK=1 \
               scripts/buildkite/build_tpp.sh'"
     env:
@@ -20,7 +20,7 @@ steps:
       ASAN_OPTIONS: "protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS}"
 
   - label: "GPU-Nvidia-Vulkan"
-    command: "${SRUN} --partition=a100 --time=0:30:00 -- \
+    command: "${SRUN} --partition=v100 --time=0:30:00 -- \
               'KIND=Debug COMPILER=clang LINKER=lld GPU=vulkan CHECK=1 \
               scripts/buildkite/build_tpp.sh'"
     env:
@@ -28,12 +28,12 @@ steps:
       # See: https://github.com/google/sanitizers/issues/629
       ASAN_OPTIONS: "protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS}"
 
-  - label: "GPU-Intel-Vulkan"
-    command: "${SRUN} -- \
-              'KIND=Debug COMPILER=clang LINKER=lld GPU=vulkan CHECK=1 CLEAN=1 \
-              scripts/buildkite/build_tpp.sh'"
-    env:
-      TPP_LAUNCH_NODE: "pvc"
+  # TODO: enable PVC tests when the device is available to the runner
+  #       currently PVC is not visible to the Vulkan runtime
+  # - label: "GPU-Intel-Vulkan"
+  #   command: "${SRUN} --partition=pvc --time=0:30:00 -- \
+  #             'KIND=Debug COMPILER=clang LINKER=lld GPU=vulkan CHECK=1 CLEAN=1 \
+  #             scripts/buildkite/build_tpp.sh'"
 
   - label: "GPU-Nvidia-Cuda-bench"
     command: "${SRUN} --partition=a100 --time=0:30:00 -- \

--- a/scripts/buildkite/tpp-gpu.yml
+++ b/scripts/buildkite/tpp-gpu.yml
@@ -5,7 +5,7 @@ env:
 
 steps:
   - label: "LLVM"
-    command: "scripts/buildkite/check_llvm.sh"
+    command: "BUILD=1 scripts/buildkite/check_llvm.sh"
   - wait
 
   - label: "GPU-Nvidia-Cuda"

--- a/scripts/buildkite/tpp-llvm.yml
+++ b/scripts/buildkite/tpp-llvm.yml
@@ -2,10 +2,26 @@ env:
   NPROCS_LIMIT_LINK: "8"
 
 steps:
-  - label: "TPP-LLVM"
+  - label: "TPP-LLVM-base"
     concurrency: 1
-    concurrency_group: "tpp-llvm"
+    concurrency_group: "tpp-llvm-base"
     command: "scripts/buildkite/check_llvm.sh || \
               ${SRUN} --partition=spr --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang \
+              scripts/buildkite/build_llvm.sh'"
+
+  - label: "TPP-LLVM-cuda"
+    concurrency: 1
+    concurrency_group: "tpp-llvm-cuda"
+    command: "GPU=cuda scripts/buildkite/check_llvm.sh || \
+              ${SRUN} --partition=a100 --time=0:30:00 -- \
+              'KIND=RelWithDebInfo COMPILER=clang GPU=cuda \
+              scripts/buildkite/build_llvm.sh'"
+
+  - label: "TPP-LLVM-vulkan"
+    concurrency: 1
+    concurrency_group: "tpp-llvm-vulkan"
+    command: "GPU=vulkan scripts/buildkite/check_llvm.sh || \
+              ${SRUN} --partition=spr --time=0:30:00 -- \
+              'KIND=RelWithDebInfo COMPILER=clang GPU=vulkan \
               scripts/buildkite/build_llvm.sh'"

--- a/scripts/buildkite/tpp-llvm.yml
+++ b/scripts/buildkite/tpp-llvm.yml
@@ -14,7 +14,7 @@ steps:
     concurrency: 1
     concurrency_group: "tpp-llvm-cuda"
     command: "GPU=cuda scripts/buildkite/check_llvm.sh || \
-              ${SRUN} --partition=a100 --time=0:30:00 -- \
+              ${SRUN} --partition=a100,v100 --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang GPU=cuda \
               scripts/buildkite/build_llvm.sh'"
 

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -53,3 +53,19 @@ llvm_version() {
   fi
   echo "${LLVM_VERSION}"
 }
+
+# Add known device extension suffixes to a base string
+add_device_extensions() {
+  local BASE=${1}
+  local DEVICE_LIST=${2}
+
+  # GPU extensions
+  if [[ ${DEVICE_LIST,,} =~ "cuda" ]]; then
+    BASE=${BASE}-cuda
+  fi
+  if [[ ${DEVICE_LIST,,} =~ "vulkan" ]]; then
+    BASE=${BASE}-vulkan
+  fi
+
+  echo ${BASE}
+}

--- a/scripts/ci/setup_gpu_env.sh
+++ b/scripts/ci/setup_gpu_env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Sets up GPU environment.
+# Usage: source setup_gpu_env.sh
+
+# Include common utils
+SCRIPT_DIR=$(realpath $(dirname $0)/..)
+source ${SCRIPT_DIR}/ci/common.sh
+
+# Env CUDA setup
+if [[ ${GPU,,} =~ "cuda" ]]; then
+  echo "Setting up CUDA environment"
+  echo "Hard-coding CUDA-compatible GCC version (12.3)"
+  source /swtools/gcc/gcc-12.3.0/gcc_vars.sh
+  source /swtools/cuda/latest/cuda_vars.sh
+  check_program nvcc
+fi
+
+# Env Vulkan setup
+if [[ ${GPU,,} =~ "vulkan" ]]; then
+  echo "Setting up Vulkan environment"
+  source /swtools/vulkan/latest/setup-env.sh
+  check_program vulkaninfo
+fi


### PR DESCRIPTION
Adds CI logic to build LLVM with GPU support and reenable TPP GPU testing jobs.
 
Dependency management is simplified by creating separate builds of both LLVM and TPP-MLIR with extra features (CUDA, Vulkan) enabled depending on the test or benchmark coverage. This ensures that extra environment dependencies are not required for every build e.g., no runtime linkage to libcuda.so.1 when no CUDA related logic is needed by a CI job.
CI agents now install different LLVM builds for the same LLVM version (commit SHA).

Minor tweaks are added to the CI scripts to ensure better error propagation.
'GPU-Intel-Vulkan' job is disabled due to missing GPU device in the Vulkan runtime.