### PR TITLE
Change `mlir-gen` to create bias with broadcast

### DIFF
--- a/test/BF16/Integration/mlir-gen-fc-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-fc-bf16.mlir
@@ -8,8 +8,9 @@
 // BF16-DAG: #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 // BF16-DAG: #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 // BF16-DAG: #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
-// BF16-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// BF16:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x64x48xbf16>, %arg2: tensor<2x16x64x48xbf16>, %arg3: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
+// BF16-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+// BF16-DAG: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// BF16:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x64x48xbf16>, %arg2: tensor<16x48xbf16>, %arg3: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
 // BF16-NOT: alloc
 // BF16:     linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
 // BF16:         arith.mulf
@@ -26,8 +27,9 @@
 // DP2-DAG: #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
 // DP2-DAG: #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
 // DP2-DAG: #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
-// DP2-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// DP2:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x32x48x2xbf16>, %arg2: tensor<2x16x64x48xbf16>, %arg3: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
+// DP2-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+// DP2-DAG: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// DP2:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x32x48x2xbf16>, %arg2: tensor<16x48xbf16>, %arg3: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
 // DP2-NOT: alloc
 // DP2:     linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]
 // DP2:         arith.mulf
@@ -44,8 +46,9 @@
 // DP4-DAG: #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
 // DP4-DAG: #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 4, d5, d3)>
 // DP4-DAG: #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
-// DP4-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// DP4:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x16x48x4xbf16>, %arg2: tensor<2x16x64x48xbf16>, %arg3: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
+// DP4-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+// DP4-DAG: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// DP4:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x16x48x4xbf16>, %arg2: tensor<16x48xbf16>, %arg3: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
 // DP4-NOT: alloc
 // DP4:     linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]
 // DP4:         arith.mulf

--- a/test/Integration/mlir-gen-fc.mlir
+++ b/test/Integration/mlir-gen-fc.mlir
@@ -6,8 +6,9 @@
 // FP32-DAG: #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 // FP32-DAG: #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 // FP32-DAG: #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
-// FP32-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// FP32:     func.func @entry(%arg0: tensor<2x36x64x64xf32>, %arg1: tensor<16x36x64x48xf32>, %arg2: tensor<2x16x64x48xf32>, %arg3: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
+// FP32-DAG: #map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+// FP32-DAG: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// FP32:     func.func @entry(%arg0: tensor<2x36x64x64xf32>, %arg1: tensor<16x36x64x48xf32>, %arg2: tensor<16x48xf32>, %arg3: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
 // FP32-NOT: alloc
 // FP32:     linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
 // FP32:         arith.mulf

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -109,6 +109,7 @@ class MLIRGenerator {
   enum MapType {
     MAP_PARALLEL,
     MAP_REDUCTION,
+    MAP_BROADCAST,
     MAP_MATMUL_INPUT,
     MAP_MATMUL_WEIGHT,
     MAP_MATMUL_OUTPUT,


### PR DESCRIPTION
This commit creates models with bias constant 1D and broadcasts it into the bias add after matmul on MLP models. This is the most common case upstream and is also the only case where we support fused BRGEMM in libxsmm.

I'm explicitly avoiding an extra option because this part of the code is already too complicated to fiddle with and we'll soon be using real IR (from PyTorch etc) to test the passes.