### PR TITLE
Do not fold unpack when for has multiple uses

### DIFF
--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -933,6 +933,8 @@ struct FoldUnPackIntoInsertSlice : public OpRewritePattern<tensor::UnPackOp> {
     if (!isa_and_nonnull<scf::ForallOp>(loop))
       return failure();
     auto forallOp = cast<scf::ForallOp>(loop);
+    if (!forallOp->hasOneUse())
+      return failure();
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPoint(forallOp);
 


### PR DESCRIPTION
We cannot take the body of the for if it has multiple uses. The for ends up with an empty body and the verifier fails.
Fix: #770