### PR TITLE
Add debug scripts for compiler passes

### DIFF
--- a/scripts/debug/debug_all_passes.sh
+++ b/scripts/debug/debug_all_passes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(realpath $(dirname $0)/..)
+source ${SCRIPT_DIR}/ci/common.sh
+
+TMP_DIR=$(mktemp -d)
+DUMP_FILE=${TMP_DIR}/dump.mlir
+SPLIT=${SCRIPT_DIR}/debug/split.py
+DIFF=${SCRIPT_DIR}/debug/diff.py
+
+ROOT_DIR=$(git_root)
+DIFF_TOOL=diff
+BIN_DIR=$ROOT_DIR/build/bin
+while getopts "b:d:" arg; do
+  case ${arg} in
+    b)
+      BIN_DIR=$(realpath ${OPTARG})
+      if [ ! -x ${BIN_DIR}/mlir-gen ]; then
+        echo "'${OPTARG}' not a bin directory"
+        exit 1
+      fi
+      ;;
+    d)
+      DIFF_TOOL=${OPTARG}
+      check_program ${DIFF_TOOL}
+      ;;
+    *)
+      echo "Invalid option: ${OPTARG}"
+      exit 1
+  esac
+done
+MLIR_GEN=${BIN_DIR}/mlir-gen
+TPP_OPT=${BIN_DIR}/tpp-opt
+
+## Get IR dump
+echo "Producing dump at ${TMP_DIR}"
+${MLIR_GEN} --bias --relu | \
+    ${TPP_OPT} \
+      --default-tpp-passes \
+      --mlir-print-ir-after-all \
+      > /dev/null 2> ${DUMP_FILE}
+
+## Split dump
+echo "Splitting the file into multiple outputs"
+pushd ${TMP_DIR}
+${SPLIT} ${DUMP_FILE}
+# Quick idea of how many files
+ls -l ${TMP_DIR}/???.mlir | head -n 3
+echo "..."
+ls -l ${TMP_DIR}/???.mlir | tail -n 3
+
+## Diff the stages
+echo "Diffing the files with ${DIFF_TOOL}"
+${DIFF} -d ${DIFF_TOOL} mlir
+popd

--- a/scripts/debug/diff.py
+++ b/scripts/debug/diff.py
@@ -5,16 +5,19 @@ import argparse
 import subprocess
 
 argParser = argparse.ArgumentParser()
-argParser.add_argument('-p', '--path')
-argParser.add_argument('-d', '--diff')
-argParser.add_argument('ext')
+argParser.add_argument("-p", "--path")
+argParser.add_argument("-d", "--diff")
+argParser.add_argument("ext")
+
 
 def syntax():
     print("Use -h for options\n")
     exit(1)
 
+
 def getFileName(counter):
     return f"{args.path}/%03d.{args.ext}" % counter
+
 
 def readFile(file):
     lines = list()
@@ -27,10 +30,12 @@ def readFile(file):
             lines.append(line)
     return lines
 
+
 def sameFile(prev, next):
     lhs = readFile(prev)
     rhs = readFile(next)
     return lhs == rhs
+
 
 def nextFile(counter):
     counter += 1
@@ -44,7 +49,7 @@ def nextFile(counter):
     return None, counter
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = argParser.parse_args()
     if args.ext is None:
         syntax()
@@ -74,14 +79,14 @@ if __name__ == '__main__':
     last = curr
     while True:
         next, counter = nextFile(counter)
-        if sameFile(curr, next):
-            curr = next
-            continue
         if next is None:
             print("No more files\n")
             break
-        cmd=[args.diff, last, next]
-        print(' '.join(cmd))
+        if sameFile(curr, next):
+            curr = next
+            continue
+        cmd = [args.diff, last, next]
+        print(" ".join(cmd))
         print("Press ENTER to continue or CTRL+C to cancel...\n")
         input()
         subprocess.run(cmd)

