### PR TITLE
[Bench] Move benchmarks to show apples-to-apples comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,14 +67,21 @@ add_subdirectory(test)
 set(BENCHMARK_DIR "${PROJECT_SOURCE_DIR}/benchmarks")
 set(CONFIG_DIR "${BENCHMARK_DIR}/config")
 
+# Run baseline benchmarks with default iterations to track simple performance
+set(BENCH_CFGS
+  ${CONFIG_DIR}/base/base.json
+  ${CONFIG_DIR}/base/pack.json
+  ${CONFIG_DIR}/base/mha.json
+)
+string(JOIN ',' BENCH_CFGS_STR ${BENCH_CFGS})
 # Run a small set of benchmarks with small iterations to test the benchmarks and run locally on small machines
 add_custom_target(benchmarks ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
-                  -c ${CONFIG_DIR}/base/base.json
+                  -c ${BENCH_CFGS_STR}
                   DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
                   WORKING_DIRECTORY ${BENCHMARK_DIR}
                   COMMENT Run Base Benchmarks)
 
-# Run baseline benchmarks with default iterations to track simple performance
+# Run OpenMP benchmarks with default iterations to track simple performance
 set(BENCH_OMP_CFGS
   ${CONFIG_DIR}/omp/dnn-fp32.json
   ${CONFIG_DIR}/omp/dnn-bf16.json
@@ -82,8 +89,8 @@ set(BENCH_OMP_CFGS
   ${CONFIG_DIR}/omp/mlir-bf16.json
 )
 string(JOIN ',' BENCH_OMP_CFGS_STR ${BENCH_OMP_CFGS})
-add_custom_target(benchmarks-omp ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR}
-  -c ${BENCH_OMP_CFGS_STR}
+add_custom_target(benchmarks-omp ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10
+                  -c ${BENCH_OMP_CFGS_STR}
                   DEPENDS tpp-opt tpp-run xsmm_dnn_mlp
                   WORKING_DIRECTORY ${BENCHMARK_DIR}
                   COMMENT Run Benchmarks)

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -1,202 +1,137 @@
 [
   {
-  "gemm": {
-    "fp32_3x1024_model_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=model --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
-    "fp32_3x1024_flat_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
-    "fp32_3x1024_64x64_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
-    "bf16_3x1024_flat_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
-      "environment": {},
-      "flags": [ "-n", "100"],
-      "extensions": [ "avx2" ]
-    },
-    "bf16_3x1024_64x64_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
-      "environment": {},
-      "flags": [ "-n", "100"],
-      "extensions": [ "avx2" ]
-    },
-    "bf16_3x1024_dp2_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=2" ],
-      "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
-      "extensions": [ "avx2" ]
-    },
-    "bf16_3x1024_dp4_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=4" ],
-      "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
-      "extensions": [ "svebf16" ]
-    }
-  }},
-  {
-  "mlp": {
-    "fp32_3x1024_model_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
-    "fp32_3x1024_flat_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
-    "fp32_3x1024_64x64_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
-    "bf16_3x1024_flat_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
-      "environment": {},
-      "flags": [ "-n", "100"],
-      "extensions": [ "avx2" ]
-    },
-    "bf16_3x1024_64x64_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
-      "environment": {},
-      "flags": [ "-n", "100"],
-      "extensions": [ "avx2" ]
-    },
-    "bf16_3x1024_dp2_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=2" ],
-      "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
-      "extensions": [ "avx2" ]
-    },
-    "bf16_3x1024_dp4_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=4" ],
-      "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
-      "extensions": [ "svebf16" ]
-    }
-  }},
-  {
-  "libxsmm-dnn": {
-    "gemm_fp32_dnn": {
+  "prepacked_targets": {
+    "gemm_fp32_dnn_target": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": {},
       "flags": [ "100", "256", "0", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
-    "mlp_fp32_dnn": {
-      "type": "XSMM-DNN",
-      "benchmark": "xsmm_dnn_mlp",
+    "gemm_fp32_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
       "environment": {},
-      "flags": [ "100", "256", "3", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
-      "extensions": []
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
     },
-    "gemm_bf16_dnn": {
+    "gemm_bf16_dnn_target": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": {},
       "flags": [ "100", "256", "0", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": [ "avx2" ]
     },
-    "mlp_bf16_dnn": {
+    "gemm_bf16_dp2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=2" ],
+      "environment": {},
+      "flags": [ "-n", "100", "--disable-lsan" ],
+      "extensions": [ "avx2" ]
+    },
+    "gemm_bf16_dp4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=4" ],
+      "environment": {},
+      "flags": [ "-n", "100", "--disable-lsan" ],
+      "extensions": [ "svebf16" ]
+    },
+    "mlp_fp32_dnn_target": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": {},
+      "flags": [ "100", "256", "3", "F", "64", "64", "64", "0", "1024", "1024", "1024", "1024" ],
+      "extensions": []
+    },
+    "mlp_fp32_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "mlp_bf16_dnn_target": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": {},
       "flags": [ "100", "256", "3", "F", "64", "64", "64", "1", "1024", "1024", "1024", "1024" ],
       "extensions": [ "avx2" ]
-    }
-  }},
-  {
-    "pack": {
-      "fp32_gemm_operand_a_512x1024": {
-        "type": "MLIR",
-        "benchmark": "fp32-pack-gemm-operand-a-512x1024.mlir",
-        "environment": {},
-        "flags": [ "-n", "500" ],
-        "extensions": [ "(avx2|asimd)" ]
     },
-    "fp32_gemm_operand_b_512x1024": {
-      "type": "MLIR",
-      "benchmark": "fp32-pack-gemm-operand-b-512x1024.mlir",
+    "mlp_bf16_dp2_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "500" ],
+      "flags": [ "-n", "100", "--disable-lsan" ],
+      "extensions": [ "avx2" ]
+    },
+    "mlp_bf16_dp4_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=4" ],
+      "environment": {},
+      "flags": [ "-n", "100", "--disable-lsan" ],
+      "extensions": [ "svebf16" ]
+    }
+  }},
+  {
+  "gemm_models": {
+    "fp32_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
+    },
+    "fp32_3x1024_args_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "bf16_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100"],
+      "extensions": [ "avx2" ]
+    },
+    "bf16_3x1024_args_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=layer --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100"],
+      "extensions": [ "avx2" ]
     }
   }},
   {
-    "unpack": {
-      "fp32_gemm_operand_c_512x512": {
-        "type": "MLIR",
-        "benchmark": "fp32-unpack-gemm-operand-a-512x512.mlir",
-        "environment": {},
-        "flags": [ "-n", "500" ],
-        "extensions": [ "(avx2|asimd)" ]
+  "mlp_models": {
+    "fp32_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "fp32_3x1024_args_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "bf16_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100"],
+      "extensions": [ "avx2" ]
+    },
+    "bf16_3x1024_args_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=layer --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100"],
+      "extensions": [ "avx2" ]
     }
