### PR TITLE
[CI] Move from secrets to variables

### DIFF
--- a/.github/workflows/tpp-benchmark.yml
+++ b/.github/workflows/tpp-benchmark.yml
@@ -37,7 +37,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ secrets.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-SPR-OMP:
     runs-on: pcl-tiergarten
@@ -48,7 +48,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ secrets.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ZEN-BASE:
     runs-on: pcl-tiergarten
@@ -60,7 +60,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ secrets.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ZEN-OMP:
     runs-on: pcl-tiergarten
@@ -72,7 +72,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ secrets.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-CLX-BASE:
     runs-on: pcl-tiergarten
@@ -84,7 +84,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ secrets.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-CLX-OMP:
     runs-on: pcl-tiergarten
@@ -96,7 +96,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ secrets.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ADL-BASE:
     runs-on: pcl-tiergarten
@@ -108,7 +108,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ secrets.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ADL-OMP:
     runs-on: pcl-tiergarten
@@ -120,4 +120,4 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ secrets.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ vars.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD

--- a/.github/workflows/tpp-benchmark.yml
+++ b/.github/workflows/tpp-benchmark.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   NPROCS_LIMIT_LINK: 8
+  SRUN: ${HOME}/srun.sh
   NUM_ITER: 100
 
 jobs:
@@ -37,7 +38,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ vars.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-SPR-OMP:
     runs-on: pcl-tiergarten
@@ -48,7 +49,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ vars.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=spr --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ZEN-BASE:
     runs-on: pcl-tiergarten
@@ -60,7 +61,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ vars.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ZEN-OMP:
     runs-on: pcl-tiergarten
@@ -72,7 +73,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ vars.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=zen4 --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-CLX-BASE:
     runs-on: pcl-tiergarten
@@ -84,7 +85,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ vars.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-CLX-OMP:
     runs-on: pcl-tiergarten
@@ -96,7 +97,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ vars.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=clxap --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ADL-BASE:
     runs-on: pcl-tiergarten
