### PR TITLE
[mlir-gen] Add Float16 type support

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -31,42 +31,42 @@
     },
     "gemm_fp32_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": []
     },
     "gemm_bf16_dp2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "gemm_bf16_dp4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
     },
     "mlp_fp32_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": []
     },
     "mlp_bf16_dp2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "mlp_bf16_dp4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
@@ -76,28 +76,28 @@
   "gemm_models": {
     "fp32_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
@@ -107,28 +107,28 @@
   "mlp_models": {
     "fp32_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/config/fc/1024x1024x512.json
+++ b/benchmarks/config/fc/1024x1024x512.json
@@ -37,14 +37,14 @@
   "fc_1024x1024x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x1024x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x1024x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x2560x1024.json
+++ b/benchmarks/config/fc/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "fc_1024x2560x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x2560x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x2560x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x352x512.json
+++ b/benchmarks/config/fc/1024x352x512.json
@@ -37,14 +37,14 @@
   "fc_1024x352x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x352x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x352x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x512x256.json
+++ b/benchmarks/config/fc/1024x512x256.json
@@ -37,14 +37,14 @@
   "fc_1024x512x256_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x512x256_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x512x256_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x1024.json
+++ b/benchmarks/config/fc/128x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_128x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x4096.json
+++ b/benchmarks/config/fc/128x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_128x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x3072x768.json
+++ b/benchmarks/config/fc/128x3072x768.json
@@ -37,14 +37,14 @@
   "fc_128x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x4096x1024.json
+++ b/benchmarks/config/fc/128x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_128x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x2304.json
+++ b/benchmarks/config/fc/128x768x2304.json
@@ -37,14 +37,14 @@
   "fc_128x768x2304_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x2304_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x2304_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x3072.json
+++ b/benchmarks/config/fc/128x768x3072.json
@@ -37,14 +37,14 @@
   "fc_128x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x768.json
+++ b/benchmarks/config/fc/128x768x768.json
@@ -37,14 +37,14 @@
   "fc_128x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x1024.json
+++ b/benchmarks/config/fc/256x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_256x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x4096.json
+++ b/benchmarks/config/fc/256x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_256x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x3072x768.json
+++ b/benchmarks/config/fc/256x3072x768.json
@@ -37,14 +37,14 @@
   "fc_256x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x4096x1024.json
+++ b/benchmarks/config/fc/256x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_256x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x3072.json
+++ b/benchmarks/config/fc/256x768x3072.json
@@ -37,14 +37,14 @@
   "fc_256x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x768.json
+++ b/benchmarks/config/fc/256x768x768.json
@@ -37,14 +37,14 @@
   "fc_256x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x1024x512.json
+++ b/benchmarks/config/matmul/1024x1024x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x1024x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x1024x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x1024x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x2560x1024.json
+++ b/benchmarks/config/matmul/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "matmul_1024x2560x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x2560x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x2560x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x352x512.json
+++ b/benchmarks/config/matmul/1024x352x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x352x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x352x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x352x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x512x256.json
+++ b/benchmarks/config/matmul/1024x512x256.json
@@ -37,14 +37,14 @@
   "matmul_1024x512x256_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x512x256_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x512x256_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x1024.json
+++ b/benchmarks/config/matmul/128x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x3072x768.json
+++ b/benchmarks/config/matmul/128x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_128x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x4096x1024.json
+++ b/benchmarks/config/matmul/128x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x2304.json
+++ b/benchmarks/config/matmul/128x768x2304.json
@@ -37,14 +37,14 @@
   "matmul_128x768x2304_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x2304_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x2304_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x3072.json
+++ b/benchmarks/config/matmul/128x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_128x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x768.json
+++ b/benchmarks/config/matmul/128x768x768.json
@@ -37,14 +37,14 @@
   "matmul_128x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x1024.json
+++ b/benchmarks/config/matmul/256x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x4096.json
+++ b/benchmarks/config/matmul/256x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x3072x768.json
+++ b/benchmarks/config/matmul/256x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_256x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x4096x1024.json
+++ b/benchmarks/config/matmul/256x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x3072.json
+++ b/benchmarks/config/matmul/256x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_256x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x768.json
+++ b/benchmarks/config/matmul/256x768x768.json
@@ -37,14 +37,14 @@
   "matmul_256x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-width=16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/omp/mlir-bf16.json
+++ b/benchmarks/config/omp/mlir-bf16.json
@@ -3,28 +3,28 @@
   "gemm_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -34,28 +34,28 @@
   "mlp_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -65,28 +65,28 @@
   "gemm_bf16_dp4_mlir": {
     "bf16_dp4_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(svebf16)" ]
@@ -96,28 +96,28 @@
   "mlp_bf16_dp4_mlir": {
     "bf16_dp4_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/omp/mlir-fp32.json
+++ b/benchmarks/config/omp/mlir-fp32.json
@@ -3,28 +3,28 @@
   "gemm_fp32_mlir": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -34,28 +34,28 @@
   "mlp_fp32_mlir": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-width=32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -36,7 +36,7 @@
              },
              "irgen": {
                  "type": "IR-GEN",
-                 "benchmark": [ "mlir-gen", "--kernel=const --float-width=16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
+                 "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
                  "environment": { "OMP_NUM_THREADS": "32" },
                  "flags": [ "-n", "100" ],
                  "extensions": [ "(avx2|asimd)" ]

--- a/include/TPP/Transforms/Utils/BuilderUtils.h
+++ b/include/TPP/Transforms/Utils/BuilderUtils.h
@@ -21,6 +21,7 @@ class TypeRange;
 class OpBuilder;
 class Operation;
 class Value;
+class FloatType;
 namespace func {
 class FuncOp;
 } // namespace func
@@ -40,7 +41,7 @@ Value createDenseMemref(OpBuilder &, ModuleOp, TensorInitType, MemRefType, int);
 // Return a ConstantOp of a certain type with a certain initializer
 Value getConstIndex(OpBuilder &, int);
 Value getConstInt(OpBuilder &, int, int);
-Value getConstFloat(OpBuilder &, float, int);
+Value getConstFloat(OpBuilder &, float, FloatType);
 
 // Return a typed attribute of specified type and value.
 // For integer types, the value is rounded toward zero.

--- a/lib/TPP/Transforms/Utils/BuilderUtils.cpp
+++ b/lib/TPP/Transforms/Utils/BuilderUtils.cpp
@@ -58,17 +58,8 @@ Value getConstInt(OpBuilder &builder, int value, int width) {
   }
 }
 
-Value getConstFloat(OpBuilder &builder, float value, int width) {
-  switch (width) {
-  case 16:
-    return getConstant(builder, builder.getBF16Type(), value);
-  case 32:
-    return getConstant(builder, builder.getF32Type(), value);
-  case 64:
-    return getConstant(builder, builder.getF64Type(), value);
-  default:
-    assert(false && "Invalid constant float size");
-  }
+Value getConstFloat(OpBuilder &builder, float value, FloatType type) {
+  return getConstant(builder, type, value);
 }
 
 Value getConstIndex(OpBuilder &builder, int value) {

--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -30,7 +30,7 @@ Examples:
 // Generates an MLP with `mlir-gen`, uses `meld`
 ./scripts/debug/debug_all_passes.sh \
   -b ./build/bin \
-  -m "--kernel=const --bias --relu --float-width=16 --batch=256 --layers=1024,1024,1024,1024" \
+  -m "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" \
   -d meld
 
 // Default behaviour, runs `mlir-gen` & `tpp-opt` without args, uses `diff`

--- a/test/BF16/Integration/mlir-gen-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-bf16.mlir
@@ -1,18 +1,18 @@
 // MLP without softmax (can't print packed version for now)
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --float-type=bf16 | tpp-run -e entry -entry-point-result=void
 
 // Matmul only
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --float-width=16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --float-type=bf16 | tpp-run -e entry -entry-point-result=void
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=args --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
+// RUN: mlir-gen --kernel=args --seed=123 --float-type=bf16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-width=16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
+// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-type=bf16 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
 
 // BF16/VNNI execution
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-width=16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-type=bf16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 --float-type=bf16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
 // GEN-MATMUL-BF16: ( 11, 11, 11, 11, 11, 11, 11, 11, 11, 11 )
 

--- a/test/BF16/Integration/mlir-gen-fc-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-fc-bf16.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/BF16/Integration/mlir-gen-matmul-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-matmul-bf16.mlir
@@ -1,6 +1,6 @@
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen-fc.mlir
+++ b/test/Integration/mlir-gen-fc.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/mlir-gen-flops.mlir
+++ b/test/Integration/mlir-gen-flops.mlir
@@ -1,19 +1,19 @@
 // Unit sizes
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
 // Small sizes
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
 // Large sizes + no tiling
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
 // Large sizes + tiling
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-width=32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
 
 // Validate that flops are computed correctly
 // MATMUL-UNIT: // BENCH_TOTAL_FLOPS: 2

--- a/test/Integration/mlir-gen-matmul.mlir
+++ b/test/Integration/mlir-gen-matmul.mlir
@@ -1,4 +1,6 @@
-// RUN: mlir-gen --kernel=args --seed=0 --float-width=32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --seed=0 --float-type=f16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP16
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void
@@ -12,3 +14,29 @@
 // FP32:         arith.mulf
 // FP32:         arith.addf
 // FP32-NOT: dealloc
+
+// BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
+// BF16: // RUN{{.*}}-e entry -entry-point-result=void
+// BF16: // BENCH_TOTAL_FLOPS: 452984832
+// BF16-DAG: #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// BF16-DAG: #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// BF16-DAG: #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// BF16:     func.func @entry(%arg0: tensor<2x36x64x64xbf16>, %arg1: tensor<16x36x64x48xbf16>, %arg2: tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
+// BF16-NOT: alloc
+// BF16:     linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
+// BF16:         arith.mulf
+// BF16:         arith.addf
+// BF16-NOT: dealloc
+
+// FP16: // RUN{{.*}}tpp-run %s -n {{\d*}}
+// FP16: // RUN{{.*}}-e entry -entry-point-result=void
+// FP16: // BENCH_TOTAL_FLOPS: 452984832
+// FP16-DAG: #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// FP16-DAG: #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// FP16-DAG: #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+// FP16:     func.func @entry(%arg0: tensor<2x36x64x64xf16>, %arg1: tensor<16x36x64x48xf16>, %arg2: tensor<2x16x64x48xf16>) -> tensor<2x16x64x48xf16>
+// FP16-NOT: alloc
+// FP16:     linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
+// FP16:         arith.mulf
+// FP16:         arith.addf
+// FP16-NOT: dealloc

--- a/test/Integration/mlir-gen.mlir
+++ b/test/Integration/mlir-gen.mlir
@@ -11,10 +11,10 @@
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=args --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
+// RUN: mlir-gen --kernel=args --seed=123 --float-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-width=32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
+// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
 
 // Packed versions
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -189,7 +189,7 @@ public:
   /// Creates a specific module. Different configurations need different modules
   /// so should create new objects to not have to share / cleanup existing MLIR
   /// modules.
-  MLIRGenerator(StringRef, unsigned, StringRef, StringRef, unsigned, int, bool,
+  MLIRGenerator(StringRef, unsigned, StringRef, StringRef, StringRef, int, bool,
                 bool, bool, int);
 
   ~MLIRGenerator() { module->destroy(); }

--- a/tools/mlir-gen/generate.sh
+++ b/tools/mlir-gen/generate.sh
@@ -126,7 +126,7 @@ debug "Random seed: $SEED"
 # Defaults
 
 # Command line to extract and run
-MLIR_GEN_ARGS="--float-width=$FLOAT_SIZE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
+MLIR_GEN_ARGS="--float-type=$FLOAT_SIZE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
 ORIG_MLIR="mlir-gen-original.mlir"
 debug "\nCreating the original MLIR model:"
 run "$MLIR_GEN $MLIR_GEN_ARGS" $ORIG_MLIR

--- a/tools/mlir-gen/generate.sh
+++ b/tools/mlir-gen/generate.sh
@@ -100,8 +100,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # BF16
-FLOAT_SIZE=32
-if [ BF16 ]; then FLOAT_SIZE="16"; fi
+FLOAT_TYPE="f32"
+if [ BF16 ]; then FLOAT_TYPE="bf16"; fi
 
 # Find binaries
 ROOT=$(git rev-parse --show-toplevel)
@@ -126,7 +126,7 @@ debug "Random seed: $SEED"
 # Defaults
 
 # Command line to extract and run
-MLIR_GEN_ARGS="--float-type=$FLOAT_SIZE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
+MLIR_GEN_ARGS="--float-type=$FLOAT_TYPE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
 ORIG_MLIR="mlir-gen-original.mlir"
 debug "\nCreating the original MLIR model:"
 run "$MLIR_GEN $MLIR_GEN_ARGS" $ORIG_MLIR
@@ -134,7 +134,7 @@ run "$MLIR_GEN $MLIR_GEN_ARGS" $ORIG_MLIR
 # FIXME: --pack-matmul isn't quite working with the rest of the pipeline
 # Once it works, we can pass the TILE variables to it
 TPP_OPT_ARGS="--default-tpp-passes"
-if [ "$FLOAT_SIZE" == "16" ]; then
+if [ "$FLOAT_TYPE" == "bf16" ]; then
   TPP_OPT_ARGS="--pack-vnni $TPP_OPT_ARGS"
 fi
 OPT_MLIR="mlir-gen-optimized.mlir"

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -47,11 +47,10 @@ llvm::cl::opt<std::string>
           llvm::cl::desc("Comma-separated values of size of each tile (N,K,C)"),
           llvm::cl::value_desc("32,32,32"), llvm::cl::init(""));
 
-// Float width
-llvm::cl::opt<unsigned> floatWidth("float-width",
-                                   llvm::cl::desc("Bitsize of float type"),
-                                   llvm::cl::value_desc("32|16"),
-                                   llvm::cl::init(32));
+// Float type
+llvm::cl::opt<std::string>
+    floatType("float-type", llvm::cl::desc("Float type and its bitsize"),
+              llvm::cl::value_desc("f32|f16|bf16"), llvm::cl::init("f32"));
 
 // Random seed
 llvm::cl::opt<int> seed("seed", llvm::cl::desc("Random seed"),
@@ -93,7 +92,7 @@ int main(int argc, char **argv) {
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Generator");
 
-  MLIRGenerator gen(kernel, batch, layers, tiles, floatWidth, seed, enableBias,
+  MLIRGenerator gen(kernel, batch, layers, tiles, floatType, seed, enableBias,
                     enableRelu, enableSoftmax, vnni);
   return gen.generate(filename);
 }


### PR DESCRIPTION
Allows IR generation with f16 data type.

The new type is mostly relevant for GPU testing as f16 is a common target for hardware accelerated operations.

Required changes are propagated around as extra differentiation is now needed to select between f16 and bf16.