### PR TITLE
Apply clang-tidy fixes (NFC)

### DIFF
--- a/lib/TPP/GPU/LinalgToGpu.cpp
+++ b/lib/TPP/GPU/LinalgToGpu.cpp
@@ -48,7 +48,7 @@ createGpuBlocksWrapper(Operation *op, ArrayRef<int64_t> blockDims,
 
   auto loc = op->getLoc();
 
-  auto parentOp = op->getParentOp();
+  auto *parentOp = op->getParentOp();
   if (isa<scf::ParallelOp>(parentOp))
     return std::nullopt;
 
@@ -242,7 +242,7 @@ static Operation *fuseEltwiseConsumers(linalg::LinalgOp rootOp,
                                        Operation *rootStoreOp,
                                        ValueRange storeIndices,
                                        PatternRewriter &rewriter) {
-  auto parentOp = rootOp->getParentOp();
+  auto *parentOp = rootOp->getParentOp();
   auto rootOutput = rootOp.getDpsInits()[0];
 
   // Traverse other ops within the same region and collect consumers.

--- a/lib/TPP/GPU/LinalgToGpu.cpp
+++ b/lib/TPP/GPU/LinalgToGpu.cpp
@@ -543,8 +543,7 @@ struct ConvertGemmToGpu : public OpRewritePattern<linalg::MatmulOp> {
 
     if (useWmma && supportsMMACompute(matmulOp))
       return gemmToGpuMMA(matmulOp, rewriter);
-    else
-      return gemmToGpuLoops(matmulOp, rewriter);
+    return gemmToGpuLoops(matmulOp, rewriter);
   }
 
 private:
@@ -572,8 +571,7 @@ struct ConvertBrgemmToGpu
 
     if (useWmma && supportsMMACompute(brgemmOp))
       return gemmToGpuMMA(brgemmOp, rewriter);
-    else
-      return gemmToGpuLoops(brgemmOp, rewriter);
+    return gemmToGpuLoops(brgemmOp, rewriter);
   }
 
 private:

--- a/lib/TPP/GPU/SetSPIRVCapabilities.cpp
+++ b/lib/TPP/GPU/SetSPIRVCapabilities.cpp
@@ -40,7 +40,7 @@ struct SetSPIRVCapabilities
 
   void runOnOperation() override {
     namespace spirv = mlir::spirv;
-    auto context = &getContext();
+    auto *context = &getContext();
     spirv::Capability caps_opencl[] = {
         // clang-format off
         spirv::Capability::Addresses,

--- a/lib/TPP/IR/MatcherUtils.cpp
+++ b/lib/TPP/IR/MatcherUtils.cpp
@@ -302,9 +302,9 @@ static bool hasReluBody(Operation *op, SmallVectorImpl<Value> *captured) {
           mlir::utils::isZeroTensor(falseVal)) {
         // case: %in > 0 ? %in : 0
         return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
-      } else if (mlir::utils::isZeroTensor(cmpLhs) &&
-                 mlir::utils::isZeroTensor(trueVal) &&
-                 cmpRhs == falseVal) {
+      }
+      if (mlir::utils::isZeroTensor(cmpLhs) &&
+          mlir::utils::isZeroTensor(trueVal) && cmpRhs == falseVal) {
         // case: 0 > %in ? 0 : %in
         return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
       }
@@ -315,9 +315,9 @@ static bool hasReluBody(Operation *op, SmallVectorImpl<Value> *captured) {
           mlir::utils::isZeroTensor(trueVal)) {
         // case: %in < 0 ? 0 : %in
         return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
-      } else if (mlir::utils::isZeroTensor(cmpLhs) &&
-                 mlir::utils::isZeroTensor(falseVal) &&
-                 cmpRhs == trueVal) {
+      }
+      if (mlir::utils::isZeroTensor(cmpLhs) &&
+          mlir::utils::isZeroTensor(falseVal) && cmpRhs == trueVal) {
         // case: 0 < %in ? %in : 0
         return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
       }

--- a/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
@@ -179,7 +179,7 @@ static bool isIdentityMapWithZeros(AffineMap map) {
 }
 
 // Helper fuction to print a bit vector.
-static void printBitVector(std::string banner,
+static void printBitVector(const std::string &banner,
                            const llvm::SmallBitVector &bitVector,
                            llvm::raw_ostream &os) {
   os << banner << "  ";

--- a/lib/TPP/Transforms/TransformUtils.cpp
+++ b/lib/TPP/Transforms/TransformUtils.cpp
@@ -33,7 +33,7 @@ Value expand(OpBuilder &builder, Location loc, Value val, Type newType,
   if (newType.isa<RankedTensorType>()) {
     return builder.create<tensor::ExpandShapeOp>(loc, newType, val,
                                                  reassociationMap);
-  } else if (newType.isa<MemRefType>()) {
+  } if (newType.isa<MemRefType>()) {
     return builder.create<memref::ExpandShapeOp>(loc, newType, val,
                                                  reassociationMap);
   }
@@ -48,7 +48,7 @@ Value collapse(OpBuilder &builder, Location loc, Value val, Type newType,
   if (newType.isa<RankedTensorType>()) {
     return builder.create<tensor::CollapseShapeOp>(loc, newType, val,
                                                    reassociationMap);
-  } else if (newType.isa<MemRefType>()) {
+  } if (newType.isa<MemRefType>()) {
     return builder.create<memref::CollapseShapeOp>(loc, newType, val,
                                                    reassociationMap);
   }


### PR DESCRIPTION
- Apply clang-tidy fixes for llvm-else-after-return in TransformUtils.cpp (NFC)

- Apply clang-tidy fixes for performance-unnecessary-value-param in TilleConsumerAndFuseProducers.cpp (NFC)

- Apply clang-tidy fixes for llvm-else-after-return in MatcherUtils.cpp (NFC)

- Apply clang-tidy fixes for llvm-qualified-auto in SetSPIRVCapabilities.cpp (NFC)

- Apply clang-tidy fixes for llvm-else-after-return in LinalgToGpu.cpp (NFC)

- Apply clang-tidy fixes for llvm-qualified-auto in LinalgToGpu.cpp (NFC)