### PR TITLE
Clang-tidy (NFC)

### DIFF
--- a/include/TPP/Dialect/Tpp/TppDialect.h
+++ b/include/TPP/Dialect/Tpp/TppDialect.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_TPP_DIALECT_H
-#define TPP_TPP_DIALECT_H
+#ifndef TPP_DIALECT_TPP_TPPDIALECT_H
+#define TPP_DIALECT_TPP_TPPDIALECT_H
 
 // clang-format off
 #include "mlir/IR/Dialect.h"
 #include "TPP/Dialect/Tpp/TppOpsDialect.h.inc"
 // clang-format on
 
-#endif // TPP_TPP_DIALECT_H
+#endif // TPP_DIALECT_TPP_TPPDIALECT_H

--- a/include/TPP/Dialect/Tpp/TppInterface.h
+++ b/include/TPP/Dialect/Tpp/TppInterface.h
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_DIALECT_TPP_TPPINTERFACE_H_
-#define MLIR_DIALECT_TPP_TPPINTERFACE_H_
+#ifndef TPP_DIALECT_TPP_TPPINTERFACE_H
+#define TPP_DIALECT_TPP_TPPINTERFACE_H
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 
 #include "TPP/Dialect/Tpp/TppInterface.h.inc"
 
-#endif // MLIR_DIALECT_TPP_TPPINTERFACE_H_
+#endif // TPP_DIALECT_TPP_TPPINTERFACE_H

--- a/include/TPP/Dialect/Tpp/TppTraits.h
+++ b/include/TPP/Dialect/Tpp/TppTraits.h
@@ -1,5 +1,5 @@
-#ifndef TPP_DIALECT_TPP_TRAITS_H
-#define TPP_DIALECT_TPP_TRAITS_H
+#ifndef TPP_DIALECT_TPP_TPPTRAITS_H
+#define TPP_DIALECT_TPP_TPPTRAITS_H
 
 #include "mlir/IR/OpDefinition.h"
 
@@ -56,4 +56,4 @@ struct QuaternaryOp : public OpTrait::TraitBase<ConcreteType, QuaternaryOp> {
 } // namespace OpTrait
 } // namespace mlir
 
-#endif // TPP_DIALECT_TPP_TRAITS_H
+#endif // TPP_DIALECT_TPP_TPPTRAITS_H

--- a/include/TPP/Dialect/Xsmm/XsmmDialect.h
+++ b/include/TPP/Dialect/Xsmm/XsmmDialect.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef XSMM_TPP_DIALECT_H
-#define XSMM_TPP_DIALECT_H
+#ifndef TPP_DIALECT_XSMM_XSMMDIALECT_H
+#define TPP_DIALECT_XSMM_XSMMDIALECT_H
 
 #include "mlir/IR/Dialect.h"
 
 #define GET_OP_CLASSES
 #include "TPP/Dialect/Xsmm/XsmmOpsDialect.h.inc"
 
-#endif // XSMM_TPP_DIALECT_H
+#endif // TPP_DIALECT_XSMM_XSMMDIALECT_H

--- a/include/TPP/Dialect/Xsmm/XsmmUtils.h
+++ b/include/TPP/Dialect/Xsmm/XsmmUtils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef XSMM_DIALECT_XSMM_XSMMUTILS_H
-#define XSMM_DIALECT_XSMM_XSMMUTILS_H
+#ifndef TPP_DIALECT_XSMM_XSMMUTILS_H
+#define TPP_DIALECT_XSMM_XSMMUTILS_H
 
 #include "TPP/Dialect/Xsmm/XsmmEnum.h"
 
@@ -56,4 +56,4 @@ void replaceOpWithUnary(RewriterBase &rewriter, Operation *operation,
 } // namespace xsmm
 } // namespace mlir
 
-#endif // XSMM_DIALECT_XSMM_XSMMUTILS_H
+#endif // TPP_DIALECT_XSMM_XSMMUTILS_H

--- a/include/TPP/IR/MatcherUtils.h
+++ b/include/TPP/IR/MatcherUtils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_MATCHER_UTILS_H
-#define TPP_MATCHER_UTILS_H
+#ifndef TPP_IR_MATCHERUTILS_H
+#define TPP_IR_MATCHERUTILS_H
 
 namespace mlir {
 class Value;
@@ -63,4 +63,4 @@ bool isTwoDFillOpWithZeros(linalg::LinalgOp linalgOp,
 } // namespace structured_match
 } // namespace mlir
 
-#endif // TPP_MATCHER_UTILS_H
+#endif // TPP_IR_MATCHERUTILS_H

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_STRUCTUREDOPMATCHERS_H
-#define TPP_STRUCTUREDOPMATCHERS_H
+#ifndef TPP_IR_STRUCTUREDOPMATCHER_H
+#define TPP_IR_STRUCTUREDOPMATCHER_H
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "llvm/ADT/SmallSet.h"
@@ -416,4 +416,4 @@ private:
 } // namespace structured_match
 } // namespace mlir
 
-#endif // TPP_STRUCTUREDOPMATCHERS_H
+#endif // TPP_IR_STRUCTUREDOPMATCHER_H

--- a/include/TPP/Transforms/Transforms.h
+++ b/include/TPP/Transforms/Transforms.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_TRANSFORMS_H
-#define TPP_TRANSFORMS_H
+#ifndef TPP_TRANSFORMS_TRANSFORMS_H
+#define TPP_TRANSFORMS_TRANSFORMS_H
 
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"

