### PR TITLE
[NFC] No need for disabling lsan anymore on benchmarks

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -26,14 +26,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=model --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
+      "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "gemm_bf16_dp4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=model --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=4" ],
       "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
+      "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
     },
     "mlp_fp32_dnn_target": {
@@ -61,14 +61,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=2" ],
       "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
+      "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "mlp_bf16_dp4_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=64,64,64 --vnni=4" ],
       "environment": {},
-      "flags": [ "-n", "100", "--disable-lsan" ],
+      "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
     }
   }},


### PR DESCRIPTION
With bufferization under control, more stable kernel generation and ownership based deallocation passes, we don't have memory leaks any more on benchmarks, as shown by the total lack of usage of the -disable-lsan flag.

Fixes #379