### PR TITLE
[CI] Persisting some changes done during benchmarking session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(BENCH_OMP_CFGS
   ${CONFIG_DIR}/omp/dnn-bf16.json
   ${CONFIG_DIR}/omp/mlir-fp32.json
   ${CONFIG_DIR}/omp/mlir-bf16.json
+  ${CONFIG_DIR}/omp/torch-dynamo.json
 )
 string(JOIN ',' BENCH_OMP_CFGS_STR ${BENCH_OMP_CFGS})
 add_custom_target(benchmarks-omp ${BENCHMARK_DIR}/driver.py -v --build ${PROJECT_BINARY_DIR} -n 10

--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -8,19 +8,33 @@
       "flags": [ "100", "256", "0", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
       "extensions": []
     },
-    "gemm_fp32_mlir": {
-      "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=model --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
-      "environment": {},
-      "flags": [ "-n", "100" ],
-      "extensions": [ "(avx2|asimd)" ]
-    },
     "gemm_bf16_dnn_target": {
       "type": "XSMM-DNN",
       "benchmark": "xsmm_dnn_mlp",
       "environment": {},
       "flags": [ "100", "256", "0", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
       "extensions": [ "avx2" ]
+    },
+    "mlp_fp32_dnn_target": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": {},
+      "flags": [ "100", "256", "5", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
+      "extensions": []
+    },
+    "mlp_bf16_dnn_target": {
+      "type": "XSMM-DNN",
+      "benchmark": "xsmm_dnn_mlp",
+      "environment": {},
+      "flags": [ "100", "256", "5", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
+      "extensions": [ "avx2" ]
+    },
+    "gemm_fp32_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=model --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
     },
     "gemm_bf16_dp2_mlir": {
       "type": "IR-GEN",
@@ -36,26 +50,12 @@
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
     },
-    "mlp_fp32_dnn_target": {
-      "type": "XSMM-DNN",
-      "benchmark": "xsmm_dnn_mlp",
-      "environment": {},
-      "flags": [ "100", "256", "5", "F", "32", "32", "32", "0", "1024", "1024", "1024", "1024" ],
-      "extensions": []
-    },
     "mlp_fp32_mlir": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=model --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
-    },
-    "mlp_bf16_dnn_target": {
-      "type": "XSMM-DNN",
-      "benchmark": "xsmm_dnn_mlp",
-      "environment": {},
-      "flags": [ "100", "256", "5", "F", "32", "32", "32", "1", "1024", "1024", "1024", "1024" ],
-      "extensions": [ "avx2" ]
     },
     "mlp_bf16_dp2_mlir": {
       "type": "IR-GEN",

--- a/benchmarks/config/omp/torch-dynamo.json
+++ b/benchmarks/config/omp/torch-dynamo.json
@@ -1,0 +1,126 @@
+[
+  {
+  "gemm_fp32_torch" : {
+    "fp32_3x1024_omp_2_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "fp32_3x1024_omp_4_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "fp32_3x1024_omp_8_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "fp32_3x1024_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    }
+  }},
+  {
+  "gemm_bf16_torch" : {
+    "bf16_3x1024_omp_2_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "bf16_3x1024_omp_4_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "bf16_3x1024_omp_8_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "bf16_3x1024_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-gemm-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    }
+  }},
+  {
+  "mlp_fp32_torch" : {
+    "fp32_3x1024_omp_2_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "fp32_3x1024_omp_4_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "fp32_3x1024_omp_8_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "fp32_3x1024_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    }
+  }},
+  {
+  "mlp_bf16_torch" : {
+    "bf16_3x1024_omp_2_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "bf16_3x1024_omp_4_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "bf16_3x1024_omp_8_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    },
+    "bf16_3x1024_omp_16_mlir": {
+      "type": "MLIR",
+      "benchmark": "pytorch/torch-dynamo-mlp-bf16-3x1024.mlir",
+      "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
+      "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
+      "extensions": [ ]
+    }
+  }}
+]