--- a/include/TPP/Transforms/Utils/TransformUtils.h
+++ b/include/TPP/Transforms/Utils/TransformUtils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_TRANSFORMUTILS_H
-#define TPP_TRANSFORMUTILS_H
+#ifndef TPP_TRANSFORMS_UTILS_TRANSFORMUTILS_H
+#define TPP_TRANSFORMS_UTILS_TRANSFORMUTILS_H
 
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"

--- a/include/TPP/Transforms/Utils/VNNIUtils.h
+++ b/include/TPP/Transforms/Utils/VNNIUtils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_VNNIUTILS_H
-#define TPP_VNNIUTILS_H
+#ifndef TPP_TRANSFORMS_UTILS_VNNIUTILS_H
+#define TPP_TRANSFORMS_UTILS_VNNIUTILS_H
 
 #include <cstdint>
 #include <optional>

--- a/include/TPP/Transforms/Utils/ValueUtils.h
+++ b/include/TPP/Transforms/Utils/ValueUtils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_VALUE_UTILS_H
-#define TPP_VALUE_UTILS_H
+#ifndef TPP_TRANSFORMS_UTILS_VALUEUTILS_H
+#define TPP_TRANSFORMS_UTILS_VALUEUTILS_H
 
 namespace mlir {
 class Value;
@@ -33,4 +33,4 @@ std::pair<Value, Value> getPtrAndOffset(OpBuilder &builder, Value val,
 } // namespace utils
 } // namespace mlir
 
-#endif // TPP_VALUE_UTILS_H
+#endif // TPP_TRANSFORMS_UTILS_VALUEUTILS_H

--- a/lib/TPP/Conversion/ConvertPerfToFunc/ConvertPerfToFunc.cpp
+++ b/lib/TPP/Conversion/ConvertPerfToFunc/ConvertPerfToFunc.cpp
@@ -251,7 +251,7 @@ static LogicalResult buildPerfSinkFunc(Location loc, std::string funcName,
   // Add function attributes which ensure that the passed data and its producers
   // operations cannot be optimized away such that the time measured by a
   // benchmark loop correctly represents the full workload.
-  auto ctx = rewriter.getContext();
+  auto *ctx = rewriter.getContext();
   funcOp->setAttr("passthrough",
                   rewriter.getArrayAttr({StringAttr::get(ctx, "optnone"),
                                          StringAttr::get(ctx, "noinline")}));

--- a/lib/TPP/Conversion/ConvertPerfToLoops/ConvertPerfToLoops.cpp
+++ b/lib/TPP/Conversion/ConvertPerfToLoops/ConvertPerfToLoops.cpp
@@ -33,7 +33,7 @@ struct ConvertBenchToLoops : public OpRewritePattern<perf::BenchOp> {
   LogicalResult matchAndRewrite(perf::BenchOp benchOp,
                                 PatternRewriter &rewriter) const override {
     auto loc = benchOp.getLoc();
-    auto benchYield = benchOp.getRegion().front().getTerminator();
+    auto *benchYield = benchOp.getRegion().front().getTerminator();
     assert(dyn_cast_or_null<perf::YieldOp>(benchYield) &&
            "expect perf.yield in perf.bench");
 

--- a/lib/TPP/Conversion/ConvertTppToXsmm/ConvertTppToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertTppToXsmm/ConvertTppToXsmm.cpp
@@ -267,7 +267,7 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
   xsmm::BinaryKindAttr getBinaryKind(RewriterBase &rewriter,
                                      tpp::FusedBrgemmOp brgemmOp) const {
     auto kind = brgemmOp.getBinaryKind();
-    auto ctx = rewriter.getContext();
+    auto *ctx = rewriter.getContext();
     if (kind == tpp::FusedBinaryOpKind::NONE)
       return xsmm::BinaryKindAttr::get(ctx, xsmm::BinaryKind::NONE);
     if (kind == tpp::FusedBinaryOpKind::ADD)
@@ -278,7 +278,7 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
   xsmm::UnaryKindAttr getUnaryKind(RewriterBase &rewriter,
                                    tpp::FusedBrgemmOp brgemmOp) const {
     auto kind = brgemmOp.getUnaryKind();
-    auto ctx = rewriter.getContext();
+    auto *ctx = rewriter.getContext();
     if (kind == tpp::FusedUnaryOpKind::NONE)
       return xsmm::UnaryKindAttr::get(ctx, xsmm::UnaryKind::NONE);
     if (kind == tpp::FusedUnaryOpKind::RELU)


### PR DESCRIPTION
Apply clang-tidy fixes for llvm-header-guard in /home/lorenzo/test-clang-tidy/tpp-mlir/lib/TPP/Conversion/ConvertLinalgToFunc/ConvertLinalgToFunc.cpp (NFC)

Apply clang-tidy fixes for llvm-header-guard in /home/lorenzo/test-clang-tidy/tpp-mlir/lib/TPP/Conversion/ConvertLinalgToTpp/ConvertLinalgToTpp.cpp (NFC)

Apply clang-tidy fixes for llvm-header-guard in /home/lorenzo/test-clang-tidy/tpp-mlir/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp (NFC)

Apply clang-tidy fixes for llvm-qualified-auto in /home/lorenzo/test-clang-tidy/tpp-mlir/lib/TPP/Conversion/ConvertPerfToFunc/ConvertPerfToFunc.cpp (NFC)

Apply clang-tidy fixes for llvm-qualified-auto in /home/lorenzo/test-clang-tidy/tpp-mlir/lib/TPP/Conversion/ConvertPerfToLoops/ConvertPerfToLoops.cpp (NFC)

Apply clang-tidy fixes for llvm-qualified-auto in /home/lorenzo/test-clang-tidy/tpp-mlir/lib/TPP/Conversion/ConvertTppToXsmm/ConvertTppToXsmm.cpp (NFC)