### PR TITLE
Remove forward decl for VNNIDialect in Passes.h (NFC)

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -55,10 +55,6 @@ namespace xsmm {
 class XsmmDialect;
 } // namespace xsmm
 
-namespace vnni {
-class VNNIDialect;
-} // namespace vnni
-
 namespace LLVM {
 class LLVMDialect;
 } // namespace LLVM


### PR DESCRIPTION
VNNIDialect was removed in: d09d627