### PR TITLE
Use linalg-to-xsmm as default

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -270,7 +270,7 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
            "bool", /*default=*/"false",
            "Skip all TPP transformations. Lower linalg directly to loops.">,
     Option<"linalgToXsmm", "linalg-to-xsmm",
-           "bool", /*default=*/"false",
+           "bool", /*default=*/"true",
            "Skip all TPP transformations. Lower lianalg directly to xsmm.">
   ];
   let constructor = "mlir::tpp::createDefaultTppPass()";
@@ -378,10 +378,10 @@ def TppLowering : Pass<"tpp-lowering", "func::FuncOp"> {
   }];
   let options= [
     Option<"tppToLoops", "tpp-to-loops",
-           "bool", /*default=*/"0",
+           "bool", /*default=*/"false",
            "By default TPP ops are lowered to XSMM. Lower TPP to loops instead.">,
     Option<"linalgToXsmm", "linalg-to-xsmm",
-           "bool", /*default=*/"0",
+           "bool", /*default=*/"true",
            "By default Linalg ops are lowered to TPP. Lower Linalg to XSMM instead.">,
   ];
   let constructor = "mlir::tpp::createTppLoweringPass()";

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -75,7 +75,7 @@ llvm::cl::opt<bool> tppToLoops("tpp-to-loops",
 // Lower linalg to XSMM directly.
 llvm::cl::opt<bool> linalgToXsmm("linalg-to-xsmm",
                                  llvm::cl::desc("Lower linalg to xsmm"),
-                                 llvm::cl::init(false));
+                                 llvm::cl::init(true));
 
 // Control parallelism.
 llvm::cl::opt<bool>

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -253,7 +253,7 @@ private:
 // Lower TPP to into combination of standard and local dialects.
 struct TppLoweringPass : public TppLoweringBase<TppLoweringPass>,
                          UtilityPassBase<func::FuncOp> {
-  TppLoweringPass() : TppLoweringPass(false, false){};
+  TppLoweringPass() : TppLoweringPass(false, true){};
   TppLoweringPass(bool tppToLoops, bool linalgToXsmm) {
     this->tppToLoops = tppToLoops;
     this->linalgToXsmm = linalgToXsmm;
@@ -305,7 +305,7 @@ private:
 // The default pipeline for TPP.
 struct DefaultTppPasses : public DefaultTppPassesBase<DefaultTppPasses>,
                           UtilityPassBase<ModuleOp> {
-  DefaultTppPasses() : DefaultTppPasses(false, false, false){};
+  DefaultTppPasses() : DefaultTppPasses(false, false, true){};
   DefaultTppPasses(bool tppToLoops, bool linalgToLoops, bool linalgToXsmm) {
     this->tppToLoops = tppToLoops;
     this->linalgToLoops = linalgToLoops;

--- a/test/BF16/Integration/matmul-pbf16.mlir
+++ b/test/BF16/Integration/matmul-pbf16.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s -print -linalg-to-xsmm="false" \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/BF16/Integration/mlp-all-bf16-tpprun.mlir
+++ b/test/BF16/Integration/mlp-all-bf16-tpprun.mlir
@@ -1,6 +1,7 @@
-// RUN: tpp-run %s \
+// RUN: tpp-run -linalg-to-xsmm="false" %s \
 // RUN:  -e entry -entry-point-result=void
 //
+
 
   memref.global "private" constant @arg1 : memref<128x512x2xbf16> = dense<1.00e+00> 
   memref.global "private" constant @arg3 : memref<256x1024x2xbf16> = dense<1.00e+00>

--- a/test/BF16/Integration/mlp-single-layer-bf16.mlir
+++ b/test/BF16/Integration/mlp-single-layer-bf16.mlir
@@ -1,5 +1,5 @@
 // Validate default pipeline
-// RUN: tpp-run %s \
+// RUN: tpp-run %s -linalg-to-xsmm="false" \
 // RUN:  -e entry -entry-point-result=void
 
 func.func @entry(){

--- a/test/BF16/Integration/mlp-single-layer-blocked-bf16.mlir
+++ b/test/BF16/Integration/mlp-single-layer-blocked-bf16.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s -linalg-to-xsmm="false" -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/BF16/Integration/tpp-run-splat-shape.mlir
+++ b/test/BF16/Integration/tpp-run-splat-shape.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -linalg-to-xsmm \
+// RUN: tpp-run %s \
 // RUN:  -e entry -entry-point-result=void \
 // RUN:  -print-mlir=mid -seed=123 -splat-to-random 2>&1 | \
 // RUN: FileCheck %s

--- a/test/Integration/conv-on-loops.mlir
+++ b/test/Integration/conv-on-loops.mlir
@@ -19,11 +19,15 @@ module {
       scf.for %arg4 = %c0 to %c2 step %c1 {
         scf.for %arg5 = %c0 to %c2 step %c1 {
           scf.for %arg6 = %c0 to %c2 step %c1 {
-            %0 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 2, 8] [1, 1, 1, 1] : memref<1x2x2x8xf32> to memref<2x8xf32, #map2>
-            %1 = memref.subview %arg1[%arg5, %arg6, 0, 0] [1, 1, 3, 8] [1, 1, 1, 1] : memref<2x2x3x8xf32> to memref<3x8xf32, #map2>
+            %0 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 2, 8] [1, 1, 1, 1] 
+              : memref<1x2x2x8xf32> to memref<2x8xf32, #map2>
+            %1 = memref.subview %arg1[%arg5, %arg6, 0, 0] [1, 1, 3, 8] [1, 1, 1, 1] 
+              : memref<2x2x3x8xf32> to memref<3x8xf32, #map2>
             %2 = affine.apply #map1(%arg4, %arg5)
-            %3 = memref.subview %arg0[%arg3, %2, %arg6, 0] [1, 1, 2, 3] [1, 1, 1, 1] : memref<1x4x4x3xf32> to memref<2x3xf32, #map0>
-            tpp.gemm ins(%3 : memref<2x3xf32, #map0>, %1 : memref<3x8xf32, #map2>, %0 : memref<2x8xf32, #map2>) outs(%0 : memref<2x8xf32, #map2>)
+            %3 = memref.subview %arg0[%arg3, %2, %arg6, 0] [1, 1, 2, 3] [1, 1, 1, 1] 
+              : memref<1x4x4x3xf32> to memref<2x3xf32, #map0>
+            linalg.matmul ins(%3, %1 : memref<2x3xf32, #map0>, memref<3x8xf32, #map2>) 
+                          outs(%0 : memref<2x8xf32, #map2>)
           }
         }
       }

--- a/test/Integration/fused-brgemm.mlir
+++ b/test/Integration/fused-brgemm.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s -linalg-to-xsmm="false" -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/matmul-tpp-with-print.mlir
+++ b/test/Integration/matmul-tpp-with-print.mlir
@@ -1,5 +1,5 @@
 // This should really be in the passes directory, not here
-// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck -check-prefix=IR %s
 
 // RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
@@ -16,53 +16,52 @@
 #map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-module {
 
- func.func @gemm_tpp(%A: tensor<4x8xf32>,
+// IR-LABEL: gemm_tpp
+func.func @gemm_tpp(%A: tensor<4x8xf32>,
            %B: tensor<8x4xf32>, %C: tensor<4x4xf32>) -> tensor<4x4xf32> {
-    // TPP: tpp.gemm
-    %0 = linalg.generic {indexing_maps = [#map0, #map1, #map2],
-                         iterator_types = ["parallel", "parallel", "reduction"]}
-    ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) {
-      ^bb0(%a: f32, %b: f32, %c: f32):
-        %0 = arith.mulf %a, %b : f32
-        %1 = arith.addf %c, %0 : f32
-        linalg.yield %1 : f32
-    } -> tensor<4x4xf32>
-    return %0 : tensor<4x4xf32>
-  }
+  // IR: xsmm_gemm_invoke
+  %0 = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                       iterator_types = ["parallel", "parallel", "reduction"]}
+  ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) {
+    ^bb0(%a: f32, %b: f32, %c: f32):
+      %0 = arith.mulf %a, %b : f32
+      %1 = arith.addf %c, %0 : f32
+      linalg.yield %1 : f32
+  } -> tensor<4x4xf32>
+  return %0 : tensor<4x4xf32>
+}
 
-  func.func @entry() {
+func.func @entry() {
 
-    // Initialize various matrices.
-    %cst_one = arith.constant 1.0 : f32
-    %da = tensor.empty() : tensor<4x8xf32>
-    %0 = linalg.fill ins(%cst_one : f32) outs(%da : tensor<4x8xf32>) -> tensor<4x8xf32>
+  // Initialize various matrices.
+  %cst_one = arith.constant 1.0 : f32
+  %da = tensor.empty() : tensor<4x8xf32>
+  %0 = linalg.fill ins(%cst_one : f32) outs(%da : tensor<4x8xf32>) -> tensor<4x8xf32>
 
-    %cst_two = arith.constant 2.0 : f32
-    %db = tensor.empty() : tensor<8x4xf32>
-    %1 = linalg.fill ins(%cst_two : f32) outs(%db : tensor<8x4xf32>) -> tensor<8x4xf32>
+  %cst_two = arith.constant 2.0 : f32
+  %db = tensor.empty() : tensor<8x4xf32>
+  %1 = linalg.fill ins(%cst_two : f32) outs(%db : tensor<8x4xf32>) -> tensor<8x4xf32>
 
-    %cst_zero = arith.constant 0.0 : f32
-    %C = tensor.empty() : tensor<4x4xf32>
-    %2 = linalg.fill ins(%cst_zero : f32) outs(%C : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %cst_zero = arith.constant 0.0 : f32
+  %C = tensor.empty() : tensor<4x4xf32>
+  %2 = linalg.fill ins(%cst_zero : f32) outs(%C : tensor<4x4xf32>) -> tensor<4x4xf32>
 
-    // Call kernel.
-    %res = call @gemm_tpp(%0, %1, %2)
+  // Call kernel.
+  %res = call @gemm_tpp(%0, %1, %2)
        : (tensor<4x8xf32>, tensor<8x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
 
-    // Print result.
-    %zeroCst = arith.constant 0 : index
-    %d1 = arith.constant -1.0 : f32
-    %v0 = vector.transfer_read %res[%zeroCst, %zeroCst], %d1 : tensor<4x4xf32>, vector<4x4xf32>
-    vector.print %v0 : vector<4x4xf32>
-    //
-    // CHECK:       ( 16,   16,   16,   16 ),
-    // CHECK-SAME:  ( 16,   16,   16,   16 ),
-    // CHECK-SAME:  ( 16,   16,   16,   16 ),
-    // CHECK-SAME:  ( 16,   16,   16,   16 )
-    //
+  // Print result.
+  %zeroCst = arith.constant 0 : index
+  %d1 = arith.constant -1.0 : f32
+  %v0 = vector.transfer_read %res[%zeroCst, %zeroCst], %d1 : tensor<4x4xf32>, vector<4x4xf32>
+  vector.print %v0 : vector<4x4xf32>
+  //
+  // CHECK:       ( 16,   16,   16,   16 ),
+  // CHECK-SAME:  ( 16,   16,   16,   16 ),
+  // CHECK-SAME:  ( 16,   16,   16,   16 ),
+  // CHECK-SAME:  ( 16,   16,   16,   16 )
+  //
 
-    return
-  }
+  return
 }

--- a/test/Integration/matmul_48x64x96.mlir
+++ b/test/Integration/matmul_48x64x96.mlir
@@ -2,8 +2,12 @@
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s
 
+// RUN: tpp-opt -default-tpp-passes %s | FileCheck %s -check-prefix=IR
+
+// IR-LABEL: entry
 func.func @entry(%A: tensor<48x96xf32>, %B: tensor<96x64xf32>,
                   %C: tensor<48x64xf32>) -> tensor<48x64xf32> {
+  // IR: xsmm_gemm_invoke
   %D = linalg.matmul ins(%A, %B: tensor<48x96xf32>, tensor<96x64xf32>) outs(%C: tensor<48x64xf32>) -> tensor<48x64xf32>
   return %D : tensor<48x64xf32>
 }

--- a/test/Integration/matmul_64x48x96.mlir
+++ b/test/Integration/matmul_64x48x96.mlir
@@ -2,8 +2,12 @@
 // RUN:  -e entry -entry-point-result=void -print | \
 // RUN: FileCheck %s
 
+// RUN: tpp-opt -default-tpp-passes %s | FileCheck %s -check-prefix=IR
+
+// IR-LABEL: entry
 func.func @entry(%A: tensor<64x96xf32>, %B: tensor<96x48xf32>,
                   %C: tensor<64x48xf32>) -> tensor<64x48xf32> {
+  // IR: xsmm_gemm_invoke
   %D = linalg.matmul ins(%A, %B: tensor<64x96xf32>, tensor<96x48xf32>) outs(%C: tensor<64x48xf32>) -> tensor<64x48xf32>
   return %D : tensor<64x48xf32>
 }

--- a/test/Integration/matmul_64x64x64.mlir
+++ b/test/Integration/matmul_64x64x64.mlir
@@ -12,6 +12,7 @@
 // RUN: tpp-opt %s -default-tpp-passes | \
 // RUN: FileCheck %s -check-prefix=IR
 
+// IR-LABEL: entry
 func.func @entry(%A: tensor<64x64xf32>, %B: tensor<64x64xf32>,
                   %C: tensor<64x64xf32>) -> tensor<64x64xf32> {
   // IR: xsmm_brgemm_invoke

--- a/test/Integration/tiling-add.mlir
+++ b/test/Integration/tiling-add.mlir
@@ -1,5 +1,4 @@
-// This should really be in the passes directory, not here
-// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck -check-prefix=IR %s
 
 // RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
@@ -15,9 +14,10 @@
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
+// IR-LABEL: bigadd
 func.func @bigadd(%A: tensor<32x16xf32>,
                   %B: tensor<32x16xf32>) -> tensor<32x16xf32>  {
-  // TPP: tpp.add
+  // IR: xsmm_binary_invoke
   %O = linalg.generic { indexing_maps = [#map0, #map0],
                         iterator_types = ["parallel", "parallel"] }
     ins(%A : tensor<32x16xf32>) outs(%B: tensor<32x16xf32>) {

--- a/test/Integration/tiling-relu.mlir
+++ b/test/Integration/tiling-relu.mlir
@@ -1,5 +1,4 @@
-// This should really be in the passes directory, not here
-// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck -check-prefix=IR %s
 
 // RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
@@ -15,9 +14,10 @@
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
+// IR-LABEL: bigrelu
 func.func @bigrelu(%B: tensor<32x16xf32>) -> tensor<32x16xf32>  {
   %c0 = arith.constant 0.0 : f32
-  // TPP: tpp.relu
+  // IR: xsmm_unary_invoke
   %O = linalg.generic { indexing_maps = [#map0],
                         iterator_types = ["parallel", "parallel"] }
     outs(%B: tensor<32x16xf32>) {

--- a/test/Integration/tpp-add.mlir
+++ b/test/Integration/tpp-add.mlir
@@ -1,16 +1,13 @@
-// This should really be in the passes directory, not here
-// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck %s
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s -check-prefix=EXE
 
-// RUN: tpp-run %s -tpp-to-loops -print \
+// RUN: tpp-run %s -linalg-to-xsmm="false" -tpp-to-loops -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE
 
 // RUN: tpp-opt %s -convert-linalg-to-loops | \
 // RUN: tpp-run -print \
-// RUN:  -e entry -entry-point-result=void | \
-// RUN: FileCheck %s -check-prefix=EXE
-
-// RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s -check-prefix=EXE
 
@@ -30,52 +27,49 @@ func.func private @generate_1D_source(%init_source : tensor<?xf32>) -> tensor<?x
 
 func.func @entry() {
   %arg0 = tensor.empty() : tensor<56x32xf32>
-  %arg2 = tensor.empty() : tensor<1x2x56x56x32xf32>
 
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
   %c56 = arith.constant 56 : index
+  %c0_cst = arith.constant 0.0 : f32
   %c1_cst = arith.constant 1.0 : f32
-  %c32 = arith.constant 32 : index
 
+  %c32 = arith.constant 32 : index
   %seed = tensor.empty(%c32) : tensor<?xf32>
   %seedGen = call @generate_1D_source(%seed) : (tensor<?xf32>) -> (tensor<?xf32>)
   %cast_seed = tensor.cast %seedGen : tensor<?xf32> to tensor<32xf32>
   %b0 = linalg.broadcast ins(%cast_seed : tensor<32xf32>)
-                   outs(%arg0 : tensor<56x32xf32>)
-                   dimensions = [0]
-  %out_shape = tensor.empty() : tensor<1x2x56x56x32xf32>
-
-  %3 = scf.for %arg3 = %c0 to %c2 step %c1 iter_args(%ia1 = %out_shape) -> (tensor<1x2x56x56x32xf32>) {
-    %4 = scf.for %arg4 = %c0 to %c56 step %c1 iter_args(%ia2 = %ia1) -> (tensor<1x2x56x56x32xf32>) {
+                         outs(%arg0 : tensor<56x32xf32>)
+                         dimensions = [0]
+  %out_shape = tensor.empty() : tensor<2x56x56x32xf32>
+  %3 = scf.for %arg3 = %c0 to %c2 step %c1 iter_args(%ia1 = %out_shape) -> (tensor<2x56x56x32xf32>) {
+    %4 = scf.for %arg4 = %c0 to %c56 step %c1 iter_args(%ia2 = %ia1) -> (tensor<2x56x56x32xf32>) {
       %out_slice = tensor.empty() : tensor<56x32xf32>
-      // CHECK: tpp.add
+      %fill = linalg.fill ins(%c0_cst : f32) outs(%out_slice : tensor<56x32xf32>) -> tensor<56x32xf32>
       %res = linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, 
                        affine_map<(d0, d1) -> (d0, d1)>], 
       iterator_types = ["parallel", "parallel"]}
       ins(%b0, %b0 : tensor<56x32xf32>, tensor<56x32xf32>)
-      outs(%out_slice : tensor<56x32xf32>) {
+      outs(%fill : tensor<56x32xf32>) {
         ^bb0(%in: f32, %in_0: f32, %out: f32):
           %0 = arith.addf %in, %in_0 : f32
           linalg.yield %0 : f32
       } -> tensor<56x32xf32>
-      %inserted_slice = tensor.insert_slice %res into %ia2 [0, %arg3, %arg4, 0, 0] [1, 1, 1, 56, 32] [1, 1, 1, 1, 1] 
-        : tensor<56x32xf32> into tensor<1x2x56x56x32xf32>
-      scf.yield %inserted_slice : tensor<1x2x56x56x32xf32>
+      %inserted_slice = tensor.insert_slice %res into %ia2 [%arg3, %arg4, 0, 0] [1, 1, 56, 32] [1, 1, 1, 1] 
+        : tensor<56x32xf32> into tensor<2x56x56x32xf32>
+      scf.yield %inserted_slice : tensor<2x56x56x32xf32>
     }
-    scf.yield %4 : tensor<1x2x56x56x32xf32>
+    scf.yield %4 : tensor<2x56x56x32xf32>
   }
   %zeroCst = arith.constant 0 : index
   %d1 = arith.constant -1.0 : f32
-  scf.for %i0 = %c0 to %c1 step %c1 {
-    scf.for %i1 = %c0 to %c2 step %c1 {
-      scf.for %i2 = %c0 to %c56 step %c1 {
-        scf.for %i3 = %c0 to %c56 step %c1 {
-          %v0 = vector.transfer_read %3[%i0, %i1, %i2, %i3, %zeroCst], %d1 : tensor<1x2x56x56x32xf32>, vector<32xf32>
-          vector.print %v0 : vector<32xf32>
-        }
+  scf.for %i1 = %c0 to %c2 step %c1 {
+    scf.for %i2 = %c0 to %c56 step %c1 {
+      scf.for %i3 = %c0 to %c56 step %c1 {
+        %v0 = vector.transfer_read %3[%i1, %i2, %i3, %zeroCst], %d1 : tensor<2x56x56x32xf32>, vector<32xf32>
+        vector.print %v0 : vector<32xf32>
       }
     }
   }

--- a/test/Integration/tpp-brgemm-non-unit-batch.mlir
+++ b/test/Integration/tpp-brgemm-non-unit-batch.mlir
@@ -1,5 +1,4 @@
-// This should really be in the passes directory, not here
-// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck -check-prefix=IR %s
 
 // RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
@@ -13,9 +12,10 @@
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 
+// IR-LABEL: brgemmtpp
 func.func @brgemmtpp(%A: tensor<2x4x8xf32>,
                      %B: tensor<2x8x4xf32>, %C: tensor<4x4xf32>) -> tensor<4x4xf32>  {
-  // TPP: tpp.brgemm
+  // IR: xsmm_brgemm_invoke
   %D = linalg.batch_reduce_matmul ins(%A, %B: tensor<2x4x8xf32>, tensor<2x8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
   return %D: tensor<4x4xf32>
 }

--- a/test/Integration/tpp-brgemm.mlir
+++ b/test/Integration/tpp-brgemm.mlir
@@ -10,8 +10,12 @@
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck %s -check-prefix=IR
+
+// IR-LABEL: brgemm_tpp
 func.func @brgemm_tpp(%A: tensor<1x4x8xf32>,
                      %B: tensor<1x8x4xf32>, %C: tensor<4x4xf32>) -> tensor<4x4xf32>  {
+  // IR: xsmm_gemm_invoke
   %D = linalg.batch_reduce_matmul ins(%A, %B: tensor<1x4x8xf32>, tensor<1x8x4xf32>) outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
   return %D: tensor<4x4xf32>
 }

--- a/test/Integration/tpp-fused-brgemm-no-fusion.mlir
+++ b/test/Integration/tpp-fused-brgemm-no-fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s \
+// RUN: tpp-run %s -linalg-to-xsmm="false" \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/tpp-fused-brgemm.mlir
+++ b/test/Integration/tpp-fused-brgemm.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s \
+// RUN: tpp-run %s -linalg-to-xsmm="false" \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 

--- a/test/Integration/tpp-identity.mlir
+++ b/test/Integration/tpp-identity.mlir
@@ -1,25 +1,24 @@
-// This should really be in the passes directory, not here
-// RUN: tpp-opt %s -canonicalize -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck -check-prefix=IR %s
 
-// We don't need to print because we use the check dialect
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s \
 // RUN:  -e entry -entry-point-result=void
 
-// RUN: tpp-run %s -tpp-to-loops -print \
+// RUN: tpp-run %s -tpp-to-loops \
 // RUN:  -e entry -entry-point-result=void
 
-// RUN: tpp-run %s -linalg-to-loops -print \
+// RUN: tpp-run %s -linalg-to-loops \
 // RUN:  -e entry -entry-point-result=void
 
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 
+// IR-LABEL: entry
 func.func @entry(){
   %init_source = tensor.empty() : tensor<64xf32>
   %cst = arith.constant 23.0 : f32
   %input_tensor = linalg.fill ins(%cst : f32) outs(%init_source : tensor<64xf32>) -> tensor<64xf32>
   %1 = tensor.empty() : tensor<56x64xf32>
-  // TPP: tpp.identity
+  // IR: xsmm_unary_invoke
   %2 = linalg.generic {indexing_maps=[#map, #map1],
                        iterator_types = ["parallel", "parallel"]}
     ins(%input_tensor : tensor<64xf32> ) outs(%1 : tensor<56x64xf32>) {

--- a/test/Integration/tpp-relu.mlir
+++ b/test/Integration/tpp-relu.mlir
@@ -1,5 +1,4 @@
-// This should really be in the passes directory, not here
-// RUN: tpp-opt %s -convert-linalg-to-tpp | FileCheck -check-prefix=TPP %s
+// RUN: tpp-opt %s -default-tpp-passes | FileCheck -check-prefix=IR %s
 
 // RUN: tpp-run %s -print \
 // RUN:  -e entry -entry-point-result=void | \
@@ -15,10 +14,10 @@
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
-// TPP: func.func @relutpp
+// IR-LABEL: relutpp
 func.func @relutpp(%A: tensor<9x6xf32>) -> tensor<9x6xf32>  {
   %c0 = arith.constant 0.0 : f32
-  // TPP: tpp.relu
+  // IR: xsmm_unary_invoke
   %O = linalg.generic { indexing_maps = [#map0], iterator_types = ["parallel", "parallel"] }
     outs(%A: tensor<9x6xf32>) {
       ^bb0(%a: f32):

--- a/test/Integration/tpp-run-bufferization.mlir
+++ b/test/Integration/tpp-run-bufferization.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-run %s -print \
+// RUN: tpp-run %s -print -linalg-to-xsmm="false" \
 // RUN:  -e entry -entry-point-result=void | \
 // RUN: FileCheck %s
 


### PR DESCRIPTION
Move the default pipeline to use linalg to XSMM conversion, thus bringing us closer to deprecating TPPs.