### PR TITLE
Change `perf` dialect to use `iter_args` correctly and fix dependency problem

### DIFF
--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -98,13 +98,9 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
 
 def Perf_BenchOp : Perf_Op<"bench",
     [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
-     RangedTypesMatchWith<"result types match types of iter_args",
-                          "iterArgs",
-                          "bodyResults",
-                          "$_self">,
      RangedTypesMatchWith<"result types match types of yield",
                           "$_self",
-                          "bodyResults",
+                          "iterArgs",
                           "getRegion().front().getTerminator()->getOperandTypes()">]> {
   let summary = "Benchmark the enclosed code.";
   let description = [{

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -143,8 +143,8 @@ def Perf_BenchOp : Perf_Op<"bench",
     An example of a benchmark with an output result:
 
     ```mlir
-    %sum = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%val : i32) {
-      %sum_next = arith.addi %val, %cst : i32
+    %sum = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %val) -> i32 {
+      %sum_next = arith.addi %arg0, %cst : i32
       perf.yield %sum_next : i32
     } -> i32
     memref.store %sum, %buff[] : memref<i32>
@@ -154,7 +154,7 @@ def Perf_BenchOp : Perf_Op<"bench",
     a benchmarking loop.
     For example, the following input:
     ```mlir
-    %res, ... = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%x, ... : ...) {
+    %res, ... = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(...) -> ... {
       ... // body - ops under measurement
 
       // Yield current iteration values to the next iteration iter_args (%x, ...)

--- a/include/TPP/Dialect/Perf/PerfOps.td
+++ b/include/TPP/Dialect/Perf/PerfOps.td
@@ -98,7 +98,7 @@ def Perf_StopTimerOp : Perf_Op<"stop_timer", []> {
 
 def Perf_BenchOp : Perf_Op<"bench",
     [AutomaticAllocationScope, SingleBlockImplicitTerminator<"perf::YieldOp">,
-     RangedTypesMatchWith<"result types match types of yield",
+     RangedTypesMatchWith<"iter_args types match types of yield",
                           "$_self",
                           "iterArgs",
                           "getRegion().front().getTerminator()->getOperandTypes()">]> {

--- a/lib/TPP/Conversion/ConvertPerfToLoops/ConvertPerfToLoops.cpp
+++ b/lib/TPP/Conversion/ConvertPerfToLoops/ConvertPerfToLoops.cpp
@@ -51,7 +51,8 @@ struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
     }
 
     // Move perf.bench region inside the loop.
-    rewriter.mergeBlocks(&benchOp.getRegion().front(), loop.getBody());
+    rewriter.mergeBlocks(&benchOp.getRegion().front(), loop.getBody(),
+                         benchOp.getIterArgs());
 
     // Wrap the benchmark kernel in timer calls.
     OpBuilder::InsertionGuard guard(rewriter);

--- a/lib/TPP/Dialect/Perf/PerfOps.cpp
+++ b/lib/TPP/Dialect/Perf/PerfOps.cpp
@@ -98,9 +98,10 @@ void BenchOp::print(OpAsmPrinter &printer) {
     assert(blockArgs.size() == initArgs.size() &&
            "expected same length of arguments and initializers");
     printer << " iter_args(";
-    llvm::interleaveComma(llvm::zip(blockArgs, initArgs), printer, [&](auto it) {
-      printer << std::get<0>(it) << " = " << std::get<1>(it);
-    });
+    llvm::interleaveComma(
+        llvm::zip(blockArgs, initArgs), printer, [&](auto it) {
+          printer << std::get<0>(it) << " = " << std::get<1>(it);
+        });
     printer << ") -> " << initArgs.getTypes();
   }
   printer << ' ';
@@ -181,19 +182,22 @@ ParseResult BenchOp::parse(OpAsmParser &parser, OperationState &result) {
       return failure();
   }
 
-  if (regionArgs.size() != result.types.size())
+  if (regionArgs.size() != result.types.size()) {
     return parser.emitError(
         parser.getNameLoc(),
         "mismatch in number of loop-carried values and defined values");
+  }
 
   // Resolve input operands.
   if (hasIterArgs) {
-    for (auto argOperandType : llvm::zip(regionArgs, operands, result.types)) {
+    for (auto argOperandType :
+         llvm::zip_equal(regionArgs, operands, result.types)) {
       Type type = std::get<2>(argOperandType);
       std::get<0>(argOperandType).type = type;
       if (parser.resolveOperand(std::get<1>(argOperandType), type,
-                                result.operands))
+                                result.operands)) {
         return failure();
+      }
     }
   }
 

--- a/test/Conversion/PerfToFunc/perf-to-func.mlir
+++ b/test/Conversion/PerfToFunc/perf-to-func.mlir
@@ -150,13 +150,13 @@ func.func @perf_example(%A: tensor<4x8xf32>,
   // CHECK:   memref.store %[[delta]], %[[deltas]][%[[i]]]
   // CHECK:   scf.yield %[[sum]]
   // CHECK: }
-  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%output : i64) {
+  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %output) -> i64 {
     %D = linalg.matmul ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>)
                        outs(%C: tensor<4x4xf32>) -> tensor<4x4xf32>
     perf.sink(%D) : tensor<4x4xf32>
-    %sum = arith.addi %n, %n : i64
+    %sum = arith.addi %arg0, %n : i64
     perf.yield %sum : i64
-  } -> i64
+  }
 
   // CHECK: %[[mean:.*]] = call @perf_mean({{.*}})
   // CHECK: %[[stdev:.*]] = call @perf_stdev({{.*}}, %[[mean]])

--- a/test/Dialect/Perf/perf-invalid.mlir
+++ b/test/Dialect/Perf/perf-invalid.mlir
@@ -21,7 +21,7 @@ func.func @perf_invalid_outs_types(%a: i32, %b: i32, %n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  // expected-error @below {{'perf.bench' op failed to verify that iter_args types match types of yield}}
   %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i64 {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
@@ -39,7 +39,7 @@ func.func @perf_invalid_outs_order(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
   %out1 = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  // expected-error @below {{'perf.bench' op failed to verify that iter_args types match types of yield}}
   %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out1, %arg1 = %out) -> (i64, i32) {
     %c = arith.addi %a, %b : i32
     perf.yield %c, %n : i32, i64
@@ -56,7 +56,7 @@ func.func @perf_no_yield(%n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  // expected-error @below {{'perf.bench' op failed to verify that iter_args types match types of yield}}
   %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i64 {
     perf.sink(%n) : i64
   }
@@ -90,7 +90,7 @@ func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  // expected-error @below {{'perf.bench' op failed to verify that iter_args types match types of yield}}
   %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i64 {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
@@ -108,7 +108,7 @@ func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
   %out1 = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  // expected-error @below {{'perf.bench' op failed to verify that iter_args types match types of yield}}
   %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out, %arg1 = %out1) -> (i32, i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %n, %c : i64, i32

--- a/test/Dialect/Perf/perf-invalid.mlir
+++ b/test/Dialect/Perf/perf-invalid.mlir
@@ -5,7 +5,7 @@ func.func @perf_no_outs(%n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
+  // expected-error @below {{cannot name an operation with no results}}
   %val = perf.bench (%n, %deltas : i64, memref<?xf64>) {
     perf.sink(%n) : i64
   } -> i64
@@ -21,11 +21,11 @@ func.func @perf_invalid_outs_types(%a: i32, %b: i32, %n: i64) {
   %deltas = memref.alloc(%size) : memref<?xf64>
   %out = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
-  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i64) {
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i64 {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
-  } -> i32
+  }
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -39,11 +39,11 @@ func.func @perf_invalid_outs_order(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
   %out1 = arith.constant 0 : i64
 
-  // expected-error @below {{'perf.bench' op failed to verify that result types match types of iter_args}}
-  %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out1, %out : i64, i32) {
+  // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
+  %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out1, %arg1 = %out) -> (i64, i32) {
     %c = arith.addi %a, %b : i32
     perf.yield %c, %n : i32, i64
-  } -> (i32, i64)
+  }
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -57,9 +57,9 @@ func.func @perf_no_yield(%n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i64) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i64 {
     perf.sink(%n) : i64
-  } -> i64
+  }
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -73,11 +73,11 @@ func.func @perf_invalid_yield_op(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i32
 
   // expected-error @below {{perf.bench' op expects region to terminate with 'perf.yield'}}
-  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i32) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i32 {
     %c = arith.addi %a, %b : i32
     // expected-note @below {{terminator here}}
     scf.yield %c : i32
-  } -> i32
+  }
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -91,10 +91,10 @@ func.func @perf_invalid_yield_types(%a: i32, %b: i32, %n: i64) {
   %out = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out : i64) {
+  %val = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out) -> i64 {
     %c = arith.addi %a, %b : i32
     perf.yield %c : i32
-  } -> i64
+  }
 
   memref.dealloc %deltas : memref<?xf64>
   return
@@ -109,10 +109,10 @@ func.func @perf_invalid_yield_order(%a: i32, %b: i32, %n: i64) {
   %out1 = arith.constant 0 : i64
 
   // expected-error @below {{'perf.bench' op failed to verify that result types match types of yield}}
-  %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%out, %out1 : i32, i64) {
+  %val, %val1 = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %out, %arg1 = %out1) -> (i32, i64) {
     %c = arith.addi %a, %b : i32
     perf.yield %n, %c : i64, i32
-  } -> (i32, i64)
+  }
 
   memref.dealloc %deltas : memref<?xf64>
   return

--- a/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
+++ b/test/Passes/DefaultPipeline/local-dialects-lowering.mlir
@@ -31,10 +31,10 @@ func.func @perf_dialect(%A: tensor<4x8xf32>,
   %deltas = memref.alloc(%size) : memref<?xf64>
   %output = arith.constant 0 : i64
 
-  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%output : i64) {
+  %res = perf.bench (%n, %deltas : i64, memref<?xf64>) iter_args(%arg0 = %output) -> i64 {
     %sum = arith.addi %n, %n : i64
     perf.yield %sum : i64
-  } -> i64
+  }
 
   %mean = perf.mean(%deltas : memref<?xf64>) : f64
   %stdev = perf.stdev(%deltas : memref<?xf64>, %mean : f64) : f64


### PR DESCRIPTION
This makes correct usage of `iter_args` by creating actual loop bound values and using them inside the loop body doesn't get removed away during canonicalization.

I've changed the existing tests to stress this feature to make sure we don't regress.

Fixes #277 