### PR TITLE
Use `linalg.copy` instead of `memref.copy` in bufferization

### DIFF
--- a/lib/TPP/Transforms/Bufferize.cpp
+++ b/lib/TPP/Transforms/Bufferize.cpp
@@ -115,6 +115,12 @@ void DuplicateFill::runOnOperation() {
   });
 }
 
+static LogicalResult defaultMemCpyFn(OpBuilder &builder, Location loc,
+                                     Value from, Value to) {
+  builder.create<linalg::CopyOp>(loc, from, to);
+  return success();
+}
+
 void Bufferize::runOnOperation() {
   ModuleOp moduleOp = getOperation();
 
@@ -131,6 +137,7 @@ void Bufferize::runOnOperation() {
   buffOpts.bufferizeFunctionBoundaries = true;
   buffOpts.setFunctionBoundaryTypeConversion(
       bufferization::LayoutMapOption::IdentityLayoutMap);
+  buffOpts.memCpyFn = defaultMemCpyFn;
   bool runOnlyAnalysis = this->testAnalysisOnly || this->printConflicts;
   if (runOnlyAnalysis) {
     buffOpts.printConflicts = this->printConflicts;

--- a/test/Conversion/LinalgToXsmm/linalg-to-unary.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-unary.mlir
@@ -508,3 +508,26 @@ func.func @identity_9(%arg0: memref<6xf32, strided<[1]>>, %arg1: memref<6x9xf32>
 // CHECK: linalg.generic
 // C_HECK: %[[DIS:.+]] = xsmm.unary.dispatch identity [6, 9, 1, 9] flags = (bcast_row) data_type = f32
 // C_HECK: xsmm.unary identity(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]])
+
+// -----
+
+func.func @linalg_copy(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
+  linalg.copy ins(%arg0 : memref<2x2xf32>) outs(%arg1 : memref<2x2xf32>)
+  return
+}
+
+// CHECK-LABEL: linalg_copy
+// CHECK-SAME: %[[ARG0:.+]]: memref<2x2xf32>, %[[ARG1:.+]]: memref<2x2xf32>
+// CHECK: %[[DIS:.+]] = xsmm.unary.dispatch identity [2, 2, 2, 2] flags = (none) data_type = f32
+// CHECK: xsmm.unary identity(data_type = f32, %[[DIS]], %[[ARG0]], %[[ARG1]])
+
+// -----
+
+func.func @linalg_copy_mixed_sem(%arg0: memref<2x2xf32>, %arg1: tensor<2x2xf32>) -> tensor<2x2xf32> {
+  %0 = linalg.copy ins(%arg0 : memref<2x2xf32>) outs(%arg1 : tensor<2x2xf32>) -> tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
+}
+
+// CHECK-LABEL: linalg_copy_mixed_sem
+// CHECK-NOT: xsmm.unary
+// CHECK: linalg.copy

--- a/test/Dialect/Tpp/tpp-bufferization.mlir
+++ b/test/Dialect/Tpp/tpp-bufferization.mlir
@@ -224,7 +224,7 @@ func.func @sequence_of_adds_on_rhs(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32
 // CHECK-LABEL: func.func @sequence_of_adds_on_rhs
 // CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>, %[[ARG1:.+]]: memref<3x3xf32>
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<3x3xf32>
-// CHECK: memref.copy %[[ARG1]], %[[ALLOC]] : memref<3x3xf32> to memref<3x3xf32>
+// CHECK: linalg.copy ins(%[[ARG1]] : memref<3x3xf32>) outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ALLOC]] : memref<3x3xf32>)
 // CHECK-SAME:    outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK: tpp.add ins(%[[ALLOC]] : memref<3x3xf32>, %[[ARG1]] : memref<3x3xf32>)
@@ -291,7 +291,7 @@ func.func @test_mlp_bf16_3_layer_1024(%arg0: tensor<256x1024xbf16>,
 // CHECK-SAME:  %[[ARG0:.+]]: memref<256x1024xbf16>, %[[ARG1:.+]]: memref<256x1024xbf16>
 // CHECK: %[[CST:.+]] = memref.get_global @__constant_1024x1024xbf16 : memref<1024x1024xbf16>
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc
-// CHECK-NEXT: memref.copy %[[ARG1]], %[[ALLOC]] : memref<256x1024xbf16> to memref<256x1024xbf16>
+// CHECK-NEXT: linalg.copy ins(%[[ARG1]] : memref<256x1024xbf16>) outs(%[[ALLOC]] : memref<256x1024xbf16>)
 // CHECK-NEXT: tpp.gemm ins(%[[ARG0]] : memref<256x1024xbf16>, %[[CST]] : memref<1024x1024xbf16>, %[[ALLOC]] : memref<256x1024xbf16>) outs(%[[ALLOC]] : memref<256x1024xbf16>)
 // CHECK-NEXT: tpp.add ins(%[[ALLOC]] : memref<256x1024xbf16>, %[[ARG1]] : memref<256x1024xbf16>) outs(%[[ARG1]] : memref<256x1024xbf16>)
 // CHECK-NEXT: tpp.relu ins(%[[ARG1]] : memref<256x1024xbf16>) outs(%[[ARG1]] : memref<256x1024xbf16>)
@@ -391,7 +391,7 @@ func.func @mlp_single_layer(%arg0: tensor<256x1024xf32>) -> tensor<256x1024xf32>
 
 // CHECK-LABEL: mlp_single_layer
 // CHECK-SAME:  %[[ARG0:.+]]: memref<256x1024xf32>
-// CHECK-NOT: memref.copy
+// CHECK-NOT: linalg.copy
 // CHECK: %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK: %[[GLOBAL1:.+]] = memref.get_global @__constant_32x32xf32 : memref<32x32xf32>
 // CHECK: %[[GLOBAL:.+]] = memref.get_global @__constant_1024x32xf32 : memref<1024x32xf32>
@@ -412,7 +412,7 @@ func.func @mlp_single_layer(%arg0: tensor<256x1024xf32>) -> tensor<256x1024xf32>
 // -----
 
 // CHECK-LABEL: splitted_init
-// CHECK-NOT: memref.copy
+// CHECK-NOT: linalg.copy
 // CHECK-COUNT-3: memref.alloc
 // Splitting initialization for each layer avoids copies but we have a
 // number of allocations = number of layers.
@@ -732,7 +732,7 @@ func.func @conflicting_in_place(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32> {
 // CHECK-LABEL: conflicting_in_place
 // CHECK-SAME: %[[ARG0:.+]]: memref<3x3xf32>
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {{.+}} : memref<3x3xf32>
-// CHECK-NEXT: memref.copy %[[ARG0]], %[[ALLOC]] : memref<3x3xf32> to memref<3x3xf32>
+// CHECK-NEXT: linalg.copy ins(%[[ARG0]] : memref<3x3xf32>) outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK-NEXT: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ALLOC]] : memref<3x3xf32>) outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK-NEXT: tpp.add ins(%[[ALLOC]] : memref<3x3xf32>, %[[ARG0]] : memref<3x3xf32>) outs(%[[ARG0]] : memref<3x3xf32>)
 // CHECK-NEXT: memref.dealloc %[[ALLOC]] : memref<3x3xf32>
@@ -748,7 +748,7 @@ func.func @conflicting_in_place(%arg0: tensor<3x3xf32>) -> tensor<3x3xf32> {
 // CHECK-LABEL: conflicting_in_place
 // CHECK-SAME:  %[[ARG0:.+]]: memref<3x3xf32>
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {{.+}} : memref<3x3xf32>
-// CHECK-NEXT: memref.copy %[[ARG0]], %[[ALLOC]] : memref<3x3xf32> to memref<3x3xf32>
+// CHECK-NEXT: linalg.copy ins(%[[ARG0]] : memref<3x3xf32>) outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK-NEXT: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ALLOC]] : memref<3x3xf32>) outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK-NEXT: tpp.add ins(%[[ARG0]] : memref<3x3xf32>, %[[ALLOC]] : memref<3x3xf32>) outs(%[[ALLOC]] : memref<3x3xf32>)
 // CHECK-NEXT: return %[[ALLOC]] : memref<3x3xf32>
@@ -781,7 +781,7 @@ func.func @gemm_back_to_back(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
 // CHECK: tpp.zero ins(%[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 // CHECK: %[[ALLOC_1:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
-// CHECK: memref.copy %[[ALLOC]], %[[ALLOC_1]] : memref<10x10xf32> to memref<10x10xf32>
+// CHECK: linalg.copy ins(%[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC_1]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ARG0]] : memref<10x10xf32>, %{{.+}} : memref<10x10xf32>, %[[ALLOC_1]] : memref<10x10xf32>) outs(%[[ALLOC_1]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ALLOC_1]] : memref<10x10xf32>, %{{.+}} : memref<10x10xf32>, %[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 
@@ -802,7 +802,7 @@ func.func @gemm_back_to_back(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>,
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
 // CHECK: tpp.zero ins(%[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 // CHECK: %[[ALLOC_1:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
-// CHECK: memref.copy %[[ALLOC]], %[[ALLOC_1]] : memref<10x10xf32> to memref<10x10xf32>
+// CHECK: linalg.copy ins(%[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC_1]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ARG0]] : memref<10x10xf32>, %[[ARG1]] : memref<10x10xf32>, %[[ALLOC_1]] : memref<10x10xf32>) outs(%[[ALLOC_1]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ALLOC_1]] : memref<10x10xf32>, %[[ARG2]] : memref<10x10xf32>, %[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 
@@ -819,7 +819,7 @@ func.func @gemm_back_to_back(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>,
 // CHECK-LABEL: gemm_back_to_back
 // CHECK-SAME:  %[[ARG0:.+]]: memref<10x10xf32>, %[[ARG1:.+]]: memref<10x10xf32>, %[[ARG2:.+]]: memref<10x10xf32>, %[[ARG3:.+]]: memref<10x10xf32>
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
-// CHECK: memref.copy %[[ARG3]], %[[ALLOC]] : memref<10x10xf32> to memref<10x10xf32>
+// CHECK: linalg.copy ins(%[[ARG3]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ARG0]] : memref<10x10xf32>, %[[ARG1]] : memref<10x10xf32>, %[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ALLOC]] : memref<10x10xf32>, %[[ARG2]] : memref<10x10xf32>, %[[ARG3]] : memref<10x10xf32>) outs(%[[ARG3]] : memref<10x10xf32>)
 
@@ -837,7 +837,7 @@ func.func @gemm_back_to_back(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>,
 // CHECK-LABEL: gemm_back_to_back
 // CHECK-SAME:  %[[ARG0:.+]]: memref<10x10xf32>, %[[ARG1:.+]]: memref<10x10xf32>, %[[ARG2:.+]]: memref<10x10xf32>, %[[ARG3:.+]]: memref<10x10xf32>, %[[ARG4:.+]]: memref<10x10xf32>
 // CHECK-NOT: memref.alloc
-// CHECK-NOT: memref.copy
+// CHECK-NOT: linalg.copy
 // CHECK: tpp.gemm ins(%[[ARG0]] : memref<10x10xf32>, %[[ARG1]] : memref<10x10xf32>, %[[ARG3]] : memref<10x10xf32>) outs(%[[ARG3]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ARG3]] : memref<10x10xf32>, %[[ARG2]] : memref<10x10xf32>, %[[ARG4]] : memref<10x10xf32>) outs(%[[ARG4]] : memref<10x10xf32>)
 
@@ -858,7 +858,7 @@ func.func @gemms(%arg0: tensor<10x10xf32>, %arg1: tensor<10x10xf32>,
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
 // CHECK: tpp.zero ins(%[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 // CHECK: %[[ALLOC_1:.+]] = memref.alloc() {{.+}} : memref<10x10xf32>
-// CHECK: memref.copy %[[ALLOC]], %[[ALLOC_1]] : memref<10x10xf32> to memref<10x10xf32>
+// CHECK: linalg.copy ins(%[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC_1]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ARG0]] : memref<10x10xf32>, %[[ARG1]] : memref<10x10xf32>, %[[ALLOC_1]] : memref<10x10xf32>) outs(%[[ALLOC_1]] : memref<10x10xf32>)
 // CHECK: tpp.gemm ins(%[[ARG2]] : memref<10x10xf32>, %[[ARG3]] : memref<10x10xf32>, %[[ALLOC]] : memref<10x10xf32>) outs(%[[ALLOC]] : memref<10x10xf32>)
 
@@ -944,7 +944,7 @@ func.func @same_repetitive_region_but_cst() -> tensor<10x10xf32> {
 // CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 64 : i64} : memref<10x10xf32>
 // CHECK: linalg.fill ins(%[[CST]] : f32) outs(%[[ALLOC]] : memref<10x10xf32>)
 // CHECK: %[[ALLOC_0:.+]] = memref.alloc() {alignment = 64 : i64} : memref<10x10xf32>
-// CHECK: memref.copy %[[GB]], %[[ALLOC_0]] : memref<10x10xf32> to memref<10x10xf32>
+// CHECK: linalg.copy ins(%[[GB]] : memref<10x10xf32>) outs(%[[ALLOC_0]] : memref<10x10xf32>)
 // CHECK: scf.for %{{.+}} = %[[C0]] to %[[C2]] step %[[C1]]
 // CHECK: tpp.add ins(%[[ALLOC]] : memref<10x10xf32>, %[[ALLOC_0]] : memref<10x10xf32>)
 // CHECK-SAME:  outs(%[[ALLOC_0]] : memref<10x10xf32>)

--- a/test/Models/mlp-3layers.mlir
+++ b/test/Models/mlp-3layers.mlir
@@ -65,12 +65,12 @@ func.func @mlp_3layers(%arg0: tensor<256x1024xf32>) -> tensor<256x1024xf32> {
 // CHECK-SAME:  %[[ARG0:.+]]: memref<256x1024xf32>)
 // CHECK: tpp.zero ins({{.+}}) outs(%[[zeroBuf:.+]] : memref<256x1024xf32>)
 // layer 1
-// CHECK: memref.copy %[[zeroBuf]], %[[out1:.+]] : memref<256x1024xf32> to memref<256x1024xf32>
+// CHECK: linalg.copy ins(%{{.+}}: memref<256x1024xf32>) outs(%{{.+}}: memref<256x1024xf32>)
 // CHECK: tpp.gemm ins(%[[ARG0]]{{.+}}) outs(%[[out1:.+]] : memref<256x1024xf32>)
 // CHECK: tpp.add ins(%[[out1]]{{.+}}) outs(%[[out1]] : memref<256x1024xf32>)
 // CHECK: tpp.relu ins(%[[out1]] : memref<256x1024xf32>) outs(%[[out1]] : memref<256x1024xf32>)
 // layer 2
-// CHECK: memref.copy %[[zeroBuf]], %[[out2:.+]] : memref<256x1024xf32> to memref<256x1024xf32>
+// CHECK: linalg.copy ins(%{{.+}}: memref<256x1024xf32>) outs(%{{.+}}: memref<256x1024xf32>)
 // CHECK: tpp.gemm ins(%[[out1]]{{.+}}) outs(%[[out2:.+]] : memref<256x1024xf32>)
 // CHECK: tpp.add ins(%[[out2]]{{.+}}) outs(%[[out2]] : memref<256x1024xf32>)
 // CHECK: tpp.relu ins(%[[out2]] : memref<256x1024xf32>) outs(%[[out2]] : memref<256x1024xf32>)

--- a/test/Passes/DefaultPipeline/default-tpp-passes.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes.mlir
@@ -230,3 +230,17 @@ func.func @batch_matmul_rewrite(%arg0: tensor<512x32x64xf32>, %arg1: tensor<512x
                            outs(%0 : tensor<512x32x32xf32>) -> tensor<512x32x32xf32>
   return %1 : tensor<512x32x32xf32>
 }
+
+// -----
+
+func.func @linalg_copy(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
+  linalg.copy ins(%arg0 : memref<2x2xf32>) outs(%arg1 : memref<2x2xf32>)
+  return
+}
+
+// CHECK-LABEL: linalg_copy
+// CHECK-SAME: %[[ARG0:.+]]: memref<2x2xf32>, %[[ARG1:.+]]: memref<2x2xf32>
+// CHECK: xsmm_unary_dispatch
+// CHECK: %[[PTR_0:.+]] = memref.extract_aligned_pointer_as_index %[[ARG0]]
+// CHECK: %[[PTR_1:.+]] = memref.extract_aligned_pointer_as_index %[[ARG1]]
+// CHECK: xsmm_unary_invoke

--- a/test/Passes/DefaultPipeline/tpp-lowering.mlir
+++ b/test/Passes/DefaultPipeline/tpp-lowering.mlir
@@ -2,13 +2,13 @@
 // RUN: tpp-opt %s -tpp-lowering="tpp-to-loops" | FileCheck %s -check-prefix=LOOPS
 
 func.func @tpp_ops(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>, %arg2: memref<5x5xf32>, %arg3: memref<5x5xf32>) {
-    tpp.brgemm ins(%arg0 : memref<3x5x4xf32>, %arg1 : memref<3x4x5xf32>, %arg2 : memref<5x5xf32>)
-               outs(%arg2 : memref<5x5xf32>)
-    tpp.relu ins(%arg2 : memref<5x5xf32>) outs(%arg2 : memref<5x5xf32>)
-    tpp.gemm ins(%arg2 : memref<5x5xf32>, %arg3 : memref<5x5xf32>, %arg2 : memref<5x5xf32>)
+  tpp.brgemm ins(%arg0 : memref<3x5x4xf32>, %arg1 : memref<3x4x5xf32>, %arg2 : memref<5x5xf32>)
              outs(%arg2 : memref<5x5xf32>)
-    return
-  }
+  tpp.relu ins(%arg2 : memref<5x5xf32>) outs(%arg2 : memref<5x5xf32>)
+  tpp.gemm ins(%arg2 : memref<5x5xf32>, %arg3 : memref<5x5xf32>, %arg2 : memref<5x5xf32>)
+           outs(%arg2 : memref<5x5xf32>)
+  return
+}
 
 // XSMM-LABEL: func.func @tpp_ops(
 // XSMM-NOT: tpp.brgemm
@@ -31,8 +31,8 @@ func.func @tpp_ops(%arg0: memref<3x5x4xf32>, %arg1: memref<3x4x5xf32>, %arg2: me
 // LOOPS:   arith.mulf
 // LOOPS:   arith.addf
 
-// XSMM-LABEL: copy
-func.func @copy(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
+// XSMM-LABEL: copy_memref
+func.func @copy_memref(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
   // XSMM: xsmm.unary.dispatch identity
   // XSMM-NEXT: xsmm.unary identity
   memref.copy %arg0, %arg1 : memref<2x2xf32> to memref<2x2xf32>

--- a/test/Passes/bufferization.mlir
+++ b/test/Passes/bufferization.mlir
@@ -1,0 +1,18 @@
+// RUN: tpp-opt %s -bufferize | FileCheck %s
+
+#map = affine_map<(d0) -> (d0 * 32)>
+
+func.func @matmul_pack(%arg0: tensor<1024x512xbf16>, %arg1: tensor<16x32x32x32xbf16>) -> tensor<16x32x32x32xbf16> {
+  %0 = scf.forall (%arg2, %arg3) in (16, 32) shared_outs(%arg4 = %arg1) -> (tensor<16x32x32x32xbf16>) {
+    %1 = affine.apply #map(%arg3)
+    %2 = affine.apply #map(%arg2)
+    %extracted_slice = tensor.extract_slice %arg0[%1, %2] [32, 32] [1, 1] : tensor<1024x512xbf16> to tensor<32x32xbf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %extracted_slice into %arg4[%arg2, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<32x32xbf16> into tensor<16x32x32x32xbf16>
+    }
+  }
+  return %0 : tensor<16x32x32x32xbf16>
+}
+
+// CHECK-LABEL: matmul_pack
+// CHECK: linalg.copy

--- a/test/Passes/pass-duplicate-fill.mlir
+++ b/test/Passes/pass-duplicate-fill.mlir
@@ -15,11 +15,11 @@ func.func @duplicate_zero_fill_on_contractions(%arg0: tensor<32x512xf32>,
       %arg1: tensor<512x64xf32>) -> tensor<32x64xf32> {
   // BUFF-COUNT-2: memref.alloc
   // BUFF-COUNT-1: memref.dealloc
-  // BUFF-NOT: memref.copy
+  // BUFF-NOT: linalg.copy
   //
   // BUFFNOTDUP-COUNT-2: memref.alloc
   // BUFFNOTDUP-COUNT-1: memref.dealloc
-  // BUFFNOTDUP-NOT: memref.copy
+  // BUFFNOTDUP-NOT: linalg.copy
   %cst_2 = arith.constant 0.0 : f32
   %0 = tensor.empty() : tensor<32x64xf32>
   %1 = linalg.fill ins(%cst_2 : f32) outs(%0 : tensor<32x64xf32>) -> tensor<32x64xf32>
@@ -186,9 +186,9 @@ func.func @matmuls(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor
 // CHECK-LABEL: matmuls_1
 func.func @matmuls_1(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
   // BUFF-COUNT-3: memref.alloc
-  // BUFF-COUNT-1: memref.copy
+  // BUFF-COUNT-1: linalg.copy
   // BUFFNOTDUP-COUNT-3: memref.alloc
-  // BUFFNOTDUP-COUNT-1: memref.copy
+  // BUFFNOTDUP-COUNT-1: linalg.copy
   // CHECK-COUNT-2: linalg.fill
   %0 = tensor.empty() : tensor<32x32xf32>
   %cst = arith.constant 0.0 : f32


### PR DESCRIPTION
Fix: #813