### PR TITLE
Require expected rank in `isInVnniLayout`

### DIFF
--- a/include/TPP/Transforms/Utils/VNNIUtils.h
+++ b/include/TPP/Transforms/Utils/VNNIUtils.h
@@ -19,11 +19,13 @@ class MemRefType;
 namespace vnni {
 namespace utils {
 
+enum class VnniOp { TRANSPOSE = 3, GEMM = 3, BRGEMM = 4 };
+
 // Returns the VNNI blocking factor: 2 for BF16 and 4 for BF8.
 std::optional<int64_t> getVnniBlockingFactor(Type type);
 
-// Return true if the memref is in VNNI layout.
-bool isInVnniLayout(MemRefType memref);
+// Return true if the memref is in VNNI layout with rank `expectedRank`.
+bool isInVnniLayout(VnniOp expectedRank, MemRefType memref);
 
 } // namespace utils
 } // namespace vnni

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -977,7 +977,7 @@ struct ConvertVnniPacking : public OpRewritePattern<linalg::TransposeOp> {
     MemRefType outType = out.getType().cast<MemRefType>();
     MemRefType sourceType = source.getType().cast<MemRefType>();
     if (!outType.hasStaticShape() || !sourceType.hasStaticShape() ||
-        outType.getRank() != 3 || !vnni::utils::isInVnniLayout(outType)) {
+        !vnni::utils::isInVnniLayout(vnni::utils::VnniOp::TRANSPOSE, outType)) {
       return failure();
     }
 

--- a/lib/TPP/Transforms/Utils/VNNIUtils.cpp
+++ b/lib/TPP/Transforms/Utils/VNNIUtils.cpp
@@ -24,9 +24,14 @@ std::optional<int64_t> getVnniBlockingFactor(Type type) {
   return std::nullopt;
 }
 
-bool isInVnniLayout(MemRefType memref) {
-  if (memref.getRank() < 3 || !memref.getElementType().isBF16())
+// Until we have a better way to express the VNNI layout (see: #563), it is up
+// to the callee to specify the expected rank in the VNNI layout as the rank
+// depends on the operations we are dealing with.
+bool isInVnniLayout(VnniOp expectedRank, MemRefType memref) {
+  if (memref.getRank() != static_cast<int64_t>(expectedRank) ||
+      !memref.getElementType().isBF16()) {
     return false;
+  }
   return memref.getShape().back() == vnni::utils::getVnniBlockingFactor(memref);
 }
 


### PR DESCRIPTION
Until we have a better way to express the VNNI layout (see: #563), it is up to the caller to specify the expected rank in the VNNI layout as the rank depends on the operations we are dealing with. The current check for rank < 3 is not correct; this is still ugly, but at least more explicit, as there are not magic assumptions on rank.