### PR TITLE
Rename mlir-gen training/inference to const/args

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -31,42 +31,42 @@
     },
     "gemm_fp32_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "gemm_bf16_dp2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "gemm_bf16_dp4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
     },
     "mlp_fp32_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "mlp_bf16_dp2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "mlp_bf16_dp4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
@@ -76,28 +76,28 @@
   "gemm_models": {
     "fp32_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "avx2" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "avx2" ]
@@ -107,28 +107,28 @@
   "mlp_models": {
     "fp32_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "avx2" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "avx2" ]

--- a/benchmarks/config/fc/1024x1024x512.json
+++ b/benchmarks/config/fc/1024x1024x512.json
@@ -37,14 +37,14 @@
   "fc_1024x1024x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x1024x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x1024x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x2560x1024.json
+++ b/benchmarks/config/fc/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "fc_1024x2560x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x2560x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x2560x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x352x512.json
+++ b/benchmarks/config/fc/1024x352x512.json
@@ -37,14 +37,14 @@
   "fc_1024x352x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x352x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x352x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x512x256.json
+++ b/benchmarks/config/fc/1024x512x256.json
@@ -37,14 +37,14 @@
   "fc_1024x512x256_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x512x256_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x512x256_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x1024.json
+++ b/benchmarks/config/fc/128x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_128x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x4096.json
+++ b/benchmarks/config/fc/128x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_128x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x3072x768.json
+++ b/benchmarks/config/fc/128x3072x768.json
@@ -37,14 +37,14 @@
   "fc_128x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x4096x1024.json
+++ b/benchmarks/config/fc/128x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_128x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x2304.json
+++ b/benchmarks/config/fc/128x768x2304.json
@@ -37,14 +37,14 @@
   "fc_128x768x2304_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x2304_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x2304_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x3072.json
+++ b/benchmarks/config/fc/128x768x3072.json
@@ -37,14 +37,14 @@
   "fc_128x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x768.json
+++ b/benchmarks/config/fc/128x768x768.json
@@ -37,14 +37,14 @@
   "fc_128x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x1024.json
+++ b/benchmarks/config/fc/256x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_256x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x4096.json
+++ b/benchmarks/config/fc/256x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_256x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x3072x768.json
+++ b/benchmarks/config/fc/256x3072x768.json
@@ -37,14 +37,14 @@
   "fc_256x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x4096x1024.json
+++ b/benchmarks/config/fc/256x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_256x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x3072.json
+++ b/benchmarks/config/fc/256x768x3072.json
@@ -37,14 +37,14 @@
   "fc_256x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x768.json
+++ b/benchmarks/config/fc/256x768x768.json
@@ -37,14 +37,14 @@
   "fc_256x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x1024x512.json
+++ b/benchmarks/config/matmul/1024x1024x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x1024x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x1024x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x1024x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x2560x1024.json
+++ b/benchmarks/config/matmul/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "matmul_1024x2560x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x2560x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x2560x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x352x512.json
+++ b/benchmarks/config/matmul/1024x352x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x352x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x352x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x352x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x512x256.json
+++ b/benchmarks/config/matmul/1024x512x256.json
@@ -37,14 +37,14 @@
   "matmul_1024x512x256_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x512x256_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x512x256_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x1024.json
+++ b/benchmarks/config/matmul/128x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x3072x768.json
+++ b/benchmarks/config/matmul/128x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_128x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x4096x1024.json
+++ b/benchmarks/config/matmul/128x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x2304.json
+++ b/benchmarks/config/matmul/128x768x2304.json
@@ -37,14 +37,14 @@
   "matmul_128x768x2304_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x2304_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x2304_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x3072.json
+++ b/benchmarks/config/matmul/128x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_128x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x768.json
+++ b/benchmarks/config/matmul/128x768x768.json
@@ -37,14 +37,14 @@
   "matmul_128x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x1024.json
+++ b/benchmarks/config/matmul/256x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x4096.json
+++ b/benchmarks/config/matmul/256x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x3072x768.json
+++ b/benchmarks/config/matmul/256x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_256x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x4096x1024.json
+++ b/benchmarks/config/matmul/256x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x3072.json
+++ b/benchmarks/config/matmul/256x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_256x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x768.json
+++ b/benchmarks/config/matmul/256x768x768.json
@@ -37,14 +37,14 @@
   "matmul_256x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=training --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -3,28 +3,28 @@
   "gemm_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -34,28 +34,28 @@
   "mlp_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/config/omp/mlir-fp32.json
+++ b/benchmarks/config/omp/mlir-fp32.json
@@ -3,28 +3,28 @@
   "gemm_fp32_mlir": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -34,28 +34,28 @@
   "mlp_fp32_mlir": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=inference --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -36,7 +36,7 @@
              },
              "irgen": {
                  "type": "IR-GEN",
-                 "benchmark": [ "mlir-gen", "--kernel=inference --float-width=16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
+                 "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
                  "environment": { "OMP_NUM_THREADS": "32" },
                  "flags": [ "-n", "100" ],
                  "extensions": [ "(avx2|asimd)" ]

--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -30,7 +30,7 @@ Examples:
 // Generates an MLP with `mlir-gen`, uses `meld`
 ./scripts/debug/debug_all_passes.sh \
   -b ./build/bin \
-  -m "--kernel=inference --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" \
+  -m "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" \
   -d meld
 
 // Default behaviour, runs `mlir-gen` & `tpp-opt` without args, uses `diff`

--- a/test/BF16/Integration/mlir-gen-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-bf16.mlir
@@ -1,18 +1,18 @@
 // MLP without softmax (can't print packed version for now)
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
 
 // Matmul only
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=training --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
+// RUN: mlir-gen --kernel=args --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=training --bias --relu --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
+// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
 
 // BF16/VNNI execution
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
 // GEN-MATMUL-BF16: ( 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 )
 

--- a/test/BF16/Integration/mlir-gen-fc-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-fc-bf16.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/BF16/Integration/mlir-gen-matmul-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-matmul-bf16.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen-fc.mlir
+++ b/test/Integration/mlir-gen-fc.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen-flops.mlir
+++ b/test/Integration/mlir-gen-flops.mlir
@@ -1,19 +1,19 @@
 // Unit sizes
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
 // Small sizes
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
 // Large sizes + no tiling
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
 // Large sizes + tiling
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --kernel=training --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
 
 // Validate that flops are computed correctly
 // MATMUL-UNIT: // BENCH_TOTAL_FLOPS: 2

--- a/test/Integration/mlir-gen-matmul.mlir
+++ b/test/Integration/mlir-gen-matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --kernel=training --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen.mlir
+++ b/test/Integration/mlir-gen.mlir
@@ -1,24 +1,24 @@
 // MLP with Softmax version
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10,10 --softmax | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --softmax | tpp-run -e entry -entry-point-result=void
 
 // MLP without softmax
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 | tpp-run -e entry -entry-point-result=void
 
 // Matmul only
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void
 
 // Constant values
-// RUN: mlir-gen --kernel=inference --bias --relu --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
+// RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=training --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
+// RUN: mlir-gen --kernel=args --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=training --bias --relu --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
+// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
 
 // Packed versions
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=inference --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
 // CONSTANT:( 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 )
 

--- a/test/Integration/xsmm-fusion-mlirgen.mlir
+++ b/test/Integration/xsmm-fusion-mlirgen.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen   --kernel=inference --bias --relu --seed=123 | tpp-run -e entry --entry-point-result=void -print-mlir=mid  2>&1 | FileCheck %s
+// RUN: mlir-gen   --kernel=const --bias --relu --seed=123 | tpp-run -e entry --entry-point-result=void -print-mlir=mid  2>&1 | FileCheck %s
 
 // CHECK: func.func @_entry(%arg0: memref<256x128xf32>) -> memref<256x512xf32>  {
 // CHECK: call @xsmm_fused_brgemm_dispatch

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -75,9 +75,9 @@ class MLIRGenerator {
   bool enableSoftmax;
 
   /// List of supported kernel types that can be generated
-  ///  * Inference: Generates weights and biases as constant (RO).
-  ///  * Training: Generates weights and biaseds as arguments (RW).
-  enum class KernelType { Inference, Training };
+  ///  * Const: Generates weights and biases as constant (RO).
+  ///  * Args: Generates weights and biaseds as arguments (RW).
+  enum class KernelType { Const, Args };
 
   /// Type of kernel to be generated
   KernelType kernelType;

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -28,8 +28,8 @@ using namespace mlir;
 // Type of kernel to be generated
 llvm::cl::opt<std::string> kernel("kernel",
                                   llvm::cl::desc("Kernel type to be generated"),
-                                  llvm::cl::value_desc("inference,training"),
-                                  llvm::cl::init("inference"));
+                                  llvm::cl::value_desc("const,args"),
+                                  llvm::cl::init("const"));
 
 // Input layer
 llvm::cl::opt<unsigned> batch("batch", llvm::cl::desc("Mini batch size"),


### PR DESCRIPTION
The current name is confusing (again), so just give up on meaning and describe what we actually do: const or args wights and biases.