### PR TITLE
Remove forward decl for `TppDialect` (NFC)

### DIFF
--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -61,7 +61,6 @@ class TensorDialect;
 } // namespace tensor
 
 namespace tpp {
-class TppDialect;
 
 // Testing passes.
 void registerTestStructuralMatchers();


### PR DESCRIPTION
This is a leftover after 12b35b549aa0cd2e8d53ba4573feaea783d9651b. 