### PR TITLE
Do not interchange in `packVNNIMatmulOp`

### DIFF
--- a/include/TPP/Transforms/Utils/VNNIUtils.h
+++ b/include/TPP/Transforms/Utils/VNNIUtils.h
@@ -1,4 +1,4 @@
-//===- VNNIUtils.cpp ---------------------------------------------*- C++-*-===//
+//===- VNNIUtils.h -----------------------------------------------*- C++-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,12 +9,20 @@
 #ifndef TPP_TRANSFORMS_UTILS_VNNIUTILS_H
 #define TPP_TRANSFORMS_UTILS_VNNIUTILS_H
 
+#include "mlir/Support/LogicalResult.h"
 #include <cstdint>
 #include <optional>
 
 namespace mlir {
 class Type;
 class MemRefType;
+class OpOperand;
+class AffineDimExpr;
+class AffineMap;
+
+namespace linalg {
+class GenericOp;
+} // namespace linalg
 
 namespace vnni {
 namespace utils {
@@ -26,11 +34,17 @@ enum class VnniOperandRank {
   BRGEMM_OUTS = 3
 };
 
-// Returns the VNNI blocking factor: 2 for BF16 and 4 for BF8.
+// Return the VNNI blocking factor: 2 for BF16 and 4 for BF8.
 std::optional<int64_t> getVnniBlockingFactor(Type type);
 
 // Return true if the memref is in VNNI layout with rank `expectedRank`.
 bool isInVnniLayout(VnniOperandRank expectedRank, MemRefType memref);
+
+// Return the first AffineDimExpr in the map `affineMap`
+// with a VNNI layout pattern (AffineDimExpr floordiv VNNI).
+FailureOr<AffineDimExpr> isInVnniLayout(linalg::GenericOp linalgOp,
+                                        AffineMap affineMap,
+                                        int64_t blockingFactor);
 
 } // namespace utils
 } // namespace vnni

--- a/test/BF16/brgemm-vnni.mlir
+++ b/test/BF16/brgemm-vnni.mlir
@@ -53,9 +53,9 @@ func.func @prepacked_matmul(%pack: tensor<4x4x32x32xbf16>, %pack_0: tensor<4x4x3
   return %1 : tensor<4x4x32x32xbf16>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d5)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5 floordiv 2, d4, d6)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4)>
 
 // CHECK-LABEL: prepacked_matmul
 // CHECK-SAME:  %[[ARG0:.+]]: tensor<4x4x32x32xbf16>, %[[ARG1:.+]]: tensor<4x4x32x32xbf16>, 
