### PR TITLE
Use 64 as blocking factors for `omp` benchmarks

### DIFF
--- a/benchmarks/config/omp/dnn-bf16.json
+++ b/benchmarks/config/omp/dnn-bf16.json
@@ -5,28 +5,28 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "gemm_bf16_omp_4_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "gemm_bf16_omp_8_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "gemm_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     }
   }},
@@ -36,28 +36,28 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "mlp_bf16_omp_4_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "mlp_bf16_omp_8_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "mlp_bf16_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": []
     }
   }}

--- a/benchmarks/config/omp/dnn-fp32.json
+++ b/benchmarks/config/omp/dnn-fp32.json
@@ -5,28 +5,28 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "gemm_fp32_omp_4_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "gemm_fp32_omp_8_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "gemm_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     }
   }},
@@ -36,28 +36,28 @@
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "1" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "mlp_fp32_omp_4_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "mlp_fp32_omp_8_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
     "mlp_fp32_omp_16_dnn": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
-      "flags": [ "100", "256", "3", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     }
   }}


### PR DESCRIPTION
In DNN we use 32, while in the IR generated by `mlir-gen` we use 64. 