-  }},
-  {
-    "mha": {
-      "fp32_mha_tensorflow_seq_len_32": {
-        "type": "MLIR",
-        "benchmark": "fp32-mha-tensorflow-seq-len-32.mlir",
-        "environment": {},
-        "flags": [ "-n", "10", "--linalg-to-xsmm", "1" ],
-        "extensions": [ "(avx2|asimd)" ]
-      },
-      "fp32_mha_tensorflow_seq_len_1024": {
-        "type": "MLIR",
-        "benchmark": "fp32-mha-tensorflow-seq-len-1024.mlir",
-        "environment": {},
-        "flags": [ "-n", "10", "--linalg-to-xsmm", "1" ],
-        "extensions": [ "(avx2|asimd)" ]
-      },
-      "fp32_projection": {
-        "type": "MLIR",
-        "benchmark": "fp32-projection.mlir",
-        "environment": {},
-        "flags": [ "-n", "100", "--linalg-to-xsmm", "1" ],
-        "extensions": [ "(avx2|asimd)" ]
-      },
-      "fp32_query_times_keys": {
-        "type": "MLIR",
-        "benchmark": "fp32-query-times-key.mlir",
-        "environment": {},
-        "flags": [ "-n", "100", "--linalg-to-xsmm", "1" ],
-        "extensions": [ "(avx2|asimd)" ]
-      },
-      "fp32_out_softmax_times_value.mlir": {
-        "type": "MLIR",
-        "benchmark": "fp32-out-softmax-times-value.mlir",
-        "environment": {},
-        "flags": [ "-n", "100", "--linalg-to-xsmm", "1" ],
-        "extensions": [ "(avx2|asimd)" ]
-      }
-    }}
+  }}
 ]

