### PR TITLE
Allow tiling dimensions equal to tile size

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -153,7 +153,9 @@ def TileConsumerAndFuseProducers : Pass<"tile-consumer-and-fuse-producers",
            "Get producers till maxDepth">,
     Option<"numIters", "num-iters", "int64_t", "3",
            "Run fusion for the given number of iterations">,
-    Option<"useForAll", "use-for-all", "bool", "true", "Use parallel forAll">
+    Option<"useForAll", "use-for-all", "bool", "true", "Use parallel forAll">,
+    Option<"minTileFactor", "min-tile-factor", "int64_t", "2",
+           "Minimum factor between dimension size and a tile size">
   ];
   let dependentDialects = ["linalg::LinalgDialect", "scf::SCFDialect",
                            "tensor::TensorDialect"];

--- a/include/TPP/Transforms/Utils/TransformUtils.h
+++ b/include/TPP/Transforms/Utils/TransformUtils.h
@@ -78,9 +78,13 @@ isContraction(linalg::LinalgOp linalgOp);
 // Specific dims can be passed using 'dims'. If dims is empty the validation
 // will start from the outermost dimension, moving to innermost ones up to the
 // number of tiles.
+// Tiling application can restricted based on the workload dimension size.
+// The tiling is applied only to when all dimensions fulfill the predicate:
+// '(dimSize[i] / tiles[i]) >= minTileFactor'.
 bool validateFullTilesOnDims(TilingInterface tileOp,
                              ArrayRef<OpFoldResult> tiles,
-                             ArrayRef<size_t> dims = {});
+                             ArrayRef<size_t> dims = {},
+                             int64_t minTileFactor = 2);
 
 // Rewrite scf.for to scf.forall. Assumes the loop to be parallel and
 // marked with `kLoopId`.

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -147,7 +147,9 @@ private:
     // Tile to split the kernel into threads and blocks.
     // Use default tiling to handle both packed and unpacked ops.
     pm.addPass(createCleanup());
-    pm.addPass(createTileConsumerAndFuseProducers());
+    TileConsumerAndFuseProducersOptions tilingOptions;
+    tilingOptions.minTileFactor = 1;
+    pm.addPass(createTileConsumerAndFuseProducers(tilingOptions));
     pm.addPass(createCleanup());
 
     // Preprocess and bufferize as further conversion requires memref

--- a/lib/TPP/Transforms/TransformUtils.cpp
+++ b/lib/TPP/Transforms/TransformUtils.cpp
@@ -315,7 +315,7 @@ static bool validateFullTilesOnDim(TilingInterface tileOp,
   if (*tileFactor == 1 && *rangeOnDim == 1)
     return true;
 
-  return (*rangeOnDim % *tileFactor == 0 && *rangeOnDim / *tileFactor != 1);
+  return (*rangeOnDim % *tileFactor == 0);
 }
 
 bool validateFullTilesOnDims(TilingInterface tileOp,

--- a/test/GPU/gpu-tiling.mlir
+++ b/test/GPU/gpu-tiling.mlir
@@ -1,0 +1,19 @@
+// RUN: tpp-opt %s \
+// RUN: -tile-consumer-and-fuse-producers="tile-sizes=128,128 min-tile-factor=1" \
+// RUN: -tile-consumer-and-fuse-producers="tile-sizes=32,32 min-tile-factor=1" \
+// RUN: -canonicalize -split-input-file | FileCheck %s
+
+func.func @matmul(%arg0: tensor<128x1024xf16>,
+                 %arg1: tensor<1024x1024xf16>,
+                 %arg2: tensor<128x1024xf16>) -> tensor<128x1024xf16> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x1024xf16>, tensor<1024x1024xf16>)
+                     outs(%arg2 : tensor<128x1024xf16>) -> tensor<128x1024xf16>
+  return %0 : tensor<128x1024xf16>
+}
+
+// CHECK-LABEL: func.func @matmul
+// First tiling - block/workgroup tiles <1x8> -> 8 tiles.
+// CHECK: scf.forall {{.*}} = (0) to (1024) step (128)
+// Second tiling - thread/workitem tiles <4x4> -> 16 subtiles.
+// CHECK: scf.forall {{.*}} = (0, 0) to (128, 128) step (32, 32)
+// CHECK: linalg.matmul ins({{.*}}: tensor<32x1024xf16>, tensor<1024x32xf16>){{.*}}-> tensor<32x32xf16>