@@ -108,7 +109,7 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -b -p"
-          ${{ vars.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD
 
   TPP-MLIR-ADL-OMP:
     runs-on: pcl-tiergarten
@@ -120,4 +121,4 @@ jobs:
         run: |-
           CMD="KIND=Release COMPILER=clang LINKER=lld BUILDKITE_BENCHMARK_NUM_ITER=${{ env.NUM_ITER }} \
                ${{ github.workspace }}/scripts/buildkite/benchmark.sh -o"
-          ${{ vars.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD
+          ${{ env.SRUN }} --partition=rpl --time=2:00:00 --constraint=\"notrb\" -- $CMD

--- a/.github/workflows/tpp-llvm.yml
+++ b/.github/workflows/tpp-llvm.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   NPROCS_LIMIT_LINK: 8
+  SRUN: ${HOME}/srun.sh
 
 jobs:
   TPP-MLIR-LLVM-Base:
@@ -15,7 +16,7 @@ jobs:
       - name: LLVM Base
         run: |-
               scripts/buildkite/check_llvm.sh || \
-              ${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
+              ${{ env.SRUN }} --partition=spr-all --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang \
               ${{ github.workspace }}/scripts/buildkite/build_llvm.sh'
 
@@ -26,7 +27,7 @@ jobs:
       - name: LLVM CUDA
         run: |-
               scripts/buildkite/check_llvm.sh || \
-              ${{ vars.SRUN }} --partition=a100,v100 --time=0:30:00 -- \
+              ${{ env.SRUN }} --partition=a100,v100 --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang GPU=cuda \
               ${{ github.workspace }}/scripts/buildkite/build_llvm.sh'
 
@@ -37,7 +38,7 @@ jobs:
       - name: LLVM Vulkan
         run: |-
               scripts/buildkite/check_llvm.sh || \
-              ${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
+              ${{ env.SRUN }} --partition=spr-all --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang GPU=vulkan \
               ${{ github.workspace }}/scripts/buildkite/build_llvm.sh'
 

--- a/.github/workflows/tpp-llvm.yml
+++ b/.github/workflows/tpp-llvm.yml
@@ -3,9 +3,6 @@ name: TPP-MLIR LLVM Build
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      SRUN:
-        required: true
 
 env:
   NPROCS_LIMIT_LINK: 8
@@ -18,7 +15,7 @@ jobs:
       - name: LLVM Base
         run: |-
               scripts/buildkite/check_llvm.sh || \
-              ${{ secrets.SRUN }} --partition=spr-all --time=0:30:00 -- \
+              ${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang \
               ${{ github.workspace }}/scripts/buildkite/build_llvm.sh'
 
@@ -29,7 +26,7 @@ jobs:
       - name: LLVM CUDA
         run: |-
               scripts/buildkite/check_llvm.sh || \
-              ${{ secrets.SRUN }} --partition=a100,v100 --time=0:30:00 -- \
+              ${{ vars.SRUN }} --partition=a100,v100 --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang GPU=cuda \
               ${{ github.workspace }}/scripts/buildkite/build_llvm.sh'
 
@@ -40,7 +37,7 @@ jobs:
       - name: LLVM Vulkan
         run: |-
               scripts/buildkite/check_llvm.sh || \
-              ${{ secrets.SRUN }} --partition=spr-all --time=0:30:00 -- \
+              ${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
               'KIND=RelWithDebInfo COMPILER=clang GPU=vulkan \
               ${{ github.workspace }}/scripts/buildkite/build_llvm.sh'
 

--- a/.github/workflows/tpp-mlir.yml
+++ b/.github/workflows/tpp-mlir.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: GCC Release
-        run: "${{ secrets.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
             'KIND=Release COMPILER=gcc CHECK=1 ONEDNN=1 \
             ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"
 
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: GCC Debug
-        run: "${{ secrets.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
             'KIND=Debug COMPILER=gcc CHECK=1 ONEDNN=1 \
             ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"
 
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Clang Release
-        run: "${{ secrets.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
             'KIND=Release COMPILER=clang LINKER=lld CHECK=1 ONEDNN=1 \
             ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"
 
@@ -49,6 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Clang Debug Sanitizers
-        run: "${{ secrets.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
                 'KIND=Debug COMPILER=clang LINKER=lld SANITIZERS=1 CHECK=1 ONEDNN=1 \
                 ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"

--- a/.github/workflows/tpp-mlir.yml
+++ b/.github/workflows/tpp-mlir.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   NPROCS_LIMIT_LINK: 8
+  SRUN: ${HOME}/srun.sh
 
 jobs:
   Check_LLVM:
@@ -19,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: GCC Release
-        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ env.SRUN }} --partition=spr-all --time=0:30:00 -- \
             'KIND=Release COMPILER=gcc CHECK=1 ONEDNN=1 \
             ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"
 
@@ -29,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: GCC Debug
-        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ env.SRUN }} --partition=spr-all --time=0:30:00 -- \
             'KIND=Debug COMPILER=gcc CHECK=1 ONEDNN=1 \
             ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"
 
@@ -39,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Clang Release
-        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ env.SRUN }} --partition=spr-all --time=0:30:00 -- \
             'KIND=Release COMPILER=clang LINKER=lld CHECK=1 ONEDNN=1 \
             ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"
 
@@ -49,6 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Clang Debug Sanitizers
-        run: "${{ vars.SRUN }} --partition=spr-all --time=0:30:00 -- \
+        run: "${{ env.SRUN }} --partition=spr-all --time=0:30:00 -- \
                 'KIND=Debug COMPILER=clang LINKER=lld SANITIZERS=1 CHECK=1 ONEDNN=1 \
                 ${{ github.workspace }}/scripts/buildkite/build_tpp.sh'"


### PR DESCRIPTION
Moves CI jobs to config environment variables instead of repository secrets.
This avoids the issue of repository secrets and variables not being passed to CI workflows triggered by PRs from forks.