--- a/scripts/debug/diff.py
+++ b/scripts/debug/diff.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import subprocess
+
+argParser = argparse.ArgumentParser()
+argParser.add_argument('-p', '--path')
+argParser.add_argument('-d', '--diff')
+argParser.add_argument('ext')
+
+def syntax():
+    print("Use -h for options\n")
+    exit(1)
+
+def getFileName(counter):
+    return f"{args.path}/%03d.{args.ext}" % counter
+
+def readFile(file):
+    lines = list()
+    with open(file, "r") as fp:
+        for line in fp:
+            if line is None or line == "":
+                continue
+            if line.startswith("//"):
+                continue
+            lines.append(line)
+    return lines
+
+def sameFile(prev, next):
+    lhs = readFile(prev)
+    rhs = readFile(next)
+    return lhs == rhs
+
+def nextFile(counter):
+    counter += 1
+    file = getFileName(counter)
+    while os.path.isfile(file):
+        with open(file, "r") as fp:
+            if len(fp.readlines()) > 3:
+                return file, counter
+        counter += 1
+        file = getFileName(counter)
+    return None, counter
+
+
+if __name__ == '__main__':
+    args = argParser.parse_args()
+    if args.ext is None:
+        syntax()
+
+    if args.path is None:
+        args.path = "."
+
+    if not os.path.isdir(args.path):
+        print(f"{args.path} not a directory\n")
+        syntax()
+
+    if not os.path.isfile(f"{args.path}/000.{args.ext}"):
+        print(f"000.{args.ext} is not a file\n")
+        print(f"Run 'split.py` first?\n")
+        syntax()
+
+    if not os.path.isfile(f"{args.path}/001.{args.ext}"):
+        print(f"001.{args.ext} is not a file\n")
+        print(f"Needs at least two files to compare\n")
+        print(f"Run 'split.py` first?\n")
+        syntax()
+
+    if args.diff is None:
+        args.diff = "diff"
+
+    curr, counter = nextFile(0)
+    last = curr
+    while True:
+        next, counter = nextFile(counter)
+        if sameFile(curr, next):
+            curr = next
+            continue
+        if next is None:
+            print("No more files\n")
+            break
+        cmd=[args.diff, last, next]
+        print(' '.join(cmd))
+        print("Press ENTER to continue or CTRL+C to cancel...\n")
+        input()
+        subprocess.run(cmd)
+        curr = next
+        last = curr

--- a/scripts/debug/split.py
+++ b/scripts/debug/split.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     ext=os.path.splitext(args.filename)[1]
     counter = 0
     filename = f"%03d{ext}" % counter
-    outfile = open(filename, "a")
+    outfile = open(filename, "w")
     with open(args.filename, "r") as file:
         for line in file:
             # New files

--- a/scripts/debug/split.py
+++ b/scripts/debug/split.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+
+argParser = argparse.ArgumentParser()
+argParser.add_argument('filename')
+
+def syntax():
+    print("Use -h for options\n")
+    exit(1)
+
+if __name__ == '__main__':
+    args = argParser.parse_args()
+    if args.filename is None:
+        syntax()
+
+    if not os.path.isfile(args.filename):
+        print(f"{args.filename} is not a file\n")
+        syntax()
+
+    ext=os.path.splitext(args.filename)[1]
+    counter = 0
+    filename = f"%03d{ext}" % counter
+    outfile = open(filename, "a")
+    with open(args.filename, "r") as file:
+        for line in file:
+            # New files
+            if line.startswith("//"):
+                counter += 1
+                filename = f"%03d{ext}" % counter
+                outfile.close()
+                outfile = open(filename, "w")
+            # Write to outfile
+            outfile.write(line)
+    outfile.close()


### PR DESCRIPTION
This is a simple set of scripts that run mlir-gen/tpp-opt, dumps the IR between passes, splits the output for each pass into files, looks at each one when the IR changes and runs the diff tool of your choice to show these differences.

For now, mlir-gen is only emitting the standard odd-shaped MLP layer over the standard TPP passes, but future changes to the scripts can add arguments to each tool.