### PR TITLE
Housekeeping for default pipeline (NFC)

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -307,19 +307,8 @@ def TppMapping : Pass<"tpp-mapping", "ModuleOp"> {
   }];
 }
 
-def TppConversion : Pass<"tpp-conversion", "func::FuncOp"> {
-  let summary = "Convert operations to TPP";
-  let description = [{
-    Convert all eligble operations into TPP operations.
-  }];
-}
-
-def TppLowering : Pass<"tpp-lowering", "func::FuncOp"> {
-  let summary = "Lower TPP operations";
-  let description = [{
-    Lower all TPP operations into combination of operations from
-    standard and local dialects.
-  }]; 
+def LinalgLowering : Pass<"linalg-lowering", "func::FuncOp"> {
+  let summary = "Lower Linalg operations to XSMM operations.";
 }
 
 def ConvertForAllToParallelOp : Pass<"convert-forall-to-parallel", 


### PR DESCRIPTION
Rename `TppLowering` to `LinalgLowering`. Tpp is removed and now we jump from linalg to xsmm directly.

`TppConversion` is no needed anymore.