### PR TITLE
(NFC) Improve `getBinaryFlags`

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmUtils.h
+++ b/include/TPP/Dialect/Xsmm/XsmmUtils.h
@@ -58,8 +58,9 @@ void replaceOpWithUnary(RewriterBase &rewriter, Operation *operation,
 FailureOr<UnaryFlags> getUnaryFlags(Type inputType, Type outputType);
 
 // Compute the broadcasting flags for 'operandType' based on 'outputType'.
+enum class OperandPos { LHS = 0, RHS = 1 };
 FailureOr<BinaryFlags> getBinaryFlags(Type operandType, Type outputType,
-                                      size_t operandNumber);
+                                      OperandPos operandNumber);
 
 } // namespace utils
 } // namespace xsmm

--- a/lib/TPP/Conversion/ConvertTppToXsmm/ConvertTppToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertTppToXsmm/ConvertTppToXsmm.cpp
@@ -230,7 +230,7 @@ struct ConvertTppFusedBrgemmOp : public OpRewritePattern<tpp::FusedBrgemmOp> {
         brgemmOp.getBiasOperand().getType().cast<MemRefType>();
     auto outputType = brgemmOp.getOutputType();
     auto flags = xsmm::utils::getBinaryFlags(binaryInputType, outputType,
-                                             /*operandNumber=*/0);
+                                             xsmm::utils::OperandPos::LHS);
     assert(succeeded(flags));
     return rewriter.getArrayAttr(
         xsmm::BinaryFlagsAttr::get(rewriter.getContext(), *flags));
@@ -444,8 +444,10 @@ struct ConvertTppAddOp : public OpRewritePattern<tpp::AddOp> {
       return rewriter.notifyMatchFailure(addOp, "Cannot compute ldo");
     int64_t ldo = *ldoDim;
 
-    auto bCastOnLhs = xsmm::utils::getBinaryFlags(lhsMemRef, outputMemRef, 0);
-    auto bCastOnRhs = xsmm::utils::getBinaryFlags(rhsMemRef, outputMemRef, 1);
+    auto bCastOnLhs = xsmm::utils::getBinaryFlags(lhsMemRef, outputMemRef,
+                                                  xsmm::utils::OperandPos::LHS);
+    auto bCastOnRhs = xsmm::utils::getBinaryFlags(rhsMemRef, outputMemRef,
+                                                  xsmm::utils::OperandPos::RHS);
     if (failed(bCastOnLhs) || failed(bCastOnRhs))
       return failure();
 

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -220,14 +220,14 @@ FailureOr<UnaryFlags> getUnaryFlags(Type inputType, Type outputType) {
 }
 
 FailureOr<BinaryFlags> getBinaryFlags(Type operandType, Type outputType,
-                                      size_t operandNumber) {
+                                      OperandPos operandNumber) {
   assert(outputType.isa<ShapedType>() && "expect shaped type on output");
   assert(outputType.cast<ShapedType>().getRank() == 2 &&
          "expect rank 2 on output");
 
   if (!operandType.isa<ShapedType>() ||
       operandType.cast<ShapedType>().getRank() == 0) {
-    if (operandNumber == 0)
+    if (operandNumber == OperandPos::LHS)
       return xsmm::BinaryFlags::BCAST_SCALAR_IN_0;
     return xsmm::BinaryFlags::BCAST_SCALAR_IN_1;
   }
@@ -243,28 +243,22 @@ FailureOr<BinaryFlags> getBinaryFlags(Type operandType, Type outputType,
   assert(shapeOutput.size() == 2);
 
   auto getBCastEnum = [](BCastType bCastType,
-                         std::optional<unsigned> operand) -> xsmm::BinaryFlags {
+                         OperandPos operandPos) -> xsmm::BinaryFlags {
     switch (bCastType) {
     case BCastType::NONE:
       return xsmm::BinaryFlags::NONE;
     case BCastType::SCALAR:
-      assert(operand != std::nullopt && "Require operand idx");
-      assert((*operand == 1 || *operand == 0) && "Expect idx to be 1 or 0");
-      if (*operand == 0)
+      if (operandPos == OperandPos::LHS)
         return xsmm::BinaryFlags::BCAST_SCALAR_IN_0;
       else
         return xsmm::BinaryFlags::BCAST_SCALAR_IN_1;
     case BCastType::ROW:
-      assert(operand != std::nullopt && "Require operand idx");
-      assert((*operand == 1 || *operand == 0) && "Expect idx to be 1 or 0");
-      if (*operand == 0)
+      if (operandPos == OperandPos::LHS)
         return xsmm::BinaryFlags::BCAST_ROW_IN_0;
       else
         return xsmm::BinaryFlags::BCAST_ROW_IN_1;
     case BCastType::COL:
-      assert(operand != std::nullopt && "Require operand idx");
-      assert((*operand == 1 || *operand == 0) && "Expect idx to be 1 or 0");
-      if (*operand == 0)
+      if (operandPos == OperandPos::LHS)
         return xsmm::BinaryFlags::BCAST_COL_IN_0;
       else
         return xsmm::BinaryFlags::BCAST_COL_IN_1;

--- a/lib/TPP/Dialect/Xsmm/XsmmVerify.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmVerify.cpp
@@ -132,10 +132,10 @@ static LogicalResult verifyFlags(xsmm::BinaryOp invokeBinaryOp,
                                  xsmm::BinaryDispatchOp dispatchBinaryOp) {
   auto expectedFlagsLhs = xsmm::utils::getBinaryFlags(
       invokeBinaryOp.getInputs()[1].getType(),
-      invokeBinaryOp.getInputs()[3].getType(), /*operandNumber=*/0);
+      invokeBinaryOp.getInputs()[3].getType(), xsmm::utils::OperandPos::LHS);
   auto expectedFlagsRhs = xsmm::utils::getBinaryFlags(
       invokeBinaryOp.getInputs()[2].getType(),
-      invokeBinaryOp.getInputs()[3].getType(), /*operandNumber=*/1);
+      invokeBinaryOp.getInputs()[3].getType(), xsmm::utils::OperandPos::RHS);
   assert(succeeded(expectedFlagsLhs) && succeeded(expectedFlagsRhs));
 
   auto flags = dispatchBinaryOp.getFlags();


### PR DESCRIPTION
Use enum class instead of size_t. It makes the code more readable and avoid checking the operand pos value within the function.