### PR TITLE
Expose `getUnaryFlags` and `getBinaryFlags` as xsmm utils (NFC)

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmUtils.h
+++ b/include/TPP/Dialect/Xsmm/XsmmUtils.h
@@ -52,6 +52,15 @@ void replaceOpWithUnary(RewriterBase &rewriter, Operation *operation,
                         ArrayRef<Value> operands, UnaryInfo unaryInfo,
                         ArrayAttr flags, UnaryKindAttr kind);
 
+// Compute the broadcasting flags for 'inputType' based 'outputType'.
+// Rules for broadcasting follows Numpy-style, and are only allowed in
+// 'inputType'. see: https://numpy.org/doc/stable/user/basics.broadcasting.html
+FailureOr<UnaryFlags> getUnaryFlags(Type inputType, Type outputType);
+
+// Compute the broadcasting flags for 'operandType' based on 'outputType'.
+FailureOr<BinaryFlags> getBinaryFlags(Type operandType, Type outputType,
+                                      size_t operandNumber);
+
 } // namespace utils
 } // namespace xsmm
 } // namespace mlir

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -148,6 +148,140 @@ FailureOr<BinaryInfo> getBinaryInfo(Value lhs, BinaryFlags lhsFlag, Value rhs,
   return binaryInfo;
 }
 
+// Examples:
+// If lower=[c], higher=[a, b, c], [c] reshaped into [1, 1, c].
+// If lower=[b, c], higher=[a, b, c], [b, c] reshaped into [1, b, c].
+// If lower=[a], higher=[a, a], [a] reshaped into [1, a].
+// If lower=[a], target=[a, b, a], [a] reshaped into [1, 1, a].
+// If lower=[], target=[a, b, c], [] reshaped into [1, 1, 1].
+static void
+computeBcastShapeInput(ArrayRef<int64_t> higherRankShape,
+                       ArrayRef<int64_t> lowerRankShape,
+                       SmallVectorImpl<int64_t> &reshapeOutputShape) {
+  // Initialize new shapes with [1] * higherRank.
+  int64_t higherRank = higherRankShape.size();
+  int64_t lowerRank = lowerRankShape.size();
+
+  reshapeOutputShape.assign(higherRank, 1);
+
+  int64_t higherRankDim;
+  int64_t lowerRankDim;
+
+  for (int64_t i = higherRank - 1, j = lowerRank - 1; i >= 0 && j >= 0;
+       i--, j--) {
+    higherRankDim = higherRankShape[i];
+    lowerRankDim = lowerRankShape[j];
+
+    if (lowerRankDim == 1 && higherRankDim > 1)
+      reshapeOutputShape[i] = 1;
+    else if ((lowerRankDim > 1 && higherRankDim == 1) ||
+             (lowerRankDim == higherRankDim))
+      reshapeOutputShape[i] = lowerRankDim;
+    else if (higherRankDim != lowerRankDim)
+      assert(false && "bCast semantics for identity op broken");
+  }
+}
+
+// Return true if `type` is a scalar or a 'scalar' memref (i.e., memref<f32> or
+// memref<1x1xf32>).
+static bool isScalarType(Type type) {
+  if (!type.isa<ShapedType>())
+    return true;
+  ShapedType shapedType = type.cast<ShapedType>();
+  ArrayRef<int64_t> shapeInput = shapedType.getShape();
+  auto isOne = [](int64_t val) { return val == 1; };
+  return llvm::all_of(shapeInput, isOne) || shapedType.getRank() == 0;
+}
+
+FailureOr<UnaryFlags> getUnaryFlags(Type inputType, Type outputType) {
+  assert(outputType.isa<ShapedType>() && "expect shaped type on output");
+  assert(outputType.cast<ShapedType>().getRank() == 2 &&
+         "expect rank 2 on output");
+
+  if (isScalarType(inputType))
+    return xsmm::UnaryFlags::BCAST_SCALAR;
+
+  ArrayRef<int64_t> shapeOutput = outputType.cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shapeInput = inputType.cast<ShapedType>().getShape();
+  assert(shapeOutput.size() >= shapeInput.size() &&
+         "output rank must be >= input rank");
+  SmallVector<int64_t> bShapeInput;
+  computeBcastShapeInput(shapeOutput, shapeInput, bShapeInput);
+  assert(shapeOutput.size() == bShapeInput.size());
+  shapeInput = bShapeInput;
+
+  if (shapeInput[1] == 1 && shapeOutput[1] > 1)
+    return xsmm::UnaryFlags::BCAST_ROW;
+
+  if (shapeInput[0] == 1 && shapeOutput[0] > 1)
+    return xsmm::UnaryFlags::BCAST_COL;
+
+  if (shapeInput == shapeOutput)
+    return xsmm::UnaryFlags::NONE;
+  return failure();
+}
+
+FailureOr<BinaryFlags> getBinaryFlags(Type operandType, Type outputType,
+                                      size_t operandNumber) {
+  assert(outputType.isa<ShapedType>() && "expect shaped type on output");
+  assert(outputType.cast<ShapedType>().getRank() == 2 &&
+         "expect rank 2 on output");
+
+  if (isScalarType(operandType)) {
+    if (operandNumber == 0)
+      return xsmm::BinaryFlags::BCAST_SCALAR_IN_0;
+    return xsmm::BinaryFlags::BCAST_SCALAR_IN_1;
+  }
+
+  enum class BCastType { NONE = 0, SCALAR, ROW, COL };
+  auto shapeOutput = outputType.cast<MemRefType>().getShape();
+  auto shapeOperand = operandType.cast<MemRefType>().getShape();
+  assert(shapeOutput.size() >= shapeOperand.size() &&
+         "Output rank must be >= operand rank");
+  SmallVector<int64_t> bOperandShape;
+  computeBcastShapeInput(shapeOutput, shapeOperand, bOperandShape);
+  assert(shapeOutput.size() == bOperandShape.size());
+  assert(shapeOutput.size() == 2);
+
+  auto getBCastEnum = [](BCastType bCastType,
+                         std::optional<unsigned> operand) -> xsmm::BinaryFlags {
+    switch (bCastType) {
+    case BCastType::NONE:
+      return xsmm::BinaryFlags::NONE;
+    case BCastType::SCALAR:
+      assert(operand != std::nullopt && "Require operand idx");
+      assert(*operand == 1 || *operand == 0 && "Expect idx to be 1 or 0");
+      if (*operand == 0)
+        return xsmm::BinaryFlags::BCAST_SCALAR_IN_0;
+      else
+        return xsmm::BinaryFlags::BCAST_SCALAR_IN_1;
+    case BCastType::ROW:
+      assert(operand != std::nullopt && "Require operand idx");
+      assert(*operand == 1 || *operand == 0 && "Expect idx to be 1 or 0");
+      if (*operand == 0)
+        return xsmm::BinaryFlags::BCAST_ROW_IN_0;
+      else
+        return xsmm::BinaryFlags::BCAST_ROW_IN_1;
+    case BCastType::COL:
+      assert(operand != std::nullopt && "Require operand idx");
+      assert(*operand == 1 || *operand == 0 && "Expect idx to be 1 or 0");
+      if (*operand == 0)
+        return xsmm::BinaryFlags::BCAST_COL_IN_0;
+      else
+        return xsmm::BinaryFlags::BCAST_COL_IN_1;
+    }
+    assert(false && "unrechable");
+  };
+
+  if (bOperandShape[1] == 1 && shapeOutput[1] > 1)
+    return getBCastEnum(BCastType::ROW, operandNumber);
+  if (bOperandShape[0] == 1 && shapeOutput[0] > 1)
+    return getBCastEnum(BCastType::COL, operandNumber);
+  if (bOperandShape == shapeOutput)
+    return getBCastEnum(BCastType::NONE, operandNumber);
+  return failure();
+}
+
 } // namespace utils
 } // namespace xsmm
 } // namespace mlir

