### PR TITLE
Allow printing higher-dim tensors by flattening

### DIFF
--- a/test/Integration/tpp-run-print-high-dim.mlir
+++ b/test/Integration/tpp-run-print-high-dim.mlir
@@ -1,0 +1,9 @@
+// RUN: tpp-run %s -e entry -entry-point-result=void -print | FileCheck %s
+
+func.func @entry(%arg0: memref<2x4x8xf32>) -> memref<2x4x8xf32> {
+  %cst = arith.constant 9.0 : f32
+  linalg.fill ins(%cst : f32) outs(%arg0 : memref<2x4x8xf32>)
+  return %arg0 : memref<2x4x8xf32>
+}
+
+// CHECK-COUNT-8: ( 9, 9, 9, 9, 9, 9, 9, 9 )

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -354,7 +354,7 @@ LogicalResult MLIRBench::printShapedType(mlir::Value val) {
     if (auto tensor = dyn_cast<RankedTensorType>(outputType))
       val = builder.create<tensor::CollapseShapeOp>(unkLoc, val, assocIdx);
     else if (auto memref = dyn_cast<MemRefType>(outputType))
-    val = builder.create<memref::CollapseShapeOp>(unkLoc, val, assocIdx);
+      val = builder.create<memref::CollapseShapeOp>(unkLoc, val, assocIdx);
     else
       llvm_unreachable("Unsupported output shaped type");
 

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -347,24 +347,19 @@ LogicalResult MLIRBench::printShapedType(mlir::Value val) {
   if (rank > 2) {
     // Higher dims into dim 1, last dim remains flat
     SmallVector<ReassociationIndices> assocIdx;
-    ReassociationIndices higherDims;
-    for (int i = 0; i < rank-1; i++)
-      higherDims.push_back(i);
-    assocIdx.push_back(higherDims);
+    assocIdx.push_back(llvm::to_vector(llvm::seq<int64_t>(0, rank - 1)));
     assocIdx.push_back(ReassociationIndices{rank-1});
 
     // Reshape output
-    if (auto tensor = dyn_cast<RankedTensorType>(outputType)) {
+    if (auto tensor = dyn_cast<RankedTensorType>(outputType))
       val = builder.create<tensor::CollapseShapeOp>(unkLoc, val, assocIdx);
-    } else if (auto memref = dyn_cast<MemRefType>(outputType)) {
-      val = builder.create<memref::CollapseShapeOp>(unkLoc, val, assocIdx);
-    } else {
+    else if (auto memref = dyn_cast<MemRefType>(outputType))
+    val = builder.create<memref::CollapseShapeOp>(unkLoc, val, assocIdx);
+    else
       llvm_unreachable("Unsupported output shaped type");
-    }
 
     // Update types
     outputType = cast<ShapedType>(val.getType());
-    outElmType = outputType.getElementType();
   }
 
   // Read into a vector and print output

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -31,6 +32,7 @@
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Perf/PerfOps.h"
@@ -340,9 +342,30 @@ LogicalResult MLIRBench::printShapedType(mlir::Value val) {
 
   Type outElmType = outputType.getElementType();
 
-  // TODO: Support more than 2D sizes
+  // Can only print up to 2D sizes. If it's higher, flatten it to 2D
   auto rank = outputType.getRank();
-  assert((rank == 1 || rank == 2) && "Only supports 1D/2D tensors for now");
+  if (rank > 2) {
+    // Higher dims into dim 1, last dim remains flat
+    SmallVector<ReassociationIndices> assocIdx;
+    ReassociationIndices higherDims;
+    for (int i = 0; i < rank-1; i++)
+      higherDims.push_back(i);
+    assocIdx.push_back(higherDims);
+    assocIdx.push_back(ReassociationIndices{rank-1});
+
+    // Reshape output
+    if (auto tensor = dyn_cast<RankedTensorType>(outputType)) {
+      val = builder.create<tensor::CollapseShapeOp>(unkLoc, val, assocIdx);
+    } else if (auto memref = dyn_cast<MemRefType>(outputType)) {
+      val = builder.create<memref::CollapseShapeOp>(unkLoc, val, assocIdx);
+    } else {
+      llvm_unreachable("Unsupported output shaped type");
+    }
+
+    // Update types
+    outputType = cast<ShapedType>(val.getType());
+    outElmType = outputType.getElementType();
+  }
 
   // Read into a vector and print output
   // We don't want to alloc the whole tensor as a vector,

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -348,7 +348,7 @@ LogicalResult MLIRBench::printShapedType(mlir::Value val) {
     // Higher dims into dim 1, last dim remains flat
     SmallVector<ReassociationIndices> assocIdx;
     assocIdx.push_back(llvm::to_vector(llvm::seq<int64_t>(0, rank - 1)));
-    assocIdx.push_back(ReassociationIndices{rank-1});
+    assocIdx.push_back(ReassociationIndices{rank - 1});
 
     // Reshape output
     if (auto tensor = dyn_cast<RankedTensorType>(outputType))


### PR DESCRIPTION
Flattnes the output shape [[0, 1, ..., N-2] [N-1]] to get a shape that can be easily printed like the others, and be able to CHECK-COUNT, if the last dim has a reasonable size.

Not crucial, but makes testing and debugging packed shapes easier.