### PR TITLE
[CI] Add conditional queue benchmarks

### DIFF
--- a/scripts/buildkite/tpp-benchmark.yml
+++ b/scripts/buildkite/tpp-benchmark.yml
@@ -1,5 +1,6 @@
 env:
   NPROCS_LIMIT_LINK: "8"
+  RUN_SPR_BENCH: 1
   #LIBXSMM_VERBOSE: 4
   #LIBXSMMFETCH: 1
 
@@ -8,7 +9,44 @@ steps:
     command: "BUILD=1 scripts/buildkite/check_llvm.sh"
   - wait
 
-  - label: "TPP-MLIR-bench"
+  - label: "TPP-MLIR-SPR"
     command: "${SRUN} --partition=spr --time=0:30:00 --constraint=\"notrb\" -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_SPR_BENCH") == "1"
+
+  - label: "TPP-MLIR-SPRQ"
+    command: "${SRUN} --partition=sprh-quad --time=0:30:00 --constraint=\"notrb\" -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_SPRQ_BENCH") == "1"
+
+  - label: "TPP-MLIR-SPRS"
+    command: "${SRUN} --partition=sprh-snc4 --time=0:30:00 --constraint=\"notrb\" -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_SPRS_BENCH") == "1"
+
+  - label: "TPP-MLIR-SPRC"
+    command: "${SRUN} --partition=sprh-cache --time=0:30:00 --constraint=\"notrb\" -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_SPRC_BENCH") == "1"
+
+  - label: "TPP-MLIR-ZEN4"
+    command: "${SRUN} --partition=zen4 --time=0:30:00 -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_ZEN4_BENCH") == "1"
+
+  - label: "TPP-MLIR-CLX"
+    command: "${SRUN} --partition=clxap --time=0:30:00 -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_CLX_BENCH") == "1"
+
+  - label: "TPP-MLIR-ADL"
+    command: "${SRUN} --partition=rpl --time=0:30:00 -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -b -o -p'"
+    if: build.env("RUN_ADL_BENCH") == "1"


### PR DESCRIPTION
Just adding the queues, still only run SPR by default. Will need scheduled builds in buildkite to enable them.

Arm builds will be added later.

Working towards #798