### PR TITLE
Do not pick default in `DefaultTppPasses` (NFC)

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -211,13 +211,10 @@ private:
     pm.addPass(createCleanup());
 
     // Convert ops to packed layouts.
-    pm.addPass(createPackConv2DNhwcHwcf(
-        PackConv2DNhwcHwcfOptions{SmallVector<int64_t>{32, 32}}));
-    pm.addPass(createPackConv2DNchwFchw(
-        PackConv2DNchwFchwOptions{SmallVector<int64_t>{32, 32}}));
+    pm.addPass(createPackConv2DNhwcHwcf());
+    pm.addPass(createPackConv2DNchwFchw());
     pm.addPass(createRewriteConvToMatmulOrBrgemm());
-    pm.addPass(
-        createPackMatmul(PackMatmulOptions{SmallVector<int64_t>{32, 32, 32}}));
+    pm.addPass(createPackMatmul());
     pm.addPass(createPackVNNI());
 
     // Postprocess packing.

--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -556,6 +556,18 @@ struct BubbleUpThroughFillOp : public OpRewritePattern<tensor::PackOp> {
   }
 };
 
+static SmallVector<int64_t>
+getDefaultBlockingFactors(linalg::LinalgOp linalgOp) {
+  assert(linalgOp && "expect a valid linalgOp");
+  if (isa<linalg::Conv2DNchwFchwOp>(linalgOp) ||
+      isa<linalg::Conv2DNhwcHwcfOp>(linalgOp)) {
+    return {32, 32};
+  }
+  assert(isa<linalg::MatmulOp>(linalgOp) ||
+         isa<linalg::BatchMatmulOp>(linalgOp));
+  return {32, 32, 32};
+}
+
 //===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//