--- a/benchmarks/config/base/mha.json
+++ b/benchmarks/config/base/mha.json
@@ -1,0 +1,40 @@
+[
+  {
+    "mha": {
+      "fp32_mha_tensorflow_seq_len_32": {
+        "type": "MLIR",
+        "benchmark": "fp32-mha-tensorflow-seq-len-32.mlir",
+        "environment": {},
+        "flags": [ "-n", "10", "--linalg-to-xsmm", "1" ],
+        "extensions": [ "(avx2|asimd)" ]
+      },
+      "fp32_mha_tensorflow_seq_len_1024": {
+        "type": "MLIR",
+        "benchmark": "fp32-mha-tensorflow-seq-len-1024.mlir",
+        "environment": {},
+        "flags": [ "-n", "10", "--linalg-to-xsmm", "1" ],
+        "extensions": [ "(avx2|asimd)" ]
+      },
+      "fp32_projection": {
+        "type": "MLIR",
+        "benchmark": "fp32-projection.mlir",
+        "environment": {},
+        "flags": [ "-n", "100", "--linalg-to-xsmm", "1" ],
+        "extensions": [ "(avx2|asimd)" ]
+      },
+      "fp32_query_times_keys": {
+        "type": "MLIR",
+        "benchmark": "fp32-query-times-key.mlir",
+        "environment": {},
+        "flags": [ "-n", "100", "--linalg-to-xsmm", "1" ],
+        "extensions": [ "(avx2|asimd)" ]
+      },
+      "fp32_out_softmax_times_value.mlir": {
+        "type": "MLIR",
+        "benchmark": "fp32-out-softmax-times-value.mlir",
+        "environment": {},
+        "flags": [ "-n", "100", "--linalg-to-xsmm", "1" ],
+        "extensions": [ "(avx2|asimd)" ]
+      }
+    }}
+]

--- a/benchmarks/config/base/pack.json
+++ b/benchmarks/config/base/pack.json
@@ -1,0 +1,29 @@
+[
+  {
+    "pack": {
+      "fp32_gemm_operand_a_512x1024": {
+        "type": "MLIR",
+        "benchmark": "fp32-pack-gemm-operand-a-512x1024.mlir",
+        "environment": {},
+        "flags": [ "-n", "500" ],
+        "extensions": [ "(avx2|asimd)" ]
+    },
+    "fp32_gemm_operand_b_512x1024": {
+      "type": "MLIR",
+      "benchmark": "fp32-pack-gemm-operand-b-512x1024.mlir",
+      "environment": {},
+      "flags": [ "-n", "500" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+    "unpack": {
+      "fp32_gemm_operand_c_512x512": {
+        "type": "MLIR",
+        "benchmark": "fp32-unpack-gemm-operand-a-512x512.mlir",
+        "environment": {},
+        "flags": [ "-n", "500" ],
+        "extensions": [ "(avx2|asimd)" ]
+    }
+  }}
+]

--- a/scripts/buildkite/benchmark.sh
+++ b/scripts/buildkite/benchmark.sh
@@ -85,6 +85,8 @@ benchmark () {
 # Base Benchmarks
 if [ "$BENCH_BASE" ]; then
   benchmark base/base.json "Base Benchmarks"
+  benchmark base/pack.json "Pack Benchmarks"
+  benchmark base/mha.json "MHA Benchmarks"
 fi
 
 # OpenMP Benchmarks


### PR DESCRIPTION
This change modifies the `base` benchmarks to show an actual comparison between libxsmm-dnn and our compiler on fair comparisons. It also splits the pack and MHA benchmarks to separate configuration files so they don't affect the baseline.

Assumptions below...

Packing behaviour:
 * libxsmm-dnn packs at 64x64x64 and uses VNNI (dp2 and dp4)
 * mlir-gen can generate similar MLIR off the bat, so the compiler tile and fuses optimally, generating the same results

BF16 comparison:
 * libxsmm-dnn changes behaviour on x86 and Arm
 * mlir-gen has dp2/dp4 variants that only run on x86/arm resp.

GEMM/MLP "Models":
 * "const" means weights and biases are constant, like inference
 * "args" means weights and biases are not constant, like training
 * All models are unpacked and the compiler needs to pack them
 * Packing is done at argument (const) and weight/bias (args)

Expectations:
 * Pre-packed benchmarks need to be as fast as XSMM-DNN
   * Any inconsistency needs to be addressed to achieve parity
 * Unpacked benchmarks will be off by a few percent
   * But still faster than unpacked tiled benchmarks
   * And much faster than unpacked untiled benchmarks

TODO:
 * Add options to the compiler to avoid packing to create benchmarks for unpacked tiling and fuse to compare as "baseline" for traditional compilers.