### PR TITLE
Update includes for `MLIRGen.cpp`

### DIFF
--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -1,6 +1,8 @@
-//===- MLIRGen.h MLIR Generator -------------------------------------------===//
+//===- MLIRGen.cpp -----------------------------------------------*- C++-*-===//
 //
-// Class that handles MLIR generation for the MLIR options.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 
@@ -8,22 +10,11 @@
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/BuiltinDialect.h"
-#include "mlir/IR/BuiltinTypeInterfaces.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Diagnostics.h"
-#include "mlir/IR/ValueRange.h"
-#include "mlir/InitAllDialects.h"
-
-#include <cstddef>
-#include <optional>
-#include <string>
 
 #include "MLIRGen.h"
 #include "llvm/Support/ErrorHandling.h"


### PR DESCRIPTION
InitAllDialects.h is a too big hammer here. We can selectively include the dialects we need.