@@ -569,6 +581,8 @@ template <typename OpTy> struct PackMatmulImpl : public OpRewritePattern<OpTy> {
 
   LogicalResult matchAndRewrite(OpTy matmulOp,
                                 PatternRewriter &rewriter) const override {
+    if (blockingFactors.empty())
+      blockingFactors = getDefaultBlockingFactors(matmulOp);
     FailureOr<linalg::GenericOp> packedMatmul = mlir::linalgx::packMatmulOp(
         rewriter, matmulOp,
         getAsOpFoldResult(rewriter.getI64ArrayAttr(blockingFactors)));
@@ -578,7 +592,7 @@ template <typename OpTy> struct PackMatmulImpl : public OpRewritePattern<OpTy> {
   }
 
 private:
-  ArrayRef<int64_t> blockingFactors;
+  mutable SmallVector<int64_t> blockingFactors;
 };
 
 // Entry point for packing a matmul operation.
@@ -592,8 +606,6 @@ struct PackMatmul : public tpp::impl::PackMatmulBase<PackMatmul> {
   using PackMatmulBase::PackMatmulBase;
 
   void runOnOperation() override {
-    if (blockingFactors.empty())
-      return;
     MLIRContext *ctx = getOperation().getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<PackMatmulImpl<linalg::MatmulOp>,
@@ -612,6 +624,8 @@ struct DoItOnConv2DNchwFchw
 
   LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwOp linalgOp,
                                 PatternRewriter &rewriter) const override {
+    if (blockingFactors.empty())
+      blockingFactors = getDefaultBlockingFactors(linalgOp);
     FailureOr<linalg::GenericOp> genericOp =
         mlir::linalgx::packConv2DNchwFchwOp(
             rewriter, linalgOp,
@@ -622,7 +636,7 @@ struct DoItOnConv2DNchwFchw
   }
 
 private:
-  SmallVector<int64_t> blockingFactors;
+  mutable SmallVector<int64_t> blockingFactors;
 };
 
 struct PackConv2DNchwFchw
@@ -630,8 +644,6 @@ struct PackConv2DNchwFchw
   using PackConv2DNchwFchwBase::PackConv2DNchwFchwBase;
 
   void runOnOperation() override {
-    if (blockingFactors.empty())
-      return;
     MLIRContext *ctx = getOperation().getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<DoItOnConv2DNchwFchw>(ctx, blockingFactors);
@@ -648,6 +660,8 @@ struct DoItOnConv2DNhwcHwcf
 
   LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp linalgOp,
                                 PatternRewriter &rewriter) const override {
+    if (blockingFactors.empty())
+      blockingFactors = getDefaultBlockingFactors(linalgOp);
     FailureOr<linalg::GenericOp> maybeGeneric =
         mlir::linalgx::packConv2DNhwcHwcfOp(
             rewriter, linalgOp,
@@ -658,7 +672,7 @@ struct DoItOnConv2DNhwcHwcf
   }
 
 private:
-  SmallVector<int64_t> blockingFactors;
+  mutable SmallVector<int64_t> blockingFactors;
 };
 
 struct PackConv2DNhwcHwcf
@@ -666,8 +680,6 @@ struct PackConv2DNhwcHwcf
   using PackConv2DNhwcHwcfBase::PackConv2DNhwcHwcfBase;
 
   void runOnOperation() override {
-    if (blockingFactors.empty())
-      return;
     MLIRContext *ctx = getOperation().getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<DoItOnConv2DNhwcHwcf>(ctx, blockingFactors);

--- a/test/Passes/pass-conv-blocking-nchw-fchw-default.mlir
+++ b/test/Passes/pass-conv-blocking-nchw-fchw-default.mlir
@@ -1,0 +1,25 @@
+// RUN: tpp-opt -pack-conv2DNchwFchw -split-input-file %s | FileCheck %s
+
+func.func @conv_2d_nchw_fchw(%i: tensor<14x512x28x28xf32>, %f: tensor<1024x512x1x1xf32>,
+                %o: tensor<14x1024x28x28xf32>) -> tensor<14x1024x28x28xf32> {
+  %0 = linalg.conv_2d_nchw_fchw ins(%i, %f: tensor<14x512x28x28xf32>, tensor<1024x512x1x1xf32>) outs(%o: tensor<14x1024x28x28xf32>) -> tensor<14x1024x28x28xf32>
+  return %0: tensor<14x1024x28x28xf32>
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d5, d2 + d6, d3 + d7, d8)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d8, d4)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
+
+// CHECK: func.func @conv_2d_nchw_fchw(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<14x512x28x28xf32>,
+// CHECK-SAME:  %[[ARG1:.+]]: tensor<1024x512x1x1xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: tensor<14x1024x28x28xf32>) -> tensor<14x1024x28x28xf32> {
+// CHECK: %[[BUF0:.+]] = tensor.empty() : tensor<14x16x28x28x32xf32>
+// CHECK: %[[PACK0:.+]] = tensor.pack %[[ARG0]] inner_dims_pos = [1] inner_tiles = [32] into %[[BUF0]] : tensor<14x512x28x28xf32> -> tensor<14x16x28x28x32xf32>
+// CHECK: %[[BUF1:.+]] = tensor.empty() : tensor<32x16x1x1x32x32xf32>
+// CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]] inner_dims_pos = [1, 0] inner_tiles = [32, 32] into %[[BUF1]] : tensor<1024x512x1x1xf32> -> tensor<32x16x1x1x32x32xf32>
+// CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<14x32x28x28x32xf32>
+// CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]] inner_dims_pos = [1] inner_tiles = [32] into %[[BUF2]] : tensor<14x1024x28x28xf32> -> tensor<14x32x28x28x32xf32>
+// CHECK: %[[VAL:.+]] = linalg.generic {indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction", "reduction"]} ins(%[[PACK0]], %[[PACK1]] : tensor<14x16x28x28x32xf32>, tensor<32x16x1x1x32x32xf32>) outs(%[[PACK2]] : tensor<14x32x28x28x32xf32>)
+// CHECK: %[[OUT:.+]] = tensor.unpack %[[VAL]] inner_dims_pos = [1] inner_tiles = [32] into %[[ARG2]] : tensor<14x32x28x28x32xf32> -> tensor<14x1024x28x28xf32>
+// CHECK: return %[[OUT]] : tensor<14x1024x28x28xf32>

--- a/test/Passes/pass-conv-blocking-nhwc-hwcf-default.mlir
+++ b/test/Passes/pass-conv-blocking-nhwc-hwcf-default.mlir
@@ -1,0 +1,39 @@
+// RUN: tpp-opt %s -pack-conv2DNhwcHwcf -split-input-file | FileCheck %s
+
+func.func @conv_2d_nhwc_hwcf(%arg0: tensor<1x113x113x64xf32>, %arg1: tensor<3x3x64x256xf32>, %arg2: tensor<1x111x111x256xf32>) -> tensor<1x111x111x256xf32> {
+  %1 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>,
+                                 strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1 : tensor<1x113x113x64xf32>, tensor<3x3x64x256xf32>)
+    outs(%arg2: tensor<1x111x111x256xf32>) -> tensor<1x111x111x256xf32>
+  return %1 : tensor<1x111x111x256xf32>
+}
+
+// CHECK: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d5, d2 + d6, d3 + d7, d8)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d8, d4)>
+// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
+
+// CHECK: func.func @conv_2d_nhwc_hwcf(
+// CHECK-SAME: %[[ARG0:.+]]: tensor<1x113x113x64xf32>,
+// CHECK-SAME: %[[ARG1:.+]]: tensor<3x3x64x256xf32>,
+// CHECK-SAME: %[[ARG2:.+]]: tensor<1x111x111x256xf32>)
+// CHECK: %[[BUF0:.+]] = tensor.empty() : tensor<1x2x113x113x32xf32>
+// CHECK: %[[PACK0:.+]] = tensor.pack %[[ARG0]]
+// CHECK-SAME:  outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32]
+// CHECK-SAME:  into %[[BUF0]] : tensor<1x113x113x64xf32> -> tensor<1x2x113x113x32xf32>
+// CHECK: %[[BUF1:.+]] = tensor.empty() : tensor<8x2x3x3x32x32xf32>
+// CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]]
+// CHECK-SAME:  outer_dims_perm = [3, 2, 0, 1] inner_dims_pos = [2, 3] inner_tiles = [32, 32]
+// CHECK-SAME:  into %[[BUF1]] : tensor<3x3x64x256xf32> -> tensor<8x2x3x3x32x32xf32>
+// CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<1x8x111x111x32xf32>
+// CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]]
+// CHECK-SAME:  outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32]
+// CHECK-SAME:  into %[[BUF2]] : tensor<1x111x111x256xf32> -> tensor<1x8x111x111x32xf32>
+// CHECK: %[[GEN:.+]] = linalg.generic {
+// CHECK-SAME:  indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
+// CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction", "reduction"]}
+// CHECK-SAME:  ins(%[[PACK0]], %[[PACK1]]
+// CHECK-SAME:  outs(%[[PACK2]]
+// CHECK: %[[RES:.+]] = tensor.unpack %[[GEN]]
+// CHECK-SAME:  outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32]
+// CHECK-SAME:  into %[[ARG2]] : tensor<1x8x111x111x32xf32> -> tensor<1x111x111x256xf32>
+// CHECK: return %[[RES]] : tensor<1x111x111x256xf32>

--- a/test/Passes/pass-matmul-blocking-default.mlir
+++ b/test/Passes/pass-matmul-blocking-default.mlir
@@ -1,0 +1,28 @@
+// RUN: tpp-opt %s -pack-matmul -split-input-file | FileCheck %s
+
+func.func @block_linalg_matmul(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32> {
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+// CHECK-DAG: #[[MAP3:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// CHECK-DAG: #[[MAP4:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// CHECK-DAG: #[[MAP5:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+// CHECK-LABEL: func @block_linalg_matmul(
+// CHECK-SAME:    %[[ARG0:[0-9a-z]+]]: tensor<128x128xf32>
+// CHECK-SAME:    %[[ARG1:[0-9a-z]+]]: tensor<128x128xf32>
+// CHECK-SAME:    %[[ARG2:[0-9a-z]+]]: tensor<128x128xf32>) -> tensor<128x128xf32> {
+// CHECK: %[[BUF0:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK0:.+]] = tensor.pack %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF0]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[BUF1:.*]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]] outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF1]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF2]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[VAL:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP4]], #[[MAP5]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[PACK0]], %[[PACK1]] : tensor<4x4x32x32xf32>, tensor<4x4x32x32xf32>) outs(%[[PACK2]] : tensor<4x4x32x32xf32>)
+// CHECK: %[[OUT:.+]] = tensor.unpack %[[VAL]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[ARG2]] : tensor<4x4x32x32xf32> -> tensor<128x128xf32>
+// CHECK: return %[[OUT]] : tensor<128x128xf32>


### PR DESCRIPTION
Localize pick for default blocking factors in the blocking passes rather than in the default pipeline. The default pipeline should not take any decision on defaults; passes should pick defaults.