### PR TITLE
Erase ops through rewriter hook

### DIFF
--- a/lib/TPP/Transforms/CombineXsmmPass.cpp
+++ b/lib/TPP/Transforms/CombineXsmmPass.cpp
@@ -176,12 +176,13 @@ struct CombineXsmmOp : public OpRewritePattern<xsmm::BrgemmOp> {
 
     // Replace and delete the old invokes and their dispatches
     rewriter.create<xsmm::FusedBrgemmOp>(loc, dtype, invokeOperands);
-    brgemmOp.erase();
-    brgemmOp.getOperand(0).getDefiningOp()->erase();
-    fusedMatch.binaryOp->erase();
-    fusedMatch.binaryOp->getOperand(0).getDefiningOp()->erase();
-    fusedMatch.unaryOp->erase();
-    fusedMatch.unaryOp->getOperand(0).getDefiningOp()->erase();
+    rewriter.eraseOp(brgemmOp);
+    rewriter.eraseOp(brgemmOp.getOperand(0).getDefiningOp());
+    rewriter.eraseOp(fusedMatch.binaryOp);
+    rewriter.eraseOp(fusedMatch.binaryOp->getOperand(0).getDefiningOp());
+    rewriter.eraseOp(fusedMatch.unaryOp);
+    rewriter.eraseOp(fusedMatch.unaryOp->getOperand(0).getDefiningOp());
+
     return success();
   }
 };

--- a/test/Passes/xsmm-combine.mlir
+++ b/test/Passes/xsmm-combine.mlir
@@ -37,7 +37,13 @@ func.func @bcast_col_in0_on_binary_add(%arg0: memref<256x128xf32>) -> memref<256
 // CHECK-LABEL: func.func @bcast_col_in0_on_binary_add(
 // CHECK: %[[ARG0:.*]]: memref<256x128xf32>) -> memref<256x512xf32> {
 // CHECK: %[[BIAS:.*]] = memref.get_global @__constant_32xf32 : memref<32xf32, strided<[32], offset: ?>> 
+// CHECK-NOT: xsmm.brgemm.dispatch
+// CHECK-NOT: xsmm.unary.dispatch
+// CHECK-NOT: xsmm.binary.dispatch
 // CHECK: %[[DISPATCH:.*]] = xsmm.fused_brgemm.dispatch [32, 32, 32, 32, 32, 32, 1024, 1024][add,relu]  flags = (beta_0)  binary_flags = (bcast_col_in0)  unary_flags = (none) data_type = f32
+// CHECK-NOT: xsmm.brgemm(
+// CHECK-NOT: xsmm.binary add
+// CHECK-NOT: xsmm.unary relu
 // CHECK: xsmm.fused_brgemm(data_type = f32, %[[DISPATCH]], %{{.*}}, %{{.*}}, %{{.*}}, %[[BIAS]], %{{.*}})
 
 


### PR DESCRIPTION
Use rewriter erase method within combine XSMM pass to adhere to Pattern Rewriter restrictions.
This fixes double free error caused by direct erase method call.

Also, extra checks are added to ensure that relevant ops are erased.