@@ -65,7 +65,7 @@ func.func @prepacked_matmul(%pack: tensor<4x4x32x32xbf16>, %pack_0: tensor<4x4x3
 // CHECK-SAME:  : tensor<4x4x32x32xbf16> -> tensor<4x4x16x32x2xbf16>
 // CHECK: {{.+}} = linalg.generic
 // CHECK-SAME:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME:  iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "reduction"]
 // CHECK-SAME: ins(%[[ARG0]], %[[PACK]]
 // CHECK-SAME: outs(%[[ARG2]]
 

--- a/test/BF16/matmul-untiled-vnni.mlir
+++ b/test/BF16/matmul-untiled-vnni.mlir
@@ -1,11 +1,16 @@
-// RUN: tpp-opt %s --pack-vnni | FileCheck %s
+// RUN: tpp-opt %s -pack-vnni | FileCheck %s
 
 #map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map5 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
 #map6 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
 
-func.func @mlp2(%arg0: tensor<32x64x4x4xbf16>, %arg1: tensor<128x64x4x4xbf16>, %arg2: tensor<32x128x4x4xbf16>) -> tensor<32x128x4x4xbf16> {
-  %0 = linalg.generic {indexing_maps = [#map4, #map5, #map6], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<32x64x4x4xbf16>, tensor<128x64x4x4xbf16>) outs(%arg2 : tensor<32x128x4x4xbf16>) {
+func.func @blocked_matmul(%arg0: tensor<32x64x4x4xbf16>, %arg1: tensor<128x64x4x4xbf16>, 
+                          %arg2: tensor<32x128x4x4xbf16>) -> tensor<32x128x4x4xbf16> {
+  %0 = linalg.generic {
+    indexing_maps = [#map4, #map5, #map6], 
+    iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} 
+    ins(%arg0, %arg1 : tensor<32x64x4x4xbf16>, tensor<128x64x4x4xbf16>) 
+    outs(%arg2 : tensor<32x128x4x4xbf16>) {
   ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
     %4 = arith.mulf %in, %in_0 : bf16
     %5 = arith.addf %out, %4 : bf16
@@ -14,15 +19,15 @@ func.func @mlp2(%arg0: tensor<32x64x4x4xbf16>, %arg1: tensor<128x64x4x4xbf16>, %
   return %0 : tensor<32x128x4x4xbf16>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
-// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
-// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
-// CHECK: func.func @mlp2(
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d3, d5)>
+// CHECK: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d5 floordiv 2, d4, d6)>
+// CHECK: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4)>
+// CHECK: func.func @blocked_matmul(
 // CHECK: %[[ARG0:.*]]: tensor<32x64x4x4xbf16>,
 // CHECK: %[[ARG1:.*]]: tensor<128x64x4x4xbf16>,
 // CHECK: %[[ARG2:.*]]: tensor<32x128x4x4xbf16>) -> tensor<32x128x4x4xbf16> {
 // CHECK:  %[[PACKBUF:.*]] = tensor.empty() : tensor<128x64x2x4x2xbf16>
 // CHECK:  linalg.generic
 // CHECK:  indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK:  iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]
+// CHECK:  iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "reduction"]
 

--- a/test/BF16/matmul-vnni.mlir
+++ b/test/BF16/matmul-vnni.mlir
@@ -12,9 +12,9 @@ func.func @matmul_static(
 }
 
 // CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4 floordiv 2, d3, d1)>
-// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3 floordiv 2, d2, d4)>
+// CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2)>
 
 // CHECK-LABEL: matmul_static
 // CHECK-SAME: %[[ARG0:.+]]: tensor<256x512xbf16>, %[[ARG1:.+]]: tensor<512x1024xbf16>, %[[ARG2:.+]]: tensor<256x1024xbf16>
@@ -38,4 +38,4 @@ func.func @matmul_static(
 // CHECK-SAME:  : tensor<256x1024xbf16> to tensor<32x32xbf16>
 // CHECK: %[[GEMM:.+]] = linalg.generic
 // CHECK-SAME:  indexing_maps = [#[[MAP1]], #[[MAP2]], #[[MAP3]]],
-// CHECK-SAME:  iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]
+// CHECK-SAME:  iterator_types = ["reduction", "parallel", "parallel", "reduction", "reduction"]

--- a/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
+++ b/test/Conversion/LinalgToTpp/linalg-to-tpp-tensor.mlir
@@ -877,15 +877,15 @@ func.func @linalg_matmul_i32(%arg0: tensor<16x16xi32>, %arg1: tensor<16x16xi32>,
 
 // -----
 
-#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
-#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4 floordiv 2, d3, d1)>
-#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d3 floordiv 2, d2, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2)>
 
 func.func @brgemm_tpp(%arg0: tensor<32x32x32xbf16>, %arg1: tensor<32x16x32x2xbf16>,
                       %arg2: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
   %0 = linalg.generic {
     indexing_maps = [#map, #map1, #map2],
-    iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]}
+    iterator_types = ["reduction", "parallel", "parallel", "reduction", "reduction"]}
     ins(%arg0, %arg1 : tensor<32x32x32xbf16>, tensor<32x16x32x2xbf16>) outs(%arg2 : tensor<32x32xbf16>) {
       ^bb0(%in: bf16, %in_7: bf16, %out: bf16):
         %6 = arith.mulf %in, %in_7 : bf16


### PR DESCRIPTION
- Packing introduces an interchange on the packed dimension; there is no
  obvious reason for doing this, and it breaks the "canonical" form. If we
  need to introduce an interchnage, we need to do this explicitly and not
  while packing.

- Make sure we can handle possible interchanges when mapping to BRGEMM.
  See changes in `isBrgemmVnniOp`.