--- a/test/Conversion/TppToXsmm/tpp-to-xsmm-relu.mlir
+++ b/test/Conversion/TppToXsmm/tpp-to-xsmm-relu.mlir
@@ -1,6 +1,6 @@
 // RUN: tpp-opt %s -convert-tpp-to-xsmm -split-input-file | FileCheck %s
 
-// CHECK-LABEL: @relu_to_xsmm(
+// CHECK-LABEL: relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<5x6xf32>)
 func.func @relu_to_xsmm(%arg0: memref<5x6xf32>) {
   // CHECK: %[[DISPACTH:.+]] = xsmm.unary.dispatch relu [5, 6, 6, 6] flags = (none) data_type = f32
@@ -22,11 +22,44 @@ func.func @relu_to_xsmm(%arg0: memref<5x6xf32>, %arg1: memref<5x6xf32>) {
 
 // -----
 
-// CHECK-LABEL: func.func @relu_to_xsmm(
+// CHECK-LABEL: relu_to_xsmm(
 // CHECK-SAME:  %[[ARG0:.+]]: memref<1x32xf32>)
 func.func @relu_to_xsmm(%arg0: memref<1x32xf32>) {
   // CHECK: %[[DISPATCH:.+]] = xsmm.unary.dispatch relu [1, 32, 32, 32] flags = (none) data_type = f32
   // CHECK-NEXT: xsmm.unary relu(data_type = f32, %[[DISPATCH]], %[[ARG0]], %[[ARG0]])
   tpp.relu ins(%arg0: memref<1x32xf32>) outs(%arg0: memref<1x32xf32>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: relu_to_xsmm
+// CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: f32
+func.func @relu_to_xsmm(%arg0: memref<3x3xf32>, %arg1: f32) {
+  // CHECK: %[[DIS:.+]] = xsmm.unary.dispatch relu [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
+  // CHECK: xsmm.unary relu(data_type = f32, %[[DIS]], %[[ARG1]], %[[ARG0]])
+  tpp.relu ins(%arg1: f32) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: relu_to_xsmm
+// CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<1xf32>
+func.func @relu_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<1xf32>) {
+  // CHECK: %[[DIS:.+]] = xsmm.unary.dispatch relu [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
+  // CHECK: xsmm.unary relu(data_type = f32, %[[DIS]], %[[ARG1]], %[[ARG0]])
+  tpp.relu ins(%arg1: memref<1xf32>) outs(%arg0: memref<3x3xf32>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: relu_to_xsmm
+// CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<1x1xf32>
+func.func @relu_to_xsmm(%arg0: memref<3x3xf32>, %arg1: memref<1x1xf32>) {
+  // CHECK: %[[DIS:.+]] = xsmm.unary.dispatch relu [3, 3, 1, 3] flags = (bcast_scalar) data_type = f32
+  // CHECK: xsmm.unary relu(data_type = f32, %[[DIS]], %[[ARG1]], %[[ARG0]])
+  tpp.relu ins(%arg1: memref<1x1xf32>) outs(%arg0: memref<3x3xf32>)
   return
 }


### PR DESCRIPTION
Needed in #810 for better XSMM verification.