### PR TITLE
Enable folding beta 0 in XSMM flags

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -59,7 +59,7 @@ def Xsmm_UnaryOp : Xsmm_Op<"unary"> {
 
   let extraClassDeclaration = [{
     bool hasScalarInput() {
-      // skip the function pointer. The operand
+      // Skip the function pointer. The operand
       // is at position 1.
       Type operand = getInputs()[1].getType();
       if (!operand.isa<ShapedType>())

--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -117,6 +117,10 @@ def Xsmm_FusedBrgemmOp : Xsmm_Op<"fused_brgemm"> {
     `(` `data_type` `=` $data_type `,` $inputs `)`
     attr-dict `:` functional-type($inputs, results)
   }];
+
+  let extraClassDeclaration = [{
+    Value getOutput() { return getInputs()[3]; }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -83,7 +83,7 @@ def Xsmm_GemmOp : Xsmm_Op<"gemm"> {
   }];
 
   let extraClassDeclaration = [{
-    Value getOutput() { return getInputs().back(); }
+    Value getOutput() { return getInputs()[3]; }
   }];
 }
 

--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -81,6 +81,10 @@ def Xsmm_GemmOp : Xsmm_Op<"gemm"> {
     `(` `data_type` `=` $data_type `,` $inputs `)`
     attr-dict `:` functional-type($inputs, results)
   }];
+
+  let extraClassDeclaration = [{
+    Value getOutput() { return getInputs().back(); }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -94,6 +98,10 @@ def Xsmm_BrgemmOp : Xsmm_Op<"brgemm"> {
   let assemblyFormat = [{
     `(` `data_type` `=` $data_type `,` $inputs `)`
     attr-dict `:` functional-type($inputs, results)
+  }];
+
+  let extraClassDeclaration = [{
+    Value getOutput() { return getInputs()[3]; }
   }];
 }
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -513,4 +513,19 @@ def GpuDataTransfer : Pass<"gpu-data-transfer", "func::FuncOp"> {
                            "gpu::GPUDialect"];
 }
 
+def FoldXsmmFlags : Pass<"fold-xsmm-flags", "func::FuncOp"> {
+  let summary = "Attempt to fold dispatch op as flags in XSMM.";
+  let description = [{
+    Attempt to fold dispatch operations as flags in consumer dispatch
+    operations, for example:
+    ```mlir
+      %alloc = memref.alloc
+      xsmm.unary zero (%alloc)
+      xsmm.gemm.dispatch (%alloc)
+    ```
+    the zero is folded as `beta_0` in `xsmm.gemm.dispatch`.
+  }];
+  let dependentDialects = [ "memref::MemRefDialect", "xsmm::XsmmDialect" ];
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -894,6 +894,7 @@ static void fuseZeroWithGemmOrBrgemm(RewriterBase &rewriter,
                                      xsmm::UnaryOp rootOp) {
   LLVM_DEBUG(llvm::dbgs() << "[fuseZeroWithGemmOrBrgemm] Candidate op: "
                           << rootOp << "\n");
+  // 1. Check if we have a gemm zero initialized by rootOp.
   auto gemmLikeOp = getZeroInitGemmLikeOp(rootOp);
   if (!gemmLikeOp)
     return;

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -848,7 +848,8 @@ static void fuseZeroWithGemmOrBrgemm(RewriterBase &rewriter,
       if (view.getViewSource() == dest)
         return;
     }
-    // An operation touching `dest`.
+    // A gemm or brgemm operation touching `dest`, fold if the
+    // output (i.e. C matrix) is `dest`.
     if (auto gemmOp = dyn_cast<xsmm::GemmOp>(*it)) {
       Value outVal = gemmOp.getOutput();
       if (outVal == dest)

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -310,6 +310,7 @@ private:
         // Tpp to Xsmm conversion patterns.
         pm.addPass(createConvertTppToXsmm());
       }
+      pm.addPass(createFoldXsmmFlags());
     }
   }
 };

--- a/test/Integration/xsmm-strided-brgemm1.mlir
+++ b/test/Integration/xsmm-strided-brgemm1.mlir
@@ -12,6 +12,7 @@
 #map1 = affine_map<(b, i, h, k, j) -> (b, k, h, j)>
 #map2 = affine_map<(b, i, h, k, j) -> (b, i, h, j)>
 
+// IR-LABEL: matmul_static
 func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
     !A_tensor_t into tensor<2x8x2x4xf32>
@@ -24,13 +25,11 @@ func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   %empty = tensor.empty() : tensor<2x2x8x2xf32>
   %fill = linalg.fill ins(%cst_fill : f32) outs(%empty: tensor<2x2x8x2xf32>) -> tensor<2x2x8x2xf32>
 
-  // IR: %[[C2:.+]] = arith.constant 2 : i64
+  // IR-DAG: %[[C2:.+]] = arith.constant 2 : i64
   // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
   // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
-  // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
   // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
-  // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
-  // IR: xsmm_gemm_dispatch(%[[C1]], %[[C2]], %[[C2]], %[[C4]], %[[C4]], %[[C16]], %[[C16]], %[[C0]])
+  // IR: xsmm_gemm_dispatch(%[[C1]], %[[C2]], %[[C2]], %[[C4]], %[[C4]], %[[C16]], %[[C16]], %[[C4]])
   %gemm = linalg.generic {
     indexing_maps = [#map, #map1, #map2], 
     iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel"]} 

--- a/test/Integration/xsmm-strided-brgemm1.mlir
+++ b/test/Integration/xsmm-strided-brgemm1.mlir
@@ -29,6 +29,7 @@ func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
   // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
   // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
+  // IR-NOT: xsmm_unary_dispatch
   // IR: xsmm_gemm_dispatch(%[[C1]], %[[C2]], %[[C2]], %[[C4]], %[[C4]], %[[C16]], %[[C16]], %[[C4]])
   %gemm = linalg.generic {
     indexing_maps = [#map, #map1, #map2], 

--- a/test/Integration/xsmm-strided-brgemm2.mlir
+++ b/test/Integration/xsmm-strided-brgemm2.mlir
@@ -12,6 +12,7 @@
 #map1 = affine_map<(b, i, h, k, j) -> (b, k, h, j)>
 #map2 = affine_map<(b, i, h, k, j) -> (b, h, i, j)>
 
+// IR-LABEL: matmul_static
 func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
     !A_tensor_t into tensor<2x2x2x4xf32> 
@@ -24,13 +25,12 @@ func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   %empty = tensor.empty() : tensor<2x2x2x8xf32>
   %fill = linalg.fill ins(%cst_fill : f32) outs(%empty: tensor<2x2x2x8xf32>) -> tensor<2x2x2x8xf32>
 
-  // IR: %[[C2:.+]] = arith.constant 2 : i64
+  // IR-DAG: %[[C2:.+]] = arith.constant 2 : i64
   // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
   // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
   // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
   // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
-  // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
-  // IR: xsmm_gemm_dispatch(%[[C1]], %[[C2]], %[[C8]], %[[C4]], %[[C8]], %[[C16]], %[[C8]], %[[C0]])
+  // IR: xsmm_gemm_dispatch(%[[C1]], %[[C2]], %[[C8]], %[[C4]], %[[C8]], %[[C16]], %[[C8]], %[[C4]])
   %gemm = linalg.generic {
     indexing_maps = [#map, #map1, #map2], 
     iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel"]} 

--- a/test/Integration/xsmm-strided-brgemm2.mlir
+++ b/test/Integration/xsmm-strided-brgemm2.mlir
@@ -30,6 +30,7 @@ func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
   // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
   // IR-DAG: %[[C16:.+]] = arith.constant 16 : i64
+  // IR-NOT: xsmm_unary_dispatch
   // IR: xsmm_gemm_dispatch(%[[C1]], %[[C2]], %[[C8]], %[[C4]], %[[C8]], %[[C16]], %[[C8]], %[[C4]])
   %gemm = linalg.generic {
     indexing_maps = [#map, #map1, #map2], 

--- a/test/Integration/xsmm-strided-brgemm3.mlir
+++ b/test/Integration/xsmm-strided-brgemm3.mlir
@@ -30,6 +30,8 @@ func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
   // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
   // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // The unary dispatch in this case is the transpose. 
+  // IR-COUNT-1: xsmm_unary_dispatch
   // IR: xsmm_gemm_dispatch(%[[C1]], %[[C8]], %[[C2]], %[[C4]], %[[C8]], %[[C2]], %[[C2]], %[[C4]]) 
   %gemm = linalg.generic {
     indexing_maps = [#map, #map1, #map2], 

--- a/test/Integration/xsmm-strided-brgemm3.mlir
+++ b/test/Integration/xsmm-strided-brgemm3.mlir
@@ -12,6 +12,7 @@
 #map1 = affine_map<(b, i, h, k, j) -> (b, j, h, k)>
 #map2 = affine_map<(b, i, h, k, j) -> (b, h, j, i)>
 
+// IR-LABEL: matmul_static
 func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   %A_exp = tensor.expand_shape %A [[0, 1], [2, 3]] :
     !A_tensor_t into tensor<2x2x2x4xf32>
@@ -24,12 +25,12 @@ func.func @matmul_static(%A : !A_tensor_t, %B : !B_tensor_t, %C : !C_tensor_t) {
   %empty = tensor.empty() : tensor<2x2x8x2xf32>
   %fill = linalg.fill ins(%cst_fill : f32) outs(%empty: tensor<2x2x8x2xf32>) -> tensor<2x2x8x2xf32>
 
-  // IR: %[[C2:.+]] = arith.constant 2 : i64
+  // IR-DAG: %[[C2:.+]] = arith.constant 2 : i64
   // IR-DAG: %[[C1:.+]] = arith.constant 1 : i64
   // IR-DAG: %[[C8:.+]] = arith.constant 8 : i64
   // IR-DAG: %[[C4:.+]] = arith.constant 4 : i64
   // IR-DAG: %[[C0:.+]] = arith.constant 0 : i64
-  // IR: xsmm_gemm_dispatch(%[[C1]], %[[C8]], %[[C2]], %[[C4]], %[[C8]], %[[C2]], %[[C2]], %[[C0]]) 
+  // IR: xsmm_gemm_dispatch(%[[C1]], %[[C8]], %[[C2]], %[[C4]], %[[C8]], %[[C2]], %[[C2]], %[[C4]]) 
   %gemm = linalg.generic {
     indexing_maps = [#map, #map1, #map2], 
     iterator_types = ["parallel", "parallel", "parallel", "reduction", "parallel"]} 

--- a/test/Passes/DefaultPipeline/linalg-to-xsmm.mlir
+++ b/test/Passes/DefaultPipeline/linalg-to-xsmm.mlir
@@ -49,6 +49,7 @@ func.func @gemm_with_zero(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> ten
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
 // CHECK-DAG: %[[C3:.+]] = arith.constant 3 : i64
 // CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
+// CHECK-NOT: xsmm_unary_dispatch
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
 // CHECK: %[[DIS:.+]] = call @xsmm_gemm_dispatch(%[[C1]], %[[C3]], %[[C3]], %[[C3]], %[[C3]], %[[C3]], %[[C3]], %[[C4]])
 // CHECK: %[[INT_PTR_ARG0:.+]] = memref.extract_aligned_pointer_as_index %[[ARG0]] : memref<3x3xf32> -> index

--- a/test/Passes/DefaultPipeline/linalg-to-xsmm.mlir
+++ b/test/Passes/DefaultPipeline/linalg-to-xsmm.mlir
@@ -30,3 +30,34 @@ func.func @fill_op_i32(%arg0: memref<3x3xi32>) {
 
 // CHECK-LABEL: fill_op_i32
 // CHECK-NOT: xsmm
+// CHECK: linalg.fill
+
+// -----
+
+func.func @gemm_with_zero(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  %cst = arith.constant 0.0 : f32  
+  %0 = tensor.empty() : tensor<3x3xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%0 : tensor<3x3xf32>) -> tensor<3x3xf32>
+  %mul = linalg.matmul ins(%arg0, %arg1 : tensor<3x3xf32>, tensor<3x3xf32>)
+                       outs(%fill: tensor<3x3xf32>) -> tensor<3x3xf32>
+  return %mul : tensor<3x3xf32>
+}
+
+// CHECK-LABEL: gemm_with_zero
+// CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
+// CHECK-DAG: %[[C3:.+]] = arith.constant 3 : i64
+// CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i64
+// CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
+// CHECK: %[[DIS:.+]] = call @xsmm_gemm_dispatch(%[[C1]], %[[C3]], %[[C3]], %[[C3]], %[[C3]], %[[C3]], %[[C3]], %[[C4]])
+// CHECK: %[[INT_PTR_ARG0:.+]] = memref.extract_aligned_pointer_as_index %[[ARG0]] : memref<3x3xf32> -> index
+// CHECK: %[[CAST_ARG0:.+]] = arith.index_cast %[[INT_PTR_ARG0]] : index to i64
+// CHECK: %[[LLVM_PTR_ARG0:.+]] = llvm.inttoptr %[[CAST_ARG0]] : i64 to !llvm.ptr<f32>
+// CHECK: %[[INT_PTR_ARG1:.+]] = memref.extract_aligned_pointer_as_index %[[ARG1]] : memref<3x3xf32> -> index
+// CHECK: %[[CAST_ARG1:.+]] = arith.index_cast %[[INT_PTR_ARG1]] : index to i64
+// CHECK: %[[LLVM_PTR_ARG1:.+]] = llvm.inttoptr %[[CAST_ARG1]] : i64 to !llvm.ptr<f32>
+// CHECK: %[[INT_PTR_ALLOC:.+]] = memref.extract_aligned_pointer_as_index %[[ALLOC]] : memref<3x3xf32> -> index
+// CHECK: %[[CAST_ALLOC:.+]] = arith.index_cast %[[INT_PTR_ALLOC]] : index to i64
+// CHECK: %[[LLVM_PTR_ALLOC:.+]] = llvm.inttoptr %[[CAST_ALLOC]] : i64 to !llvm.ptr<f32>
+// CHECK: call @xsmm_gemm_invoke(%[[C1]], %[[DIS]], %[[LLVM_PTR_ARG0]], %[[C0]], %[[LLVM_PTR_ARG1]], %[[C0]], %[[LLVM_PTR_ALLOC]], %[[C0]])

--- a/test/Passes/fold-xsmm-flags.mlir
+++ b/test/Passes/fold-xsmm-flags.mlir
@@ -1,0 +1,160 @@
+// RUN: tpp-opt %s -fold-xsmm-flags -split-input-file | FileCheck %s
+
+func.func @zero_flag(%arg0: memref<32x512xf32, strided<[512, 1], offset: ?>>,
+                     %arg1: memref<512x64xf32, strided<[512, 1], offset: ?>>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
+  %0 = xsmm.unary.dispatch zero [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<32x64xf32>) -> ()
+  %1 = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %alloc) : (i64, memref<32x512xf32, strided<[512, 1], offset: ?>>, memref<512x64xf32, strided<[512, 1], offset: ?>>, memref<32x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: zero_flag
+// CHECK-SAME: %[[ARG0:.+]]: memref<32x512xf32, strided<[512, 1], offset: ?>>
+// CHECK-SAME: %[[ARG1:.+]]: memref<512x64xf32, strided<[512, 1], offset: ?>>
+// CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
+// CHECK: xsmm.gemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ALLOC]])
+
+// -----
+
+func.func @non_zero_flag(%arg0: memref<32x512xf32, strided<[512, 1], offset: ?>>, 
+                         %arg1: memref<512x64xf32, strided<[512, 1], offset: ?>>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
+  %0 = xsmm.unary.dispatch identity [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+  xsmm.unary identity(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<32x64xf32>) -> ()
+  %1 = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %alloc) : (i64, memref<32x512xf32, strided<[512, 1], offset: ?>>, memref<512x64xf32, strided<[512, 1], offset: ?>>, memref<32x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: non_zero_flag
+// CHECK-NOT: xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
+// CHECK: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+
+// -----
+
+func.func @zero_flag_bb_arg(%arg0: memref<32x512xf32, strided<[512, 1], offset: ?>>,
+                            %arg1: memref<512x64xf32, strided<[512, 1], offset: ?>>,
+                            %arg2: memref<32x64xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = xsmm.unary.dispatch zero [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %arg2) : (i64, f32, memref<32x64xf32>) -> ()
+  %1 = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %arg2) : (i64, memref<32x512xf32, strided<[512, 1], offset: ?>>, memref<512x64xf32, strided<[512, 1], offset: ?>>, memref<32x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: zero_flag_bb_arg
+// CHECK: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
+
+// -----
+
+func.func @zero_subview(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>) {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<5x32x64xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  scf.forall (%iv) in (5) {
+    %sub = memref.subview %alloc[%iv, 0, 0] [1, 32, 64] [1, 1, 1] : memref<5x32x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>
+    %0 = xsmm.unary.dispatch zero [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+    xsmm.unary zero(data_type = f32, %0, %cst, %sub) : (i64, f32, memref<32x64xf32, strided<[64, 1], offset: ?>>) -> ()
+    %1 = xsmm.gemm.dispatch [32, 32, 64, 32, 32, 64] flags = (none) data_type = f32
+    xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %sub) : (i64, memref<32x32xf32>, memref<32x32xf32>, memref<32x64xf32, strided<[64, 1], offset: ?>>) -> ()
+  }
+  return
+}
+
+// CHECK-LABEL: zero_subview
+// CHECK: %{{.+}} = xsmm.gemm.dispatch [32, 32, 64, 32, 32, 64] flags = (beta_0) data_type = f32
+
+// -----
+
+// Copy prevents folding.
+func.func @zero_with_copy(%arg0: memref<32x512xf32, strided<[512, 1], offset: ?>>,
+                          %arg1: memref<512x64xf32, strided<[512, 1], offset: ?>>,
+                          %arg2: memref<32x64xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
+  %0 = xsmm.unary.dispatch zero [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<32x64xf32>) -> ()
+  memref.copy %alloc, %arg2 : memref<32x64xf32> to memref<32x64xf32>
+  %1 = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %arg2) : (i64, memref<32x512xf32, strided<[512, 1], offset: ?>>, memref<512x64xf32, strided<[512, 1], offset: ?>>, memref<32x64xf32>) -> ()
+  return
+}
+
+// CHECK-LABEL: zero_with_copy
+// CHECK: xsmm.unary.dispatch zero
+// CHECK: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+
+// -----
+
+func.func @multiple_users(%arg0: memref<32x512xf32, strided<[512, 1], offset: ?>>,
+                          %arg1: memref<512x64xf32, strided<[512, 1], offset: ?>>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x64xf32>
+  
+  %0 = xsmm.unary.dispatch zero [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<32x64xf32>) -> ()
+  %1 = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %alloc) 
+    : (i64, memref<32x512xf32, strided<[512, 1], offset: ?>>, 
+            memref<512x64xf32, strided<[512, 1], offset: ?>>, memref<32x64xf32>) -> ()
+
+  %2 = xsmm.unary.dispatch zero [32, 64, 1, 64] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<32x64xf32>) -> ()
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %alloc) 
+    : (i64, memref<32x512xf32, strided<[512, 1], offset: ?>>, 
+            memref<512x64xf32, strided<[512, 1], offset: ?>>, memref<32x64xf32>) -> ()
+  return
+}
+
+// Here we could replace the flag but we bail if the gemm.dispatch has multiple users.
+// CHECK-LABEL: multiple_users
+// CHECK-NOT: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
+// CHECK: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+
+// -----
+
+func.func @multiple_users_1(%arg0: memref<512x512xf32>,
+                          %arg1: memref<512x512xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<512x512xf32>
+  
+  %0 = xsmm.unary.dispatch zero [512, 512, 1, 512] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<512x512xf32>) -> ()
+  %1 = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (none) data_type = f32
+  xsmm.gemm(data_type = f32, %1, %arg0, %arg1, %alloc) 
+    : (i64, memref<512x512xf32>, memref<512x512xf32>, memref<512x512xf32>) -> ()
+
+  xsmm.gemm(data_type = f32, %1, %arg0, %alloc, %alloc) 
+    : (i64, memref<512x512xf32>, memref<512x512xf32>, memref<512x512xf32>) -> ()
+  return
+}
+
+// Here we must not replace the flag.
+// CHECK-LABEL: multiple_users_1
+// CHECK-NOT: %{{.+}} = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (beta_0) data_type = f32
+// CHECK: %{{.+}} = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (none) data_type = f32
+
+// -----
+
+func.func @zero_flag(%arg0: memref<1x32x32xf32>, %arg1: memref<1x32x32xf32>) {
+  %c1_i64 = arith.constant 1 : i64
+  %cst = arith.constant 0.000000e+00 : f32
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+  %0 = xsmm.unary.dispatch zero [32, 512, 1, 512] flags = (bcast_scalar) data_type = f32
+  xsmm.unary zero(data_type = f32, %0, %cst, %alloc) : (i64, f32, memref<32x32xf32>) -> ()
+  %1 = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32, 32, 1] flags = (none) data_type = f32
+  xsmm.brgemm(data_type = f32, %1, %arg0, %arg1, %alloc, %c1_i64) : (i64, memref<1x32x32xf32>, memref<1x32x32xf32>, memref<32x32xf32>, i64) -> ()
+  return
+}
+
+// CHECK-LABEL: zero_flag
+// CHECK-SAME: %[[ARG0:.+]]: memref<1x32x32xf32>, %[[ARG1:.+]]: memref<1x32x32xf32> 
+// CHECK: %[[C1:.+]] = arith.constant 1 : i64
+// CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<32x32xf32>
+// CHECK: %[[DIS:.+]] = xsmm.brgemm.dispatch [32, 32, 32, 32, 32, 32, 32, 1] flags = (beta_0) data_type = f32
+// CHECK: xsmm.brgemm(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ALLOC]], %[[C1]])

--- a/test/Passes/fold-xsmm-flags.mlir
+++ b/test/Passes/fold-xsmm-flags.mlir
@@ -111,10 +111,12 @@ func.func @multiple_users(%arg0: memref<32x512xf32, strided<[512, 1], offset: ?>
   return
 }
 
-// Here we could replace the flag but we bail if the gemm.dispatch has multiple users.
 // CHECK-LABEL: multiple_users
-// CHECK-NOT: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
-// CHECK: %{{.+}} = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (none) data_type = f32
+// CHECK: %[[FIRST_GEMM:.+]] = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
+// CHECK: %[[SECOND_GEMM:.+]] = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 64] flags = (beta_0) data_type = f32
+// CHECK: xsmm.gemm(data_type = f32, %[[FIRST_GEMM]], %{{.+}}, %{{.+}}, %{{.+}})
+// CHECK: xsmm.gemm(data_type = f32, %[[SECOND_GEMM]], %{{.+}}, %{{.+}}, %{{.+}})
+
 
 // -----
 
@@ -134,10 +136,11 @@ func.func @multiple_users_1(%arg0: memref<512x512xf32>,
   return
 }
 
-// Here we must not replace the flag.
 // CHECK-LABEL: multiple_users_1
-// CHECK-NOT: %{{.+}} = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (beta_0) data_type = f32
-// CHECK: %{{.+}} = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (none) data_type = f32
+// CHECK: %[[FIRST_GEMM:.+]] = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (beta_0) data_type = f32
+// CHECK: %[[SECOND_GEMM:.+]] = xsmm.gemm.dispatch [512, 512, 512, 512, 512, 512] flags = (none) data_type = f32
+// CHECK: xsmm.gemm(data_type = f32, %[[FIRST_GEMM]], %{{.+}}, %{{.+}}, %{{.+}})
+// CHECK: xsmm.gemm(data_type = f32, %[[SECOND_GEMM]], %{{.+}}, %{{.+}}, %{{.+}})
 
 // -----
 


### PR DESCRIPTION
This PR allows us to generate the same micro-kernel as DNN, which has
been checked manually for the `prepacked_targets.` However, there is
still some performance gap with DNN. Some observations in regard:
- There are no allocations in DNN. Everything is pre-allocated. We do
  have allocations in the kernels. For example, `gemm_fp32_mlir` ends up
  with two mallocs.
- Allocations have different alignments (64 for us while 2097152 for
  DNN).