### PR TITLE
Retire method style casts

### DIFF
--- a/include/TPP/Dialect/Check/CheckOps.td
+++ b/include/TPP/Dialect/Check/CheckOps.td
@@ -49,7 +49,7 @@ def CHECK_ExpectAlmostEqOp :
     Op<CHECK_Dialect, "expect_almost_eq",
     [TypesMatchWith<"Operand types match",
                     "lhs", "rhs",
-                    "$_self.cast<ShapedType>()">,
+                    "cast<ShapedType>($_self)">,
      MemoryEffects<[MemWrite, MemRead]>]> {
   let summary = [{Checks that the operands are almost equal}];
   let description = [{

--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -48,12 +48,12 @@ def Xsmm_BinaryOp : Xsmm_Op<"binary", [MemoryEffects<[MemWrite, MemRead]>]> {
 
     bool hasScalarLhs() {
       Type operand = getInputs()[1].getType();
-      return !operand.isa<ShapedType>();
+      return !isa<ShapedType>(operand);
     }
 
     bool hasScalarRhs() {
       Type operand = getInputs()[2].getType();
-      return !operand.isa<ShapedType>();
+      return !isa<ShapedType>(operand);
     }
   }];
 
@@ -84,7 +84,7 @@ def Xsmm_UnaryOp : Xsmm_Op<"unary", [MemoryEffects<[MemWrite, MemRead]>]> {
 
     bool hasScalarInput() {
       Type operand = getInputs()[1].getType();
-      return !operand.isa<ShapedType>();
+      return !isa<ShapedType>(operand);
     }
   }];
 

--- a/include/TPP/IR/StructuredOpMatcher.h
+++ b/include/TPP/IR/StructuredOpMatcher.h
@@ -214,7 +214,7 @@ struct HasRank {
     auto operandType = operand->get().getType();
     if (!isa<ShapedType>(operandType))
       return llvm::is_contained(ranks, HasRank::SCALAR);
-    int64_t rank = operandType.cast<ShapedType>().getRank();
+    int64_t rank = cast<ShapedType>(operandType).getRank();
     return llvm::any_of(
         ranks, [=](int64_t expectedRank) { return expectedRank == rank; });
   }

--- a/lib/TPP/Conversion/ConvertLinalgToFunc/ConvertLinalgToFunc.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToFunc/ConvertLinalgToFunc.cpp
@@ -109,7 +109,7 @@ struct ConvertMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
     SmallVector<Value> operands = matmulOp.getDpsInputs();
     operands.push_back(matmulOp.getDpsInits()[0]);
     if (!llvm::all_of(operands, [](Value operand) {
-          MemRefType memref = operand.getType().cast<MemRefType>();
+          MemRefType memref = cast<MemRefType>(operand.getType());
           return memref.getLayout().isIdentity() &&
                  memref.getElementType().isF32();
         })) {

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -244,14 +244,14 @@ static FailureOr<xsmm::UnaryFlags> getBroadCastUnaryFlagFromMap(AffineMap map) {
 static Value makeOperandShapeRowBroadCastable(RewriterBase &rewriter,
                                               Location loc, Value output,
                                               Value operand) {
-  assert(output.getType().isa<ShapedType>());
-  assert(operand.getType().isa<ShapedType>());
+  assert(isa<ShapedType>(output.getType()));
+  assert(isa<ShapedType>(operand.getType()));
 
-  ShapedType shapedOutput = output.getType().cast<ShapedType>();
+  ShapedType shapedOutput = cast<ShapedType>(output.getType());
   if (shapedOutput.getRank() != 2)
     return operand;
 
-  ShapedType shapedOperand = operand.getType().cast<ShapedType>();
+  ShapedType shapedOperand = cast<ShapedType>(operand.getType());
   if (shapedOperand.getRank() != 1)
     return operand;
 
@@ -642,7 +642,7 @@ static void emitTransposeOnOperand(RewriterBase &rewriter,
   rewriter.setInsertionPoint(linalgOp);
 
   Location loc = linalgOp.getLoc();
-  auto operandType = operand->get().getType().cast<ShapedType>();
+  auto operandType = cast<ShapedType>(operand->get().getType());
   auto rank = operandType.getRank();
   SmallVector<int64_t> shape = llvm::to_vector(operandType.getShape());
   auto permutation = llvm::to_vector(llvm::seq<int64_t>(0, rank));
@@ -697,7 +697,7 @@ static void emitTransposeOnOperand(RewriterBase &rewriter,
 }
 
 static bool isInnerMostDim(OpOperand *operand, unsigned minorDim) {
-  auto shapedType = operand->get().getType().cast<ShapedType>();
+  auto shapedType = cast<ShapedType>(operand->get().getType());
   unsigned rank = shapedType.getRank();
   return minorDim == rank - 1;
 }
@@ -1017,8 +1017,8 @@ struct ConvertVnniPacking : public OpRewritePattern<linalg::TransposeOp> {
 
     Value out = transposeOp.getInit();
     Value source = transposeOp.getInput();
-    MemRefType outType = out.getType().cast<MemRefType>();
-    MemRefType sourceType = source.getType().cast<MemRefType>();
+    MemRefType outType = cast<MemRefType>(out.getType());
+    MemRefType sourceType = cast<MemRefType>(source.getType());
     if (!outType.hasStaticShape() || !sourceType.hasStaticShape() ||
         !vnni::utils::isInVnniLayout(vnni::utils::VnniOperandRank::TRANSPOSE,
                                      outType)) {
@@ -1078,15 +1078,15 @@ struct ConvertGenericToVnniMatmulLikeOp
     Value bufferB = genericOp.getDpsInputs()[1];
     Value bufferC = genericOp.getDpsInits()[0];
 
-    int64_t m = bufferC.getType().cast<ShapedType>().getShape()[0];
-    int64_t n = bufferC.getType().cast<ShapedType>().getShape()[1];
+    int64_t m = cast<ShapedType>(bufferC.getType()).getShape()[0];
+    int64_t n = cast<ShapedType>(bufferC.getType()).getShape()[1];
     int64_t kPos = 1;
     if (hasBatch)
       kPos++;
-    int64_t k = bufferA.getType().cast<ShapedType>().getShape()[kPos];
+    int64_t k = cast<ShapedType>(bufferA.getType()).getShape()[kPos];
     int64_t batch = 0;
     if (hasBatch)
-      batch = bufferA.getType().cast<ShapedType>().getShape()[0];
+      batch = cast<ShapedType>(bufferA.getType()).getShape()[0];
 
     auto stridesOnLhs = utils::getStaticStrides(bufferA);
     auto stridesOnRhs = utils::getStaticStrides(bufferB);

--- a/lib/TPP/Dialect/Transform/LinalgXTransformOps.cpp
+++ b/lib/TPP/Dialect/Transform/LinalgXTransformOps.cpp
@@ -88,8 +88,8 @@ transform::CollapseOp::getReassociationIndices() {
   SmallVector<ReassociationIndices, 4> reassociationIndices;
   for (auto attr : getReassociation())
     reassociationIndices.push_back(llvm::to_vector<2>(
-        llvm::map_range(attr.cast<ArrayAttr>(), [&](Attribute indexAttr) {
-          return indexAttr.cast<IntegerAttr>().getInt();
+        llvm::map_range(cast<ArrayAttr>(attr), [&](Attribute indexAttr) {
+          return cast<IntegerAttr>(indexAttr).getInt();
         })));
   return reassociationIndices;
 }
@@ -172,7 +172,7 @@ transform::GetBlockedConvolutions::apply(transform::TransformRewriter &rewriter,
     if (linalgx::utils::isBlockedConvolution(op))
       res.push_back(op);
   }
-  results.set(getResult().cast<OpResult>(), res);
+  results.set(cast<OpResult>(getResult()), res);
   return DiagnosedSilenceableFailure::success();
 }
 
@@ -192,7 +192,7 @@ transform::GetBlockedMatmuls::apply(transform::TransformRewriter &rewriter,
       res.push_back(op);
     }
   }
-  results.set(getResult().cast<OpResult>(), res);
+  results.set(cast<OpResult>(getResult()), res);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
@@ -256,7 +256,7 @@ verifyUniquenessAndConsistency(ArrayAttr flags, Operation *op,
                                const std::string_view &flagsName) {
   SmallVector<int64_t> flagsAsInt;
   for (auto flag : flags)
-    flagsAsInt.push_back(flag.cast<IntegerAttr>().getInt());
+    flagsAsInt.push_back(cast<IntegerAttr>(flag).getInt());
 
   // check uniqueness
   std::sort(flagsAsInt.begin(), flagsAsInt.end());
@@ -286,7 +286,7 @@ static LogicalResult verifyGemmFlags(ArrayAttr flags, DataType dataType,
 
   SmallVector<int64_t> flagsAsInt;
   for (auto flag : flags) {
-    flagsAsInt.push_back(flag.cast<IntegerAttr>().getInt());
+    flagsAsInt.push_back(cast<IntegerAttr>(flag).getInt());
   }
   // VNNI flags must be specified only for bf16 type
   if (dataType != DataType::BF16 && llvm::any_of(flagsAsInt, [](int64_t flag) {

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -50,7 +50,7 @@ FailureOr<UnaryInfo> getUnaryInfo(Value input, Value output,
   Type outputType = output.getType();
 
   assert(isa<ShapedType>(outputType));
-  auto outputShapedType = outputType.cast<ShapedType>();
+  auto outputShapedType = cast<ShapedType>(outputType);
   if (outputShapedType.getRank() != 2 || !outputShapedType.hasStaticShape() ||
       !isa<FloatType>(outputShapedType.getElementType())) {
     return failure();
@@ -96,7 +96,7 @@ FailureOr<BinaryInfo> getBinaryInfo(Value lhs, BinaryFlags lhsFlag, Value rhs,
   Type outputType = output.getType();
 
   assert(isa<ShapedType>(outputType));
-  auto outputShapedType = outputType.cast<ShapedType>();
+  auto outputShapedType = cast<ShapedType>(outputType);
   if (outputShapedType.getRank() != 2 || !outputShapedType.hasStaticShape() ||
       !isa<FloatType>(outputShapedType.getElementType())) {
     return failure();
@@ -187,17 +187,17 @@ computeBcastShapeInput(ArrayRef<int64_t> higherRankShape,
 }
 
 FailureOr<UnaryFlags> getUnaryFlags(Type inputType, Type outputType) {
-  assert(outputType.isa<ShapedType>() && "expect shaped type on output");
-  assert(outputType.cast<ShapedType>().getRank() == 2 &&
+  assert(isa<ShapedType>(outputType) && "expect shaped type on output");
+  assert(cast<ShapedType>(outputType).getRank() == 2 &&
          "expect rank 2 on output");
 
-  if (!inputType.isa<ShapedType>() ||
-      inputType.cast<ShapedType>().getRank() == 0) {
+  if (!isa<ShapedType>(inputType) ||
+      cast<ShapedType>(inputType).getRank() == 0) {
     return xsmm::UnaryFlags::BCAST_SCALAR;
   }
 
-  ArrayRef<int64_t> shapeOutput = outputType.cast<ShapedType>().getShape();
-  ArrayRef<int64_t> shapeInput = inputType.cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shapeOutput = cast<ShapedType>(outputType).getShape();
+  ArrayRef<int64_t> shapeInput = cast<ShapedType>(inputType).getShape();
   assert(shapeOutput.size() >= shapeInput.size() &&
          "output rank must be >= input rank");
   SmallVector<int64_t> bShapeInput;
@@ -225,20 +225,20 @@ FailureOr<UnaryFlags> getUnaryFlags(Type inputType, Type outputType) {
 
 FailureOr<BinaryFlags> getBinaryFlags(Type operandType, Type outputType,
                                       OperandPos operandNumber) {
-  assert(outputType.isa<ShapedType>() && "expect shaped type on output");
-  assert(outputType.cast<ShapedType>().getRank() == 2 &&
+  assert(isa<ShapedType>(outputType) && "expect shaped type on output");
+  assert(cast<ShapedType>(outputType).getRank() == 2 &&
          "expect rank 2 on output");
 
-  if (!operandType.isa<ShapedType>() ||
-      operandType.cast<ShapedType>().getRank() == 0) {
+  if (!isa<ShapedType>(operandType) ||
+      cast<ShapedType>(operandType).getRank() == 0) {
     if (operandNumber == OperandPos::LHS)
       return xsmm::BinaryFlags::BCAST_SCALAR_IN_0;
     return xsmm::BinaryFlags::BCAST_SCALAR_IN_1;
   }
 
   enum class BCastType { NONE = 0, SCALAR, ROW, COL };
-  auto shapeOutput = outputType.cast<MemRefType>().getShape();
-  auto shapeOperand = operandType.cast<MemRefType>().getShape();
+  auto shapeOutput = cast<MemRefType>(outputType).getShape();
+  auto shapeOperand = cast<MemRefType>(operandType).getShape();
   assert(shapeOutput.size() >= shapeOperand.size() &&
          "Output rank must be >= operand rank");
   SmallVector<int64_t> bOperandShape;

--- a/lib/TPP/Dialect/Xsmm/XsmmVerify.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmVerify.cpp
@@ -73,7 +73,7 @@ static LogicalResult verifyGemmDispatchAndInvokeLikeOp(InvokeTy gemmOp) {
   // VNNI flags must be consistent with the memref shapes.
   ArrayAttr flags = dispatchOp->getFlags();
   for (auto flag : flags) {
-    int64_t gemmFlag = flag.cast<IntegerAttr>().getInt();
+    int64_t gemmFlag = cast<IntegerAttr>(flag).getInt();
     if (gemmFlag == static_cast<int64_t>(xsmm::GemmFlags::VNNI_A) &&
         !vnni::utils::isInVnniLayout(expectedVnniRankIns, operandA)) {
       return gemmOp.emitOpError(
@@ -101,7 +101,7 @@ static LogicalResult verifyFlags(xsmm::UnaryOp invokeUnaryOp,
   assert(succeeded(expectedFlag));
   auto flags = dispatchUnaryOp.getFlags();
   for (auto flag : flags) {
-    switch (flag.cast<xsmm::UnaryFlagsAttr>().getValue()) {
+    switch (cast<xsmm::UnaryFlagsAttr>(flag).getValue()) {
     case xsmm::UnaryFlags::NONE:
       if (*expectedFlag != xsmm::UnaryFlags::NONE) {
         return invokeUnaryOp.emitOpError("invalid 'none' flag for input");
@@ -140,7 +140,7 @@ static LogicalResult verifyFlags(xsmm::BinaryOp invokeBinaryOp,
 
   auto flags = dispatchBinaryOp.getFlags();
   for (auto flag : flags) {
-    switch (flag.cast<xsmm::BinaryFlagsAttr>().getValue()) {
+    switch (cast<xsmm::BinaryFlagsAttr>(flag).getValue()) {
     case xsmm::BinaryFlags::NONE:
       if ((*expectedFlagsLhs != xsmm::BinaryFlags::NONE) ||
           (*expectedFlagsRhs != xsmm::BinaryFlags::NONE)) {

--- a/lib/TPP/GPU/GpuDataTransfer.cpp
+++ b/lib/TPP/GPU/GpuDataTransfer.cpp
@@ -68,8 +68,8 @@ static FailureOr<Value> matchTransferBuffers(RewriterBase &rewriter,
                                              Value gpuBuffer) {
   auto loc = gpuBuffer.getLoc();
 
-  auto operandType = kernelOperand.getType().cast<MemRefType>();
-  auto gpuAllocType = gpuBuffer.getType().cast<MemRefType>();
+  auto operandType = cast<MemRefType>(kernelOperand.getType());
+  auto gpuAllocType = cast<MemRefType>(gpuBuffer.getType());
 
   // Kernel operands type already matches the device buffer.
   // The host and device buffers can be used directly.

--- a/lib/TPP/GPU/GpuVulkanAbi.cpp
+++ b/lib/TPP/GPU/GpuVulkanAbi.cpp
@@ -57,15 +57,15 @@ static Type FlattenMemrefType(MemRefType memrefType) {
 static Type getVulkanTypeWrapper(Type type,
                                  const SPIRVTypeConverter &typeConverter,
                                  RewriterBase &rewriter) {
-  assert(!type.isa<TensorType>() && "Tensors are not supported by Vulkan");
+  assert(!isa<TensorType>(type) && "Tensors are not supported by Vulkan");
 
   // Buffers are already Vulkan compatible.
   if (auto memrefType = type.dyn_cast<MemRefType>())
     return FlattenMemrefType(memrefType);
 
   // Index has to be converted to a fixed-size integer.
-  if (type.isa<IndexType>()) {
-    auto spirvIndex = typeConverter.getIndexType().cast<spirv::SPIRVType>();
+  if (isa<IndexType>(type)) {
+    auto spirvIndex = cast<spirv::SPIRVType>(typeConverter.getIndexType());
     type = rewriter.getIntegerType(*(spirvIndex.getSizeInBytes()) * 8);
   }
 
@@ -142,17 +142,17 @@ static Value getVulkanOperandWrapper(Value operand,
   auto loc = operand.getLoc();
   auto type = operand.getType();
 
-  assert(!type.isa<TensorType>() && "Tensors are not supported by Vulkan");
+  assert(!isa<TensorType>(type) && "Tensors are not supported by Vulkan");
 
   // Buffers are Vulkan compatible but need to be min 1D and max 3D shaped.
-  if (type.isa<MemRefType>())
+  if (isa<MemRefType>(type))
     return FlattenMemrefOperand(operand, rewriter);
 
   auto wrapperType =
-      getVulkanTypeWrapper(type, typeConverter, rewriter).cast<MemRefType>();
+      cast<MemRefType>(getVulkanTypeWrapper(type, typeConverter, rewriter));
 
   // Cast index to a fixed-size integer.
-  if (type.isa<IndexType>()) {
+  if (isa<IndexType>(type)) {
     auto castType = wrapperType.getElementType();
     operand =
         rewriter.create<arith::IndexCastOp>(loc, castType, operand).getOut();

--- a/lib/TPP/GPU/LinalgToGpu.cpp
+++ b/lib/TPP/GPU/LinalgToGpu.cpp
@@ -86,9 +86,9 @@ static bool isMMACompatible(linalg::LinalgOp linalgOp,
   if (linalgOp.hasDynamicShape())
     return false;
 
-  auto aType = linalgOp.getDpsInputs()[0].getType().cast<ShapedType>();
-  auto bType = linalgOp.getDpsInputs()[1].getType().cast<ShapedType>();
-  auto cType = linalgOp.getDpsInits()[0].getType().cast<ShapedType>();
+  auto aType = cast<ShapedType>(linalgOp.getDpsInputs()[0].getType());
+  auto bType = cast<ShapedType>(linalgOp.getDpsInputs()[1].getType());
+  auto cType = cast<ShapedType>(linalgOp.getDpsInits()[0].getType());
 
   auto elemTypeA = aType.getElementType();
   auto elemTypeB = bType.getElementType();
@@ -131,7 +131,7 @@ eltwiseFusion(linalg::LinalgOp rootOp, linalg::LinalgOp consumer,
   Location loc = rootOp.getLoc();
 
   auto rootOutput = rootOp.getDpsInits()[0];
-  auto outputType = rootOutput.getType().cast<ShapedType>();
+  auto outputType = cast<ShapedType>(rootOutput.getType());
 
   // Must be a floating point type.
   // TODO: Add integer support.
@@ -239,7 +239,7 @@ static std::optional<memref::StoreOp> eltwiseFusion(linalg::LinalgOp rootOp,
                                                     PatternRewriter &rewriter) {
   Location loc = rootOp.getLoc();
   auto rootOutput = rootOp.getDpsInits()[0];
-  auto outputType = rootOutput.getType().cast<ShapedType>();
+  auto outputType = cast<ShapedType>(rootOutput.getType());
 
   // Must be a floating point type.
   // TODO: Add integer support.
@@ -259,7 +259,7 @@ static std::optional<memref::StoreOp> eltwiseFusion(linalg::LinalgOp rootOp,
   if (structured_match::utils::isTwoDAddOp(consumer, &operands)) {
     // Get the value to be added. Load the element first, if necessary.
     auto addValue = (operands[0] != rootOutput) ? operands[0] : operands[1];
-    if (addValue.getType().isa<ShapedType>()) {
+    if (isa<ShapedType>(addValue.getType())) {
       addValue = rewriter.create<memref::LoadOp>(loc, addValue, storeIndices)
                      .getResult();
     }
@@ -379,9 +379,9 @@ static LogicalResult gemmToGpuMMA(linalg::LinalgOp linalgOp,
   auto matB = linalgOp.getDpsInputs()[1];
   auto matC = linalgOp.getDpsInits()[0];
 
-  auto typeA = matA.getType().cast<ShapedType>();
-  auto typeB = matB.getType().cast<ShapedType>();
-  auto typeC = matC.getType().cast<ShapedType>();
+  auto typeA = cast<ShapedType>(matA.getType());
+  auto typeB = cast<ShapedType>(matB.getType());
+  auto typeC = cast<ShapedType>(matC.getType());
 
   auto stridesA = utils::getStaticStrides(matA);
   auto stridesB = utils::getStaticStrides(matB);
@@ -612,8 +612,8 @@ static LogicalResult gemmToGpuLoops(linalg::LinalgOp linalgOp,
   auto matB = linalgOp.getDpsInputs()[1];
   auto matC = linalgOp.getDpsInits()[0];
 
-  ArrayRef<int64_t> shapeC = matC.getType().cast<ShapedType>().getShape();
-  ArrayRef<int64_t> shapeA = matA.getType().cast<ShapedType>().getShape();
+  ArrayRef<int64_t> shapeC = cast<ShapedType>(matC.getType()).getShape();
+  ArrayRef<int64_t> shapeA = cast<ShapedType>(matA.getType()).getShape();
 
   // Parallel dims.
   Value i = rewriter.create<arith::ConstantIndexOp>(loc, shapeC[0]);

--- a/lib/TPP/IR/MatcherUtils.cpp
+++ b/lib/TPP/IR/MatcherUtils.cpp
@@ -400,7 +400,7 @@ bool isTwoDZeroOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
 
   // Only take the output as tpp.zero is an in-place operation.
   Value output = linalgOp.getDpsInits()[0];
-  if (!output.getType().isa<ShapedType>())
+  if (!isa<ShapedType>(output.getType()))
     return false;
 
   if (operands)
@@ -424,7 +424,7 @@ bool isTwoDBiasReluOp(linalg::LinalgOp linalgOp,
 
   // Only take the output as tpp.add + tpp.relu should be in-place operations.
   Value output = linalgOp.getDpsInits()[0];
-  if (!output.getType().isa<ShapedType>())
+  if (!isa<ShapedType>(output.getType()))
     return false;
 
   if (operands)

--- a/lib/TPP/Transforms/CombineXsmmPass.cpp
+++ b/lib/TPP/Transforms/CombineXsmmPass.cpp
@@ -82,7 +82,7 @@ struct CombineXsmmOp : public OpRewritePattern<xsmm::BrgemmOp> {
                                    brgemmOp.getOperand(0).getDefiningOp())
                                    .getInputs());
     auto memrefB = brgemmOp.getOperand(2);
-    int64_t batchSize = memrefB.getType().cast<ShapedType>().getShape()[0];
+    int64_t batchSize = cast<ShapedType>(memrefB.getType()).getShape()[0];
     auto brgemmFlags = xsmm::utils::getBrgemmFlags<xsmm::BrgemmDispatchOp>(
         rewriter,
         dyn_cast<xsmm::BrgemmDispatchOp>(

--- a/lib/TPP/Transforms/ConstantFoldPack.cpp
+++ b/lib/TPP/Transforms/ConstantFoldPack.cpp
@@ -42,7 +42,7 @@ struct ConstantFoldPack
     if (!cstOp)
       return failure();
     auto cst = cstOp.getValue();
-    if (!cst.isa<DenseElementsAttr>())
+    if (!isa<DenseElementsAttr>(cst))
       return failure();
     auto oldDense = cast<DenseElementsAttr>(cst);
     return std::make_pair(cstOp, oldDense);

--- a/lib/TPP/Transforms/RewriteConvToMatmulImpl.cpp
+++ b/lib/TPP/Transforms/RewriteConvToMatmulImpl.cpp
@@ -21,7 +21,7 @@ using namespace mlir;
 static SmallVector<OpFoldResult>
 computeSizeGemmForImage(OpBuilder &builder, linalg::LinalgOp linalgOp) {
   OpOperand *image = linalgOp.getDpsInputOperands()[0];
-  unsigned rank = image->get().getType().cast<ShapedType>().getRank();
+  unsigned rank = cast<ShapedType>(image->get().getType()).getRank();
   SmallVector<OpFoldResult> sizes;
   sizes.reserve(rank);
 
@@ -32,10 +32,9 @@ computeSizeGemmForImage(OpBuilder &builder, linalg::LinalgOp linalgOp) {
 
   Value output = linalgOp.getDpsInits()[0];
   OpOperand *filter = linalgOp.getDpsInputOperands()[1];
-  ArrayRef<int64_t> outputShape =
-      output.getType().cast<ShapedType>().getShape();
+  ArrayRef<int64_t> outputShape = cast<ShapedType>(output.getType()).getShape();
   ArrayRef<int64_t> filterShape =
-      filter->get().getType().cast<ShapedType>().getShape();
+      cast<ShapedType>(filter->get().getType()).getShape();
   int64_t mIdx = outputShape.size() - 2;
   int64_t kIdx = filterShape.size() - 2;
   sizes.push_back(
@@ -104,7 +103,7 @@ static FailureOr<Value> getSlicedConvOperandImpl(OpBuilder &builder,
                                                  ValueRange ivs,
                                                  ValueRange valuesToUse) {
   Value operandToUse = valuesToUse[operand->getOperandNumber()];
-  ShapedType operandType = operandToUse.getType().cast<ShapedType>();
+  ShapedType operandType = cast<ShapedType>(operandToUse.getType());
   size_t rank = operandType.getRank();
   bool isImage = operand->getOperandNumber() == 0;
   unsigned desiredResultRank = 2;
@@ -292,8 +291,8 @@ mlir::linalgx::rewriteConvToMatmul(RewriterBase &rewriter,
   SmallVector<Operation *, 8> loops;
   loops.reserve(ivs.size());
   for (Value iv : ivs) {
-    if (iv.isa<BlockArgument>()) {
-      loops.push_back(iv.cast<BlockArgument>().getOwner()->getParentOp());
+    if (isa<BlockArgument>(iv)) {
+      loops.push_back(cast<BlockArgument>(iv).getOwner()->getParentOp());
       assert(loops.back() && "no owner found for induction variable!");
     } else {
       loops.push_back(nullptr);

--- a/lib/TPP/Transforms/RewriteToBatchReduceGemm.cpp
+++ b/lib/TPP/Transforms/RewriteToBatchReduceGemm.cpp
@@ -154,8 +154,8 @@ static Operation *getOuterMostLoop(ArrayRef<Value> ivs) {
   SmallVector<Operation *, 8> loops;
   loops.reserve(ivs.size());
   for (Value iv : ivs) {
-    if (iv.isa<BlockArgument>()) {
-      loops.push_back(iv.cast<BlockArgument>().getOwner()->getParentOp());
+    if (isa<BlockArgument>(iv)) {
+      loops.push_back(cast<BlockArgument>(iv).getOwner()->getParentOp());
       assert(loops.back() && "no owner found for induction variable!");
     } else {
       loops.push_back(nullptr);

--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -56,9 +56,9 @@ static Value toPackLayoutImpl(OpBuilder &builder, Location loc, Value input,
   SmallVector<int64_t> staticTiles;
   dispatchIndexOpFoldResults(tiles, dynamicTiles, staticTiles);
   RankedTensorType result =
-      tensor::PackOp::inferPackedType(input.getType().cast<RankedTensorType>(),
+      tensor::PackOp::inferPackedType(cast<RankedTensorType>(input.getType()),
                                       staticTiles, innerDimsPos, outerDimsPerm);
-  auto inputType = input.getType().cast<RankedTensorType>();
+  auto inputType = cast<RankedTensorType>(input.getType());
   ArrayRef<int64_t> shape = result.getShape();
   Value output =
       builder.create<tensor::EmptyOp>(loc, shape, inputType.getElementType());
@@ -82,7 +82,7 @@ static Value handleLayout_VNNI(OpBuilder &builder, Location loc, Value input,
                                ArrayRef<OpFoldResult> tiles) {
   assert(tiles.size() == 1 && "expect 1 block for VNNI");
   SmallVector<int64_t> innerDimPos = {
-      input.getType().cast<ShapedType>().getRank() - 2};
+      cast<ShapedType>(input.getType()).getRank() - 2};
   return toPackLayoutImpl(builder, loc, input, tiles, innerDimPos,
                           /*outerDimsPerm=*/{});
 }

--- a/tools/tpp-run/MLIRBench.cpp
+++ b/tools/tpp-run/MLIRBench.cpp
@@ -401,7 +401,7 @@ LogicalResult MLIRBench::printResult(Operation *kernelCall) {
     auto memrefType =
         MemRefType::get(resType.getShape(), resType.getElementType());
 
-    if (result.getType().isa<TensorType>()) {
+    if (isa<TensorType>(result.getType())) {
       result =
           builder.create<bufferization::ToMemrefOp>(unkLoc, memrefType, result);
     }


### PR DESCRIPTION
Aligns with MLIR style guideline on casting style.
The method style casts are now deprecated.