### PR TITLE
Move `isMarkedWithTpp` out from `TppUtils.h` (NFC)

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -27,10 +27,6 @@ class FusedBrgemmOp;
 
 namespace utils {
 
-// Returns true if the linalg operation is marked with 'target'.
-// FIXME: This should be unnecessary but it's still used by convolutions
-bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target);
-
 // Return true if the linalg.generic can convert to a brgemm in VNNI format.
 bool isBrgemmVnniOp(linalg::GenericOp linalgOp,
                     SmallVectorImpl<Value> *capturedOperands = nullptr);

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -19,12 +19,6 @@ namespace mlir {
 namespace tpp {
 namespace utils {
 
-// TODO: Remove this once convolutions stop using it
-bool isMarkedWithTpp(linalg::LinalgOp linalgOp, const std::string &target) {
-  return isa<linalg::GenericOp>(linalgOp) &&
-         linalgOp.getLibraryCallName() == target;
-}
-
 // Return true if the linalg.generic an be mapped to a tpp.brgemm in VNNI
 // format.
 bool isBrgemmVnniOp(linalg::GenericOp linalgOp,


### PR DESCRIPTION
It is used in `RewriteConvsToMatmulOrBrgemm.cpp` and there is not need to expose it. We
are also retiring tpp and we need to move these utils out from the dialect directory.