### PR TITLE
Allow conversion for VNNI layout matmul in linalg to xsmm

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -28,7 +28,7 @@ class FusedBrgemmOp;
 namespace utils {
 
 // Return true if the linalg.generic can convert to a brgemm in VNNI format.
-bool isBrgemmVnniOp(linalg::GenericOp linalgOp,
+bool isBrgemmVnniOp(linalg::GenericOp linalgOp, bool &hasBatch,
                     SmallVectorImpl<Value> *capturedOperands = nullptr);
 
 // Splits and replaces fused op with its individual components.

--- a/lib/TPP/Conversion/ConvertLinalgToTpp/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToTpp/ConvertLinalgToTpp.cpp
@@ -83,7 +83,8 @@ struct ConvertGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
       return success();
     }
 
-    if (tpp::utils::isBrgemmVnniOp(linalgOp, /*captures=*/nullptr)) {
+    bool hasBatch = false;
+    if (tpp::utils::isBrgemmVnniOp(linalgOp, hasBatch, /*captures=*/nullptr)) {
       SmallVector<Value> operands = linalgOp.getDpsInputs();
       SmallVector<Value> initOperands = linalgOp.getDpsInits();
       operands.append(initOperands.begin(), initOperands.end());

--- a/test/Conversion/LinalgToXsmm/linalg-to-gemm.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-gemm.mlir
@@ -143,3 +143,220 @@ func.func @mha_projection(%arg0: memref<512x8x64xf32>, %arg1: memref<64x32x512xf
 // CHECK-SAME:  : memref<512x8x64xf32> to memref<512x64xf32, strided<[512, 1], offset: ?>>
 // CHECK: %[[GEMM:.+]] = xsmm.gemm.dispatch [32, 64, 512, 512, 512, 512] flags = (none) data_type = f32
 // CHECK: xsmm.gemm(data_type = f32, %[[GEMM]], %[[SUB_0]], %[[SUB_1]], %[[SUB]])
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3 floordiv 2, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+
+func.func @vnni_gemm(%arg0: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<32x64x2xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]} 
+    ins(%arg0, %arg1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>, memref<32x64x2xbf16>) 
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: vnni_gemm
+// CHECK-SAME:  %[[ARG0:.+]]: memref<64x64xbf16, strided<[64, 1], offset: ?>>, 
+// CHECK-SAME:  %[[ARG1:.+]]: memref<32x64x2xbf16>, 
+// CHECK-SAME:  %[[ARG2:.+]]: memref<64x64xbf16, strided<[64, 1], offset: ?>>
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [64, 64, 64, 64, 64, 64] flags = (vnni_b) data_type = bf16
+// CHECK: xsmm.gemm(data_type = bf16, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]])
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3 floordiv 2, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+
+// Require a transpose on C.
+func.func @expect_not_to_match_vnni_gemm(%arg0: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<32x64x2xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]} 
+    ins(%arg0, %arg1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>, memref<32x64x2xbf16>) 
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: expect_not_to_match_vnni_gemm
+// CHECK-NOT: xsmm.gemm
+// CHECK: linalg.generic
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3 floordiv 5, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+
+// Not VNNI layout.
+func.func @expect_not_to_match_vnni_gemm(%arg0: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<32x64x2xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>, memref<32x64x2xbf16>)
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: expect_not_to_match_vnni_gemm
+// CHECK-NOT: xsmm.gemm
+// CHECK: linalg.generic
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d3, d1)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3 floordiv 2, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+
+// Require a transpose on A.
+func.func @expect_not_to_match_vnni_gemm(%arg0: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<32x64x2xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>, memref<32x64x2xbf16>)
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: expect_not_to_match_vnni_gemm
+// CHECK-NOT: xsmm.gemm
+// CHECK: linalg.generic
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d2 floordiv 2, d1, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+func.func @vnni_gemm_interchanged(%arg0: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<32x64x2xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["parallel", "parallel", "reduction", "reduction"]}
+    ins(%arg0, %arg1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>, memref<32x64x2xbf16>)
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: vnni_gemm_interchanged
+// CHECK-SAME:  %[[ARG0:.+]]: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<32x64x2xbf16>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<64x64xbf16, strided<[64, 1], offset: ?>>
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [64, 64, 64, 64, 64, 64] flags = (vnni_b) data_type = bf16
+// CHECK: xsmm.gemm(data_type = bf16, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]])
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3 floordiv 2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d2, d1)>
+
+// Not VNNI layout.
+func.func @expect_not_to_match_vnni_gemm(%arg0: memref<64x64xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<2x64x32xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>, memref<2x64x32xbf16>)
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: expect_not_to_match_vnni_gemm
+// CHECK-NOT: xsmm.gemm
+// CHECK: linalg.generic
+
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3 floordiv 2, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+
+func.func @vnni_gemm(%arg0: memref<64x16xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<8x64x2xbf16>, %arg2: memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2], 
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : memref<64x16xbf16, strided<[64, 1], offset: ?>>, memref<8x64x2xbf16>)
+    outs(%arg2 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: vnni_gemm
+// CHECK-SAME:  %[[ARG0:.+]]: memref<64x16xbf16, strided<[64, 1], offset: ?>>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<8x64x2xbf16>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<64x64xbf16, strided<[64, 1], offset: ?>>
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [64, 64, 16, 64, 64, 64] flags = (vnni_b) data_type = bf16
+// CHECK: xsmm.gemm(data_type = bf16, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]])
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3 floordiv 2, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+
+func.func @vnni_gemm(%arg0: memref<4x16xbf16, strided<[64, 1], offset: ?>>,
+  %arg1: memref<8x64x2xbf16>, %arg2: memref<4x64xbf16, strided<[64, 1], offset: ?>>) {
+  linalg.generic {
+    indexing_maps = [#map, #map1, #map2],
+    iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+    ins(%arg0, %arg1 : memref<4x16xbf16, strided<[64, 1], offset: ?>>, memref<8x64x2xbf16>)
+    outs(%arg2 : memref<4x64xbf16, strided<[64, 1], offset: ?>>) {
+      ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
+        %1 = arith.mulf %in, %in_2 : bf16
+        %2 = arith.addf %out, %1 : bf16
+        linalg.yield %2 : bf16
+    }
+  return
+}
+
+// CHECK-LABEL: vnni_gemm
+// CHECK-SAME:  %[[ARG0:.+]]: memref<4x16xbf16, strided<[64, 1], offset: ?>>,
+// CHECK-SAME:  %[[ARG1:.+]]: memref<8x64x2xbf16>,
+// CHECK-SAME:  %[[ARG2:.+]]: memref<4x64xbf16, strided<[64, 1], offset: ?>>
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [4, 64, 16, 64, 64, 64] flags = (vnni_b) data_type = bf16
+// CHECK: xsmm.gemm(data_type = bf16, %[[DIS]], %[[ARG0]], %[[ARG1]], %[[ARG2]])


### PR DESCRIPTION
Matmuls are BRGEMMs without a batch dimension, this is true also in the VNNI layout. This PR made some changes to `isBrgemmVnniOp` and `ConvertGenericToVnniBrgemm` to allow matmuls lowering in VNNI layout.

Fix: #806