### PR TITLE
(NFC) Rename `ProjectedPermutation` to `BroadcastableProjectedPermuta…

### DIFF
--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -108,12 +108,12 @@ struct HasMap {
   AffineMap *ptrMap = nullptr;
 };
 
-// Callble object to verify if `map` is a projected permutation map.
-// We require the dimensions to be in sorted order this avoid filtering
+// Callble object to verify if `map` is a broadcastable projected permutation
+// map. We require the dimensions to be in sorted order this avoid filtering
 // projected permutation without broadcasting semantics, for example
 // affine_map<(d0, d1) -> (d1, d0)> is rejected.
-struct ProjectedPermutation {
-  ProjectedPermutation() = default;
+struct BroadcastableProjectedPermutation {
+  BroadcastableProjectedPermutation() = default;
 
   bool operator()(AffineMap map) const {
     if (map.getNumSymbols() > 0 || map.getNumResults() > map.getNumInputs())
@@ -130,8 +130,9 @@ struct ProjectedPermutation {
       } else if (auto constExpr = dyn_cast<AffineConstantExpr>(expr)) {
         if (constExpr.getValue() != 0)
           return false;
-      } else
+      } else {
         return false;
+      }
     }
     return llvm::is_sorted(pos);
   }

--- a/lib/TPP/IR/MatcherUtils.cpp
+++ b/lib/TPP/IR/MatcherUtils.cpp
@@ -56,9 +56,9 @@ std::pair<bool, bool> isBrgemmVnniOp(linalg::GenericOp linalgOp,
           .operation(NumOfLoops(_OR(EqualsTo(5), EqualsTo(4))))
           .input(MatchAll(), HasStaticShape())
           .output(MatchAll(), HasStaticShape())
-          .input(MatchOne(0), HasMap(ProjectedPermutation(), &mapOperandA))
+          .input(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &mapOperandA))
           .input(MatchOne(1), HasMap(Any(), &mapOperandB))
-          .output(MatchOne(0), HasMap(ProjectedPermutation(), &mapOperandC))
+          .output(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &mapOperandC))
           .region(MatchOne(0),
                   WithOpChain<arith::MulFOp, arith::AddFOp>(operands));
   // clang-format on
@@ -172,7 +172,7 @@ static bool isTppBinaryOp(linalg::LinalgOp linalgOp) {
           .dim(MatchAll(), mlir::utils::IteratorType::parallel)
           .operation(NumOfLoops(EqualsTo(2)))
           .output(MatchAll(), HasMap(Identity()))
-          .input(MatchAll(), HasMap(ProjectedPermutation()));
+          .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()));
   // clang-format on
   return isTppOp(linalgOp) && binaryMatcher.match(linalgOp);
 }
@@ -351,7 +351,7 @@ bool isTwoDReluOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
   auto reluMatcher =
     StructuredOpMatcher::make<linalg::LinalgOp>()
     .output(MatchAll(), HasMap(Identity()))
-    .input(MatchAll(), HasMap(ProjectedPermutation()))
+    .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
     .region(MatchOne(0), WithReluBody(operands));
   // clang-format on
   return isTppUnaryOp(linalgOp) && reluMatcher.match(linalgOp);
@@ -365,7 +365,7 @@ bool isTwoDIdentityOp(linalg::LinalgOp linalgOp,
   auto identityMatcher = 
     StructuredOpMatcher::make<linalg::LinalgOp>()
     .output(MatchAll(), HasMap(Identity()))
-    .input(MatchAll(), HasMap(ProjectedPermutation()))
+    .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
     .region(
       MatchOne(0), WithSingleOp<linalg::YieldOp>(&linalgOperands));
   // clang-format on
@@ -387,7 +387,7 @@ bool isTwoDZeroOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
   auto zeroMatcher = 
     StructuredOpMatcher::make<linalg::LinalgOp>()
     .output(MatchAll(), HasMap(Identity()))
-    .input(MatchAll(), HasMap(ProjectedPermutation()))
+    .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
     .region(MatchOne(0), WithSingleOp<linalg::YieldOp>());
   // clang-format on
 

--- a/lib/TPP/Transforms/ConvInitSimplify.cpp
+++ b/lib/TPP/Transforms/ConvInitSimplify.cpp
@@ -35,7 +35,7 @@ static bool isBroadCastOp(linalg::GenericOp linalgOp) {
     .operation(NumDpsInits(EqualsTo(1)))
     .operation(NumDpsInputs(EqualsTo(1)))
     .output(MatchAll(), HasMap(Identity()))
-    .input(MatchOne(0), HasMap(ProjectedPermutation(), &inputMap))
+    .input(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &inputMap))
     .region(
       MatchOne(0), WithSingleOp<linalg::YieldOp>(/*operands=*/nullptr));
   // clan-format on

--- a/lib/TPP/Transforms/LinalgDeGeneralize.cpp
+++ b/lib/TPP/Transforms/LinalgDeGeneralize.cpp
@@ -132,7 +132,7 @@ struct FillOpDeGeneralizationPattern
             .operation(NumRegions(EqualsTo(1)))
             .dim(MatchAll(), mlir::utils::IteratorType::parallel)
             .output(MatchAll(), HasMap(Identity()))
-            .input(MatchAll(), HasMap(ProjectedPermutation()))
+            .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
             .input(MatchAll(), HasRank({HasRank::SCALAR}))
             .region(MatchOne(0),
                     WithSingleOp<linalg::YieldOp>(/*captures=*/nullptr));

--- a/test/TestLib/TestMatchers.cpp
+++ b/test/TestLib/TestMatchers.cpp
@@ -128,7 +128,7 @@ void testTppIdentity(FunctionOpInterface funcOp) {
       .output(MatchAll(), HasStaticShape())
       .input(MatchAll(), HasStaticShape())
       .output(MatchAll(), HasMap(Identity()))
-      .input(MatchAll(), HasMap(ProjectedPermutation()))
+      .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
       .region(MatchOne(0), WithSingleOp<linalg::YieldOp>(&operands));
   // clang-format on
 
@@ -147,9 +147,9 @@ void testCaptureAffineMaps(FunctionOpInterface funcOp) {
     StructuredOpMatcher::make<linalg::GenericOp>()
       .operation(NumDpsInits(EqualsTo(1)))
       .operation(NumDpsInputs(EqualsTo(2)))
-      .input(MatchOne(0), HasMap(ProjectedPermutation(), &aMap))
+      .input(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &aMap))
       .input(MatchOne(1), HasMap(Any(), &bMap))
-      .output(MatchOne(0), HasMap(ProjectedPermutation(), &cMap));
+      .output(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &cMap));
   // clang-format on
   funcOp->walk([&](linalg::LinalgOp linalgOp) {
     if (matcher.match(linalgOp)) {
@@ -169,8 +169,8 @@ void testCaptureAffineMapsExpectToFail(FunctionOpInterface funcOp) {
       .operation(NumDpsInits(EqualsTo(1)))
       .operation(NumDpsInputs(EqualsTo(2)))
       .input(MatchOne(0), HasMap(Identity(), &aMap))
-      .input(MatchOne(1), HasMap(ProjectedPermutation(), &bMap))
-      .output(MatchOne(0), HasMap(ProjectedPermutation(), &cMap));
+      .input(MatchOne(1), HasMap(BroadcastableProjectedPermutation(), &bMap))
+      .output(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &cMap));
   // clang-format on
   funcOp->walk([&](linalg::LinalgOp linalgOp) {
     if (matcher.match(linalgOp)) {


### PR DESCRIPTION
…tion`

The name was misleading, as we are also checking if the permutation is broadcastable by requiring all the dimensions to be in sorted order.