### PR TITLE
Rename `isTppVnniOp` to `isBrgemmVnniOp` (NFC)

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -31,9 +31,9 @@ namespace utils {
 // FIXME: This should be unnecessary but it's still used by convolutions
 bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target);
 
-// Return true if the linalg.generic can convert to a tpp.brgemm in VNNI format.
-bool isTppVnniOp(linalg::GenericOp linalgOp,
-                 SmallVectorImpl<Value> *capturedOperands = nullptr);
+// Return true if the linalg.generic can convert to a brgemm in VNNI format.
+bool isBrgemmVnniOp(linalg::GenericOp linalgOp,
+                    SmallVectorImpl<Value> *capturedOperands = nullptr);
 
 // Returns true if: 1) the region has a single block. 2) The block has a single
 // operation `OP`. 3) The operation result types are int or float.

--- a/lib/TPP/Conversion/ConvertLinalgToTpp/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToTpp/ConvertLinalgToTpp.cpp
@@ -83,7 +83,7 @@ struct ConvertGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
       return success();
     }
 
-    if (tpp::utils::isTppVnniOp(linalgOp, /*captures=*/nullptr)) {
+    if (tpp::utils::isBrgemmVnniOp(linalgOp, /*captures=*/nullptr)) {
       SmallVector<Value> operands = linalgOp.getDpsInputs();
       SmallVector<Value> initOperands = linalgOp.getDpsInits();
       operands.append(initOperands.begin(), initOperands.end());

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -1060,7 +1060,7 @@ struct ConvertGenericToVnniBrgemm : public OpRewritePattern<linalg::GenericOp> {
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     if (!genericOp.hasBufferSemantics() ||
-        !tpp::utils::isTppVnniOp(genericOp, /*captures=*/nullptr)) {
+        !tpp::utils::isBrgemmVnniOp(genericOp, /*captures=*/nullptr)) {
       return failure();
     }
     Value bufferA = genericOp.getDpsInputs()[0];

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -27,7 +27,8 @@ bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target) {
 
 // Return true if the linalg.generic an be mapped to a tpp.brgemm in VNNI
 // format.
-bool isTppVnniOp(linalg::GenericOp linalgOp, SmallVectorImpl<Value> *operands) {
+bool isBrgemmVnniOp(linalg::GenericOp linalgOp,
+                    SmallVectorImpl<Value> *operands) {
   using MapList = ArrayRef<ArrayRef<AffineExpr>>;
   auto infer = [](MapList m) { return AffineMap::inferFromExprList(m); };
   AffineExpr r1, p4, p5, r2, r3;


### PR DESCRIPTION
The name was too general.