### PR TITLE
Retire downstream pack-fill propagation

### DIFF
--- a/test/Passes/pack-unpack-propagation.mlir
+++ b/test/Passes/pack-unpack-propagation.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -propagate-pack-and-unpack -simplify-pack -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -propagate-pack-and-unpack -simplify-pack -canonicalize -split-input-file | FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>


### PR DESCRIPTION
The logic is covered by upstream fill op canonicalization pattern.