### PR TITLE
XSMM Bump to HEAD of main

### DIFF
--- a/cmake/modules/xsmm-dnn.cmake
+++ b/cmake/modules/xsmm-dnn.cmake
@@ -16,8 +16,8 @@ else()
 
   FetchContent_Declare(
     xsmm_dnn
-    URL https://github.com/libxsmm/libxsmm-dnn/archive/c606d05e234debbec02ad8d5ccd4c1f4d6499a40.tar.gz
-    URL_HASH SHA256=e528c117451c6ff75157802842da58e2725de84aaa5794bd0d0f5c933bcbd694
+    URL https://github.com/libxsmm/libxsmm-dnn/archive/3ef7d1d6206fa4b75c9a787e1e2c11aa3e925f60.tar.gz
+    URL_HASH SHA256=223b6c6f03830701afd1c8fcf950ab67e2a0da22dee8e00c062682a750f56056
   )
 
   FetchContent_GetProperties(xsmm_dnn)

--- a/cmake/modules/xsmm.cmake
+++ b/cmake/modules/xsmm.cmake
@@ -13,8 +13,8 @@ else()
 
   FetchContent_Declare(
     xsmm
-    URL https://github.com/libxsmm/libxsmm/archive/e53f85e5aaa02de48a3ca77b0549c0b3e4f8aee9.tar.gz
-    URL_HASH SHA256=cba53c071431f5109c76cbd5789c803d4aadd0f3e671d12dd7da1203601845de
+    URL https://github.com/libxsmm/libxsmm/archive/54b8bb32042d204ff6fe550fa70d961f22c0b99e.tar.gz
+    URL_HASH SHA256=b2c3dd4f50cb6d045a2f9f2e93aa846b23a83ff22619352fb10cf97d2fe16d22
   )
 
   FetchContent_GetProperties(xsmm)


### PR DESCRIPTION
This bumps XSMM and XSMM-DNN to HEAD of main on both repos. We still get the warnings (#707) but at least now we're on a known commit.

Once #707 and https://github.com/libxsmm/libxsmm-dnn/issues/21 get fixed, we can bump again and enforce warnings as errors, so that we don't get to this place again.