--- a/test/Passes/DefaultPipeline/default-tpp-passes.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes.mlir
@@ -219,13 +219,10 @@ func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> te
 // CHECK-LABEL: batch_matmul_rewrite
 func.func @batch_matmul_rewrite(%arg0: tensor<512x32x64xf32>, %arg1: tensor<512x64x32xf32>) -> tensor<512x32x32xf32> {
   %0 = tensor.empty() : tensor<512x32x32xf32>
-  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
-  // CHECK-DAG: %[[C32:.+]] = arith.constant 32 : i64
-  // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : i64
-  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
-  // CHECK: %{{.+}} = call @xsmm_gemm_dispatch(%[[C1]], %[[C32]], %[[C32]], %[[C64]], %[[C64]], %[[C32]], %[[C32]], %[[C0]])
+  // CHECK-NOT: linalg.batch_matmul
+  // CHECK: call @xsmm_{{.*}}_dispatch
   // CHECK: scf.parallel
-  // CHECK: xsmm_gemm_invoke
+  // CHECK: xsmm_{{.*}}_invoke
   %1 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<512x32x64xf32>, tensor<512x64x32xf32>)
                            outs(%0 : tensor<512x32x32xf32>) -> tensor<512x32x32xf32>
   return %1 : tensor<512x32x32xf32>

--- a/test/Passes/DefaultPipeline/default-tpp-passes.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes.mlir
@@ -223,8 +223,11 @@ func.func @batch_matmul_rewrite(%arg0: tensor<512x32x64xf32>, %arg1: tensor<512x
   // CHECK-DAG: %[[C32:.+]] = arith.constant 32 : i64
   // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : i64
   // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // CHECK-DAG: %[[C0_i:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1_i:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C512_i:.+]] = arith.constant 512 : index
   // CHECK: %{{.+}} = call @xsmm_gemm_dispatch(%[[C1]], %[[C32]], %[[C32]], %[[C64]], %[[C64]], %[[C32]], %[[C32]], %[[C0]])
-  // CHECK: scf.parallel
+  // CHECK: scf.parallel{{.*}}(%[[C0_i]]) to (%[[C512_i]]) step (%[[C1_i]])
   // CHECK: xsmm_gemm_invoke
   %1 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<512x32x64xf32>, tensor<512x64x32xf32>)
                            outs(%0 : tensor<512x32x32xf32>) -> tensor<512x32x32xf32>

--- a/test/Passes/DefaultPipeline/default-tpp-passes.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes.mlir
@@ -219,12 +219,13 @@ func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> te
 // CHECK-LABEL: batch_matmul_rewrite
 func.func @batch_matmul_rewrite(%arg0: tensor<512x32x64xf32>, %arg1: tensor<512x64x32xf32>) -> tensor<512x32x32xf32> {
   %0 = tensor.empty() : tensor<512x32x32xf32>
-  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-  // CHECK-DAG: %[[C512:.+]] = arith.constant 512 : index
-  // CHECK: call @xsmm_brgemm_dispatch
-  // CHECK: scf.parallel{{.*}}(%[[C0]]) to (%[[C512]]) step (%[[C1]])
-  // CHECK: call @xsmm_brgemm_invoke
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
+  // CHECK-DAG: %[[C32:.+]] = arith.constant 32 : i64
+  // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : i64
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
+  // CHECK: %{{.+}} = call @xsmm_gemm_dispatch(%[[C1]], %[[C32]], %[[C32]], %[[C64]], %[[C64]], %[[C32]], %[[C32]], %[[C0]])
+  // CHECK: scf.parallel
+  // CHECK: xsmm_gemm_invoke
   %1 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<512x32x64xf32>, tensor<512x64x32xf32>)
                            outs(%0 : tensor<512x32x32xf32>) -> tensor<512x32x32xf32>
   return %1 : tensor<512x32x32xf32>

