### PR TITLE
Fix libxsmm / libxsmm-dnn cast warnings

### DIFF
--- a/cmake/modules/xsmm-dnn.cmake
+++ b/cmake/modules/xsmm-dnn.cmake
@@ -16,8 +16,8 @@ else()
 
   FetchContent_Declare(
     xsmm_dnn
-    URL https://github.com/libxsmm/libxsmm-dnn/archive/3ef7d1d6206fa4b75c9a787e1e2c11aa3e925f60.tar.gz
-    URL_HASH SHA256=223b6c6f03830701afd1c8fcf950ab67e2a0da22dee8e00c062682a750f56056
+    URL https://github.com/libxsmm/libxsmm-dnn/archive/24fefde9f8c4ed777d0a8d675db46bc4e3a92120.tar.gz
+    URL_HASH SHA256=5f5fcf5a47e38f658f80efa3b1654b6ca8df6f610efdc5ccaf2b83f6cd5a1b70
   )
 
   FetchContent_GetProperties(xsmm_dnn)
@@ -37,6 +37,8 @@ add_executable(xsmm_dnn_mlp
   ${XSMM_DNN_SRCS}
   ${LIBXSMM_DNNROOT}/tests/mlp/mlp_example.c
 )
+set_property(TARGET xsmm_dnn_mlp PROPERTY COMPILE_WARNING_AS_ERROR ON)
+
 set_Target_properties(xsmm_dnn_mlp PROPERTIES RUNTIME_OUTPUT_DIRECTORY bin)
 target_include_directories(xsmm_dnn_mlp PRIVATE ${XSMM_INCLUDE_DIRS})
 target_include_directories(xsmm_dnn_mlp PRIVATE ${XSMM_INCLUDE_DIRS}/../src/template)

--- a/cmake/modules/xsmm.cmake
+++ b/cmake/modules/xsmm.cmake
@@ -13,8 +13,8 @@ else()
 
   FetchContent_Declare(
     xsmm
-    URL https://github.com/libxsmm/libxsmm/archive/54b8bb32042d204ff6fe550fa70d961f22c0b99e.tar.gz
-    URL_HASH SHA256=b2c3dd4f50cb6d045a2f9f2e93aa846b23a83ff22619352fb10cf97d2fe16d22
+    URL https://github.com/libxsmm/libxsmm/archive/c62dae286096c3f3e057cff08f60cb9f9c588423.tar.gz
+    URL_HASH SHA256=b2c3c744bb6dc86c8cd2d01b9a3f8173f135f99de4a5584a11aa1f944d479533
   )
 
   FetchContent_GetProperties(xsmm)
@@ -38,6 +38,8 @@ target_compile_definitions(xsmm PRIVATE
   __BLAS=0
 )
 add_definitions(-DLIBXSMM_DEFAULT_CONFIG -U_DEBUG)
+
+set_property(TARGET xsmm PROPERTY COMPILE_WARNING_AS_ERROR ON)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,1 +1,3 @@
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+
 add_subdirectory(TPP)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+
 add_subdirectory(mlir-gen)
 add_subdirectory(tpp-opt)
 add_subdirectory(tpp-run)


### PR DESCRIPTION
All warnings fixed in libxsmm and libxsmm-dnn.

Adding `-Werror` to all our libraries, tools, libxsmm and libxsmm-dnn to
make sure we don't regress.

Fixes #707