--- a/benchmarks/config/pytorch/torch_dynamo.json
+++ b/benchmarks/config/pytorch/torch_dynamo.json
@@ -1,30 +1,30 @@
 [
   {
     "torch_dynamo" : {
-      "mlp_3x1024_fp32" : { 
-        "type": "MLIR",
-        "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
-        "environment": {}, 
-        "flags": [ "-n", "50" ],
-        "extensions": [ ] 
-      },
-      "mlp_3x1024_bf16" : { 
-        "type": "MLIR",
-        "benchmark": "pytorch/torch-dynamo-mlp-bf16-3x1024.mlir",
-        "environment": {}, 
-        "flags": [ "-n", "50" ],
-        "extensions": [ ] 
-      },
-      "gemm_3x1024_fp32" : { 
+      "gemm_fp32_torch" : {
         "type": "MLIR",
         "benchmark": "pytorch/torch-dynamo-gemm-fp32-3x1024.mlir",
         "environment": {}, 
         "flags": [ "-n", "50" ],
         "extensions": [ ] 
       },
-      "gemm_3x1024_bf16" : { 
+      "gemm_bf16_torch" : {
         "type": "MLIR",
         "benchmark": "pytorch/torch-dynamo-gemm-bf16-3x1024.mlir",
+        "environment": {}, 
+        "flags": [ "-n", "50" ],
+        "extensions": [ ] 
+      },
+      "mlp_fp32_torch" : {
+        "type": "MLIR",
+        "benchmark": "pytorch/torch-dynamo-mlp-fp32-3x1024.mlir",
+        "environment": {}, 
+        "flags": [ "-n", "50" ],
+        "extensions": [ ] 
+      },
+      "mlp_bf16_torch" : {
+        "type": "MLIR",
+        "benchmark": "pytorch/torch-dynamo-mlp-bf16-3x1024.mlir",
         "environment": {}, 
         "flags": [ "-n", "50" ],
         "extensions": [ ] 

--- a/scripts/buildkite/benchmark.sh
+++ b/scripts/buildkite/benchmark.sh
@@ -111,6 +111,7 @@ if [ "$BENCH_OMP" ]; then
   benchmark omp/dnn-bf16.json "OpenMP XSMM-DNN BF16"
   benchmark omp/mlir-fp32.json "OpenMP TPP-MLIR FP32"
   benchmark omp/mlir-bf16.json "OpenMP TPP-MLIR BF16"
+  benchmark omp/torch-dynamo.json "OpenMP TPP-MLIR PyTorch"
 fi
 
 # Matmul Benchmarks

--- a/scripts/buildkite/build_tpp.sh
+++ b/scripts/buildkite/build_tpp.sh
@@ -54,8 +54,12 @@ if [ "${GPU}" ]; then
   GPU_OPTION="-G ${GPU}"
   source ${SCRIPT_DIR}/ci/setup_gpu_env.sh
 fi
-# Always build OpenMP and OneDNN in CI
-EXTENSIONS="-O -D"
+# Always build OpenMP in CI
+EXTENSIONS="-O"
+# Enable OneDNN build
+if [ "${ONEDNN}" ]; then
+  EXTENSIONS="${EXTENSIONS} -D"
+fi
 
 if [ "${CLEAN}" ]; then
   BUILD_DIR_RM=-R

--- a/scripts/buildkite/tpp-benchmark.yml
+++ b/scripts/buildkite/tpp-benchmark.yml
@@ -9,49 +9,49 @@ steps:
     command: "BUILD=1 scripts/buildkite/check_llvm.sh"
   - wait
 
-  - label: "TPP-MLIR-SPR"
+  - label: "TPP-MLIR-SPR-BASE"
     command: "${SRUN} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_SPR_BENCH") == "1"
 
-  - label: "TPP-MLIR-ZEN4"
+  - label: "TPP-MLIR-ZEN4-BASE"
     command: "${SRUN} --partition=zen4 --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_ZEN4_BENCH") == "1"
 
-  - label: "TPP-MLIR-CLX"
+  - label: "TPP-MLIR-CLX-BASE"
     command: "${SRUN} --partition=clxap --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_CLX_BENCH") == "1"
 
-  - label: "TPP-MLIR-ADL"
+  - label: "TPP-MLIR-ADL-BASE"
     command: "${SRUN} --partition=rpl --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_ADL_BENCH") == "1"
 
-  - label: "TPP-MLIR-SPR"
+  - label: "TPP-MLIR-SPR-OMP"
     command: "${SRUN} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -o'"
     if: build.env("RUN_SPR_BENCH") == "1"
 
-  - label: "TPP-MLIR-ZEN4"
+  - label: "TPP-MLIR-ZEN4-OMP"
     command: "${SRUN} --partition=zen4 --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -o'"
     if: build.env("RUN_ZEN4_BENCH") == "1"
 
-  - label: "TPP-MLIR-CLX"
+  - label: "TPP-MLIR-CLX-OMP"
     command: "${SRUN} --partition=clxap --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -o'"
     if: build.env("RUN_CLX_BENCH") == "1"
 
-  - label: "TPP-MLIR-ADL"
+  - label: "TPP-MLIR-ADL-OMP"
     command: "${SRUN} --partition=rpl --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
               scripts/buildkite/benchmark.sh -o'"

--- a/scripts/buildkite/tpp-benchmark.yml
+++ b/scripts/buildkite/tpp-benchmark.yml
@@ -12,41 +12,47 @@ steps:
   - label: "TPP-MLIR-SPR"
     command: "${SRUN} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- \
               'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
+              scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_SPR_BENCH") == "1"
-
-  - label: "TPP-MLIR-SPRQ"
-    command: "${SRUN} --partition=sprh-quad --time=2:00:00 --constraint=\"notrb\" -- \
-              'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
-    if: build.env("RUN_SPRQ_BENCH") == "1"
-
-  - label: "TPP-MLIR-SPRS"
-    command: "${SRUN} --partition=sprh-snc4 --time=2:00:00 --constraint=\"notrb\" -- \
-              'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
-    if: build.env("RUN_SPRS_BENCH") == "1"
-
-  - label: "TPP-MLIR-SPRC"
-    command: "${SRUN} --partition=sprh-cache --time=2:00:00 --constraint=\"notrb\" -- \
-              'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
-    if: build.env("RUN_SPRC_BENCH") == "1"
 
   - label: "TPP-MLIR-ZEN4"
     command: "${SRUN} --partition=zen4 --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
+              scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_ZEN4_BENCH") == "1"
 
   - label: "TPP-MLIR-CLX"
     command: "${SRUN} --partition=clxap --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
+              scripts/buildkite/benchmark.sh -b -p'"
     if: build.env("RUN_CLX_BENCH") == "1"
 
   - label: "TPP-MLIR-ADL"
     command: "${SRUN} --partition=rpl --time=2:00:00 -- \
               'KIND=Release COMPILER=clang LINKER=lld \
-              scripts/buildkite/benchmark.sh -b -o -p'"
+              scripts/buildkite/benchmark.sh -b -p'"
+    if: build.env("RUN_ADL_BENCH") == "1"
+
+  - label: "TPP-MLIR-SPR"
+    command: "${SRUN} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -o'"
+    if: build.env("RUN_SPR_BENCH") == "1"
+
+  - label: "TPP-MLIR-ZEN4"
+    command: "${SRUN} --partition=zen4 --time=2:00:00 -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -o'"
+    if: build.env("RUN_ZEN4_BENCH") == "1"
+
+  - label: "TPP-MLIR-CLX"
+    command: "${SRUN} --partition=clxap --time=2:00:00 -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -o'"
+    if: build.env("RUN_CLX_BENCH") == "1"
+
+  - label: "TPP-MLIR-ADL"
+    command: "${SRUN} --partition=rpl --time=2:00:00 -- \
+              'KIND=Release COMPILER=clang LINKER=lld \
+              scripts/buildkite/benchmark.sh -o'"
     if: build.env("RUN_ADL_BENCH") == "1"

--- a/scripts/buildkite/tpp-mlir.yml
+++ b/scripts/buildkite/tpp-mlir.yml
@@ -10,20 +10,20 @@ steps:
 
   - label: "TPP-MLIR-gcc-rel"
     command: "${SRUN} --partition=spr-all --time=0:30:00 -- \
-              'KIND=Release COMPILER=gcc CHECK=1 \
+              'KIND=Release COMPILER=gcc CHECK=1 ONEDNN=1 \
               scripts/buildkite/build_tpp.sh'"
 
   - label: "TPP-MLIR-gcc-deb"
     command: "${SRUN} --partition=spr-all --time=0:30:00 -- \
-              'KIND=Debug COMPILER=gcc CHECK=1 \
+              'KIND=Debug COMPILER=gcc CHECK=1 ONEDNN=1 \
               scripts/buildkite/build_tpp.sh'"
 
   - label: "TPP-MLIR-clang-rel"
     command: "${SRUN} --partition=spr-all --time=0:30:00 -- \
-              'KIND=Release COMPILER=clang LINKER=lld CHECK=1 \
+              'KIND=Release COMPILER=clang LINKER=lld CHECK=1 ONEDNN=1 \
               scripts/buildkite/build_tpp.sh'"
 
   - label: "TPP-MLIR-clang-deb"
     command: "${SRUN} --partition=spr-all --time=0:30:00 -- \
-              'KIND=Debug COMPILER=clang LINKER=lld SANITIZERS=1 CHECK=1 \
+              'KIND=Debug COMPILER=clang LINKER=lld SANITIZERS=1 CHECK=1 ONEDNN=1 \
               scripts/buildkite/build_tpp.sh'"


### PR DESCRIPTION
Some of the changes we did this week should be persisted, as they were good changes:
* Reorder some benchmarks in the result to make it easier to copy&paste into a spreadsheet. No change in the benchmarks themselves.
* Add PyTorch OpenMP tests in the same way as tpp-mlir and libxsmm-dnn. This gives us a packing scalability measurement.
* Split base / openmp into two different jobs to increase scalability of benchmark CI jobs (run in parallel). We just need to be careful with the machines we don't have too many, so for now it's only enabled by default on SPR.
* Disabling unnecessary build of OneDNN in benchmarks until we actually benchmark OneDNN calls.