--- a/test/Passes/DefaultPipeline/default-tpp-passes.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes.mlir
@@ -219,10 +219,12 @@ func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> te
 // CHECK-LABEL: batch_matmul_rewrite
 func.func @batch_matmul_rewrite(%arg0: tensor<512x32x64xf32>, %arg1: tensor<512x64x32xf32>) -> tensor<512x32x32xf32> {
   %0 = tensor.empty() : tensor<512x32x32xf32>
-  // CHECK-NOT: linalg.batch_matmul
-  // CHECK: call @xsmm_{{.*}}_dispatch
-  // CHECK: scf.parallel
-  // CHECK: xsmm_{{.*}}_invoke
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C512:.+]] = arith.constant 512 : index
+  // CHECK: call @xsmm_brgemm_dispatch
+  // CHECK: scf.parallel{{.*}}(%[[C0]]) to (%[[C512]]) step (%[[C1]])
+  // CHECK: call @xsmm_brgemm_invoke
   %1 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<512x32x64xf32>, tensor<512x64x32xf32>)
                            outs(%0 : tensor<512x32x32xf32>) -> tensor<512x32x32xf32>
   return %1 : tensor<512x32x32xf32>

--- a/test/Passes/tile-and-fuse-default.mlir
+++ b/test/Passes/tile-and-fuse-default.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="use-for-all=false" -cse -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="use-for-all=false" -cse -canonicalize -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
@@ -244,9 +244,9 @@ func.func @matmul_fuse_with_fill(%arg0: tensor<64x64xf32>, %arg1: tensor<64x64xf
 // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<64x64xf32>
 // CHECK: %{{.+}} = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C64]] step %[[C32]] iter_args(%[[ARG3:.+]] = %[[EMPTY]])
 // CHECK-NEXT: %{{.+}} = scf.for %[[ARG4:.+]] = %[[C0]] to %[[C64]] step %[[C32]] iter_args(%[[ARG5:.+]] = %[[ARG3]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0] [32, 64] [1, 1] : tensor<64x64xf32> to tensor<32x64xf32>
-// CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG4]]] [64, 32] [1, 1] : tensor<64x64xf32> to tensor<64x32xf32>
-// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG2]], %[[ARG4]]] [32, 32] [1, 1] : tensor<64x64xf32> to tensor<32x32xf32>
+// CHECK-DAG: %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0] [32, 64] [1, 1] : tensor<64x64xf32> to tensor<32x64xf32>
+// CHECK-DAG: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG4]]] [64, 32] [1, 1] : tensor<64x64xf32> to tensor<64x32xf32>
+// CHECK-DAG: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG2]], %[[ARG4]]] [32, 32] [1, 1] : tensor<64x64xf32> to tensor<32x32xf32>
 // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[SLICE1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
 // CHECK: %[[MUL:.+]] = linalg.matmul ins(%[[SLICE]], %[[SLICE0]] : tensor<32x64xf32>, tensor<64x32xf32>)
 // CHECK-SAME:  outs(%[[FILL]] : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -343,14 +343,12 @@ func.func @blocked_batch_matmul(%pack: tensor<512x1x2x32x32xf32>,
 // CHECK-DAG: %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<512x1x1x32x32xf32>
 // CHECK: %{{.+}} = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C512]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[EMPTY]])
-// CHECK-NEXT: %{{.+}} = scf.for %[[ARG4:.+]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG3]])
-// CHECK-NEXT: %{{.+}} = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG7:.+]] = %[[ARG5]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG7]][%[[ARG2]], %[[ARG4]], %[[ARG6]], 0, 0] [1, 1, 1, 32, 32] [1, 1, 1, 1, 1]
+// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG3]][%[[ARG2]], 0, 0, 0, 0] [1, 1, 1, 32, 32] [1, 1, 1, 1, 1]
 // CHECK-SAME:  : tensor<512x1x1x32x32xf32> to tensor<32x32xf32>
 // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[SLICE]] : tensor<32x32xf32>) -> tensor<32x32xf32>
-// CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], %[[ARG4]], 0, 0, 0] [1, 1, 2, 32, 32] [1, 1, 1, 1, 1]
+// CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0, 0, 0, 0] [1, 1, 2, 32, 32] [1, 1, 1, 1, 1]
 // CHECK-SAME:  : tensor<512x1x2x32x32xf32> to tensor<2x32x32xf32>
-// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG2]], %[[ARG6]], 0, 0, 0] [1, 1, 2, 32, 32] [1, 1, 1, 1, 1]
+// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG2]], 0, 0, 0, 0] [1, 1, 2, 32, 32] [1, 1, 1, 1, 1]
 // CHECK-SAME:  : tensor<512x1x2x32x32xf32> to tensor<2x32x32xf32>
 // CHECK: %{{.+}} = linalg.batch_reduce_matmul ins(%[[SLICE0]], %[[SLICE1]] : tensor<2x32x32xf32>, tensor<2x32x32xf32>)
 // CHECK-SAME:  outs(%[[FILL]] : tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -378,7 +376,7 @@ func.func @projection_mha(%arg2: tensor<64x32x8x64xf32>, %cst_3: tensor<8x64x8x6
   return %2 : tensor<64x32x8x64xf32>
 }
 
-// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
 // CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
 
@@ -487,6 +485,7 @@ func.func @batch_mha(%arg0: tensor<64x8x32x32xf32>, %arg1: tensor<64x32x8x64xf32
 // CHECK-LABEL: batch_mha
 // CHECK-SAME: %[[ARG0:.+]]: tensor<64x8x32x32xf32>, %[[ARG1:.+]]: tensor<64x32x8x64xf32>
 // CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
 // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
@@ -496,12 +495,15 @@ func.func @batch_mha(%arg0: tensor<64x8x32x32xf32>, %arg1: tensor<64x32x8x64xf32
 // CHECK: %{{.+}} = scf.for %[[ARG4:.+]] = %[[C0]] to %[[C8]] step %[[C1]] iter_args(%[[ARG5:.+]] = %[[ARG3]])
 // CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG2]], 0, %[[ARG4]], 0] [1, 32, 1, 64] [1, 1, 1, 1]
 // CHECK-SAME:  : tensor<64x32x8x64xf32> to tensor<32x64xf32>
-// CHECK: %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32)
-// CHECK-SAME:  outs(%[[SLICE]] : tensor<32x64xf32>) -> tensor<32x64xf32>
+// CHECK: %{{.+}} = scf.for %[[ARG6:.+]] = %[[C0]] to %[[C64]] step %[[C32]] iter_args(%[[ARG7:.+]] = %[[SLICE]])
+// CHECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG7]][0, %[[ARG6]]] [32, 32] [1, 1]
+// CHECK-SAME:  : tensor<32x64xf32> to tensor<32x32xf32>
 // CHECK: %[[SLICE_0:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], %[[ARG4]], 0, 0] [1, 1, 32, 32] [1, 1, 1, 1]
 // CHECK-SAME:  : tensor<64x8x32x32xf32> to tensor<32x32xf32>
-// CHECK: %[[SLICE_1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG2]], 0, %[[ARG4]], 0] [1, 32, 1, 64] [1, 1, 1, 1]
-// CHECK-SAME:  : tensor<64x32x8x64xf32> to tensor<32x64xf32>
+// CHECK: %[[SLICE_1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG2]], 0, %[[ARG4]], %[[ARG6]]] [1, 32, 1, 32] [1, 1, 1, 1]
+// CHECK-SAME:  : tensor<64x32x8x64xf32> to tensor<32x32xf32>
+// CHECK: %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32)
+// CHECK-SAME:  outs(%[[SLICE1]] : tensor<32x32xf32>) -> tensor<32x32xf32>
 // CHECK: %{{.+}} = linalg.generic
 // CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
 // CHECK-SAME: iterator_types = ["parallel", "reduction", "parallel"]
@@ -651,12 +653,9 @@ func.func @contraction(%arg0: tensor<1024x1024xf32>, %arg1: tensor<1024x64xf32>)
 // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1024x64xf32>
 // CHECK: %{{.+}} = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C1024]] step %[[C32]] iter_args(%[[ARG3:.+]] = %[[EMPTY]])
 // CHECK: %{{.+}} = scf.for %[[ARG4:.+]] = %[[C0]] to %[[C64]] step %[[C32]] iter_args(%[[ARG5:.+]] = %[[ARG3]])
-// CHECK: %[[SLICE_ARG0:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0] [32, 1024] [1, 1]
-// CHECK-SAME:  : tensor<1024x1024xf32> to tensor<32x1024xf32>
-// CHECK: %[[SLICE_ARG1:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG4]]] [1024, 32] [1, 1]
-// CHECK-SAME:  : tensor<1024x64xf32> to tensor<1024x32xf32>
-// CHECK: %[[SLICE_INIT:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG2]], %[[ARG4]]] [32, 32] [1, 1]
-// CHECK-SAME:  : tensor<1024x64xf32> to tensor<32x32xf32>
+// CHECK-DAG: %[[SLICE_ARG0:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0] [32, 1024] [1, 1] : tensor<1024x1024xf32> to tensor<32x1024xf32>
+// CHECK-DAG: %[[SLICE_ARG1:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG4]]] [1024, 32] [1, 1] : tensor<1024x64xf32> to tensor<1024x32xf32>
+// CHECK-DAG: %[[SLICE_INIT:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG2]], %[[ARG4]]] [32, 32] [1, 1] : tensor<1024x64xf32> to tensor<32x32xf32>
 // CHECK: %[[FILL:.+]] = linalg.fill ins(%{{.+}} : f32) outs(%[[SLICE_INIT]] : tensor<32x32xf32>) -> tensor<32x32xf32>
 // CHECK: %{{.+}} = linalg.generic
 // CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
@@ -696,10 +695,8 @@ func.func @contraction(%arg0: tensor<16x1024xf32>, %arg1: tensor<1024x64xf32>) -
 // CHECK-DAG: %[[CST:.+]] = arith.constant 0.000000e+00 : f32
 // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<16x64xf32>
 // CHECK: %{{.+}} = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C64]] step %[[C32]] iter_args(%[[ARG3:.+]] = %[[EMPTY]])
-// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG2]]] [1024, 32] [1, 1]
-// CHECK-SAME:  : tensor<1024x64xf32> to tensor<1024x32xf32>
-// CHECK: %[[SLICE_1:.+]] = tensor.extract_slice %[[ARG3]][0, %[[ARG2]]] [16, 32] [1, 1]
-// CHECK-SAME:  : tensor<16x64xf32> to tensor<16x32xf32>
+// CHECK-DAG: %[[SLICE:.+]] = tensor.extract_slice %[[ARG1]][0, %[[ARG2]]] [1024, 32] [1, 1] : tensor<1024x64xf32> to tensor<1024x32xf32>
+// CHECK-DAG: %[[SLICE_1:.+]] = tensor.extract_slice %[[ARG3]][0, %[[ARG2]]] [16, 32] [1, 1] : tensor<16x64xf32> to tensor<16x32xf32>
 // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[SLICE_1]] : tensor<16x32xf32>) -> tensor<16x32xf32>
 // CHECK: %{{.+}} = linalg.generic
 // CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]

--- a/test/Passes/tile-and-fuse-tile-factor.mlir
+++ b/test/Passes/tile-and-fuse-tile-factor.mlir
@@ -1,0 +1,94 @@
+// RUN: tpp-opt %s -tile-consumer-and-fuse-producers="use-for-all=false tile-sizes=32,32 min-tile-factor=2" -cse -split-input-file | FileCheck %s
+
+func.func @tile_factor_half(%arg0: tensor<16x16xf32>,
+                 %arg1: tensor<16x16xf32>,
+                 %arg2: tensor<16x16xf32>) -> tensor<16x16xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<16x16xf32>, tensor<16x16xf32>)
+                     outs(%arg2 : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %0 : tensor<16x16xf32>
+}
+
+// CHECK-LABEL: func.func @tile_factor_half
+// CHECK-NOT: scf.for
+// CHECK: linalg.matmul{{.*}}-> tensor<16x16xf32>
+
+// -----
+
+func.func @tile_factor_1(%arg0: tensor<32x32xf32>,
+                 %arg1: tensor<32x32xf32>,
+                 %arg2: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<32x32xf32>, tensor<32x32xf32>)
+                     outs(%arg2 : tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: func.func @tile_factor_1
+// CHECK-NOT: scf.for
+// CHECK: linalg.matmul{{.*}}-> tensor<32x32xf32>
+
+// -----
+
+func.func @tile_factor_2(%arg0: tensor<64x64xf32>,
+                 %arg1: tensor<64x64xf32>,
+                 %arg2: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<64x64xf32>, tensor<64x64xf32>)
+                     outs(%arg2 : tensor<64x64xf32>) -> tensor<64x64xf32>
+  return %0 : tensor<64x64xf32>
+}
+
+// CHECK-LABEL: func.func @tile_factor_2
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+// CHECK-COUNT-2: scf.for {{.*}} = %[[c0]] to %[[c64]] step %[[c32]]
+// CHECK: linalg.matmul ins({{.*}}: tensor<32x64xf32>, tensor<64x32xf32>){{.*}}-> tensor<32x32xf32>
+
+// -----
+
+func.func @tile_factor_4(%arg0: tensor<128x128xf32>,
+                 %arg1: tensor<128x128xf32>,
+                 %arg2: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<128x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+// CHECK-LABEL: func.func @tile_factor_4
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c128:.+]] = arith.constant 128 : index
+// CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+// CHECK-COUNT-2: scf.for {{.*}} = %[[c0]] to %[[c128]] step %[[c32]]
+// CHECK: linalg.matmul ins({{.*}}: tensor<32x128xf32>, tensor<128x32xf32>){{.*}}-> tensor<32x32xf32>
+
+// -----
+
+func.func @tile_factor_1_by_2(%arg0: tensor<32x64xf32>,
+                 %arg1: tensor<64x64xf32>,
+                 %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<32x64xf32>, tensor<64x64xf32>)
+                     outs(%arg2 : tensor<32x64xf32>) -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @tile_factor_1_by_2
+// CHECK-NOT: scf.for
+// CHECK: linalg.matmul{{.*}}-> tensor<32x64xf32>
+
+// -----
+
+func.func @tile_factor_2_by_4(%arg0: tensor<64x128xf32>,
+                 %arg1: tensor<128x128xf32>,
+                 %arg2: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<64x128xf32>, tensor<128x128xf32>)
+                     outs(%arg2 : tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %0 : tensor<64x128xf32>
+}
+
+// CHECK-LABEL: func.func @tile_factor_2_by_4
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[c64:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[c32:.+]] = arith.constant 32 : index
+// CHECK-DAG: %[[c128:.+]] = arith.constant 128 : index
+// CHECK: scf.for {{.*}} = %[[c0]] to %[[c64]] step %[[c32]]
+// CHECK: scf.for {{.*}} = %[[c0]] to %[[c128]] step %[[c32]]
+// CHECK: linalg.matmul ins({{.*}}: tensor<32x128xf32>, tensor<128x32xf32>){{.*}}-> tensor<32x32xf32>


### PR DESCRIPTION
Adds a new option to tile-and-fuse pass to expose control over dimension to tile size factor (ratio) when selecting eligible operations for tiling. The chosen factor requirement must be fulfilled for all dimensions.

This change allows tiling when dimensions are equal to their corresponding tile size or restricts tiling to larger workloads.
For example, tile factor of 1 creates more opportunities in kernel outlining for wide and tall workloads e.g., memref<128x1024> into 128x128 tiles.