### PR TITLE
Retire `hasOnlyOp`

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -31,26 +31,6 @@ namespace utils {
 bool isBrgemmVnniOp(linalg::GenericOp linalgOp,
                     SmallVectorImpl<Value> *capturedOperands = nullptr);
 
-// Returns true if: 1) the region has a single block. 2) The block has a single
-// operation `OP`. 3) The operation result types are int or float.
-template <typename OP> static bool hasOnlyOp(Region &region) {
-  if (!region.hasOneBlock())
-    return false;
-  unsigned numberOfOpsInRegion = 2;
-  if (std::is_same<OP, linalg::YieldOp>::value)
-    numberOfOpsInRegion = 1;
-  if (std::distance(region.front().begin(), region.front().end()) !=
-      numberOfOpsInRegion)
-    return false;
-  for (Operation &op : region.front()) {
-    if (!isa<OP, linalg::YieldOp>(op) ||
-        llvm::any_of(op.getResultTypes(),
-                     [](Type type) { return !type.isIntOrFloat(); }))
-      return false;
-  }
-  return true;
-}
-
 // Splits and replaces fused op with its individual components.
 // Temporary workaround for:
 // https://github.com/libxsmm/libxsmm/issues/766


### PR DESCRIPTION
Retire `hasOnlyOp` from `TppUtils.h` and use matchers in `ConvInitSimplify.cpp` to detect add and bias operation.