### PR TITLE
Avoid loosing shape-row broadcastable information

### DIFF
--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -242,6 +242,33 @@ static FailureOr<xsmm::UnaryFlags> getBroadCastUnaryFlagFromMap(AffineMap map) {
   }
 }
 
+static Value makeOperandShapeRowBroadCastable(RewriterBase &rewriter,
+                                              Location loc, Value output,
+                                              Value operand) {
+  assert(output.getType().isa<ShapedType>());
+  assert(operand.getType().isa<ShapedType>());
+
+  OpBuilder::InsertionGuard guard(rewriter);
+  ShapedType shapedOutput = output.getType().cast<ShapedType>();
+  if (shapedOutput.getRank() != 2)
+    return operand;
+
+  ShapedType shapedOperand = operand.getType().cast<ShapedType>();
+  if (shapedOperand.getRank() != 1)
+    return operand;
+
+  SmallVector<int64_t> shapeOperand = llvm::to_vector(shapedOperand.getShape());
+  shapeOperand.push_back(1);
+  auto newShapedOperand =
+      MemRefType::get(shapeOperand, shapedOperand.getElementType());
+  auto reassoc =
+      getReassociationIndicesForReshape(shapedOperand, newShapedOperand);
+  assert(reassoc.has_value());
+  return linalgx::utils::expand(
+      rewriter, loc, operand, newShapedOperand,
+      getReassociationIndicesAttribute(rewriter, *reassoc));
+}
+
 // Convert linalg.generic to xsmm unary relu or identity op.
 struct ConvertGenericToUnary : public OpRewritePattern<linalg::GenericOp> {
   using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
@@ -270,6 +297,16 @@ struct ConvertGenericToUnary : public OpRewritePattern<linalg::GenericOp> {
         genericOp.getMatchingIndexingMap(inputOperand));
     if (failed(broadCastFlag))
       return failure();
+
+    // Make shape broadcast compatible.
+    // For later XSMM verification we need to introduce back
+    // unit dimension if we are dealing with a row broadcast.
+    // Example: memref<10xf32> -> memref<10x1xf32>
+    if (*broadCastFlag == xsmm::UnaryFlags::BCAST_ROW) {
+      operands[0] = makeOperandShapeRowBroadCastable(
+          rewriter, genericOp.getLoc(), operands[1], operands[0]);
+    }
+
     auto unaryInfo =
         xsmm::utils::getUnaryInfo(operands[0], operands[1], *broadCastFlag);
     if (failed(unaryInfo))
@@ -306,27 +343,34 @@ getBroadCastBinaryFlagFromMap(AffineMap map, unsigned operandIdx) {
 
 static LogicalResult rewriteBinaryOp(RewriterBase &rewriter,
                                      linalg::GenericOp genericOp,
-                                     ArrayRef<Value> operands,
+                                     MutableArrayRef<Value> operands,
                                      xsmm::BinaryKind xsmmTy) {
   assert(operands.size() == 3);
-  auto lhs = operands[0];
-  auto rhs = operands[1];
-  auto output = operands[2];
+  Location loc = genericOp.getLoc();
 
-  OpOperand *lhsOperand = getOperandFromValue(genericOp, lhs);
+  OpOperand *lhsOperand = getOperandFromValue(genericOp, operands[0]);
   auto broadCastFlagLhs = getBroadCastBinaryFlagFromMap(
       genericOp.getMatchingIndexingMap(lhsOperand), /*operandIdx=*/0);
   if (failed(broadCastFlagLhs))
     return failure();
+  if (*broadCastFlagLhs == xsmm::BinaryFlags::BCAST_ROW_IN_0) {
+    operands[0] = makeOperandShapeRowBroadCastable(rewriter, loc, operands[2],
+                                                   operands[0]);
+  }
 
-  OpOperand *rhsOperand = getOperandFromValue(genericOp, rhs);
+  OpOperand *rhsOperand = getOperandFromValue(genericOp, operands[1]);
   auto broadCastFlagRhs = getBroadCastBinaryFlagFromMap(
       genericOp.getMatchingIndexingMap(rhsOperand), /*operandIdx=*/1);
   if (failed(broadCastFlagRhs))
     return failure();
+  if (*broadCastFlagRhs == xsmm::BinaryFlags::BCAST_ROW_IN_1) {
+    operands[1] = makeOperandShapeRowBroadCastable(rewriter, loc, operands[2],
+                                                   operands[1]);
+  }
 
-  auto binaryInfo = xsmm::utils::getBinaryInfo(lhs, *broadCastFlagLhs, rhs,
-                                               *broadCastFlagRhs, output);
+  auto binaryInfo =
+      xsmm::utils::getBinaryInfo(operands[0], *broadCastFlagLhs, operands[1],
+                                 *broadCastFlagRhs, operands[2]);
   if (failed(binaryInfo))
     return failure();
 

--- a/lib/TPP/Transforms/TransformUtils.cpp
+++ b/lib/TPP/Transforms/TransformUtils.cpp
@@ -27,6 +27,7 @@ namespace utils {
 // Given a value `val` expand it's shape based on `reassociationMap`.
 Value expand(OpBuilder &builder, Location loc, Value val, Type newType,
              ArrayAttr reassociationMap) {
+  OpBuilder::InsertionGuard guard(builder);
   if (newType == val.getType())
     return val;
   if (newType.isa<RankedTensorType>()) {

--- a/test/Conversion/LinalgToXsmm/linalg-to-binary.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-binary.mlir
@@ -683,7 +683,7 @@ func.func @mul_bcast_row_1(%arg0: memref<256x1024xf32>, %arg1: memref<256xf32>) 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
 
-func.func @mul_bcast_row_2(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
+func.func @mul_bcast_row_in0(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
   linalg.generic {
     indexing_maps = [#map1, #map, #map],
     iterator_types = ["parallel", "parallel"]}
@@ -696,7 +696,7 @@ func.func @mul_bcast_row_2(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
   return
 }
 
-// CHECK-LABEL: mul_bcast_row_2
+// CHECK-LABEL: mul_bcast_row_in0
 // CHECK-SAME: %[[ARG0:.+]]: memref<10xf32>, %[[ARG1:.+]]: memref<10x10xf32>
 // CHECK: %[[EXP:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]] : memref<10xf32> into memref<10x1xf32>
 // CHECK: %[[DIS:.+]] = xsmm.binary.dispatch mul [10, 10, 1, 10, 10] flags = (bcast_row_in0) data_type = f32
@@ -707,7 +707,7 @@ func.func @mul_bcast_row_2(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
 
-func.func @mul_bcast_row_2(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
+func.func @mul_bcast_row_in1(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
   linalg.generic {
     indexing_maps = [#map, #map1, #map],
     iterator_types = ["parallel", "parallel"]}
@@ -720,7 +720,7 @@ func.func @mul_bcast_row_2(%arg0: memref<10xf32>, %arg1: memref<10x10xf32>) {
   return
 }
 
-// CHECK-LABEL: mul_bcast_row_2
+// CHECK-LABEL: mul_bcast_row_in1
 // CHECK-SAME: %[[ARG0:.+]]: memref<10xf32>, %[[ARG1:.+]]: memref<10x10xf32>
 // CHECK: %[[EXP:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]] : memref<10xf32> into memref<10x1xf32>
 // CHECK: %[[DIS:.+]] = xsmm.binary.dispatch mul [10, 10, 10, 1, 10] flags = (bcast_row_in1) data_type = f32

--- a/test/Conversion/LinalgToXsmm/linalg-to-unary.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-unary.mlir
@@ -423,7 +423,7 @@ func.func @identity_5(%arg0 : memref<10xf32>, %arg1 : memref<10x10xf32>) {
 
 // -----
 
-func.func @identity_5_1(%arg0 : memref<10x1xf32>, %arg1 : memref<10x10xf32>) {
+func.func @identity_bcast_row(%arg0 : memref<10x1xf32>, %arg1 : memref<10x10xf32>) {
   linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, 0)>, affine_map<(d0, d1) -> (d0, d1)>], 
     iterator_types = ["parallel", "parallel"]} 
@@ -434,7 +434,7 @@ func.func @identity_5_1(%arg0 : memref<10x1xf32>, %arg1 : memref<10x10xf32>) {
   return 
 }
 
-// CHECK-LABEL: identity_5_1
+// CHECK-LABEL: identity_bcast_row
 // CHECK-SAME: %[[ARG0:.+]]: memref<10x1xf32>, %[[ARG1:.+]]: memref<10x10xf32>
 // CHECK: %[[DIS:.+]] = xsmm.unary.dispatch identity [10, 10, 1, 10] flags = (bcast_row) data_type = f32
 // CHECK: xsmm.unary identity(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]])

--- a/test/Conversion/LinalgToXsmm/linalg-to-unary.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-unary.mlir
@@ -417,6 +417,25 @@ func.func @identity_5(%arg0 : memref<10xf32>, %arg1 : memref<10x10xf32>) {
 
 // CHECK-LABEL: identity_5
 // CHECK-SAME: %[[ARG0:.+]]: memref<10xf32>, %[[ARG1:.+]]: memref<10x10xf32>
+// CHECK: %[[EXP:.+]] = memref.expand_shape %[[ARG0]] {{\[}}[0, 1]] : memref<10xf32> into memref<10x1xf32>
+// CHECK: %[[DIS:.+]] = xsmm.unary.dispatch identity [10, 10, 1, 10] flags = (bcast_row) data_type = f32
+// CHECK: xsmm.unary identity(data_type = f32, %[[DIS]], %[[EXP]], %[[ARG1]])
+
+// -----
+
+func.func @identity_5_1(%arg0 : memref<10x1xf32>, %arg1 : memref<10x10xf32>) {
+  linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, 0)>, affine_map<(d0, d1) -> (d0, d1)>], 
+    iterator_types = ["parallel", "parallel"]} 
+    ins(%arg0 : memref<10x1xf32>) outs(%arg1 : memref<10x10xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+  }
+  return 
+}
+
+// CHECK-LABEL: identity_5_1
+// CHECK-SAME: %[[ARG0:.+]]: memref<10x1xf32>, %[[ARG1:.+]]: memref<10x10xf32>
 // CHECK: %[[DIS:.+]] = xsmm.unary.dispatch identity [10, 10, 1, 10] flags = (bcast_row) data_type = f32
 // CHECK: xsmm.unary identity(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]])
 


### PR DESCRIPTION
In some cases, we may lose broadcast information on the shape by running linalg pass fold-unit-dims. If this information is lost on the shape, we cannot verify the libs call as we currently use Numpy-style broadcasting rules. This PR attempts to preserve this information by adding back ones.