### PR TITLE
[NFC] Separate local dialect lowering from low-level parallelization

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -280,6 +280,22 @@ def Cleanup : Pass<"cleanup", "func::FuncOp"> {
   let summary = "General IR cleanup e.g., canonicalization, CSE etc.";
 }
 
+def LowLevelParallelization : Pass<"low-level-paralle", "ModuleOp"> {
+  let summary = "Low level parallelization (multi-threading, AMX config).";
+  let dependentDialects = ["affine::AffineDialect",
+                           "arith::ArithDialect",
+                           "func::FuncDialect",
+                           "memref::MemRefDialect",
+                           "scf::SCFDialect",
+                           "xsmm::XsmmDialect",
+                           "LLVM::LLVMDialect"];
+  let options = [
+    ListOption<"parallelTaskGrid", "parallel-task-grid",
+           "unsigned", "Grid-sizes for parallel tasks.">
+
+  ];
+}
+
 def LocalDialectsLowering : Pass<"lower-local-dialects", "ModuleOp"> {
   let summary = "Lower all local dialects (XSMM, check etc.).";
   let dependentDialects = ["affine::AffineDialect",
@@ -292,12 +308,6 @@ def LocalDialectsLowering : Pass<"lower-local-dialects", "ModuleOp"> {
                            "tensor::TensorDialect",
                            "xsmm::XsmmDialect",
                            "LLVM::LLVMDialect"];
-  let options = [
-    ListOption<"parallelTaskGrid", "parallel-task-grid",
-           "unsigned", "Grid-sizes for parallel tasks.">
-
-  ];
-
 }
 
 def Postprocessing : Pass<"postprocess", "func::FuncOp"> {

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -280,7 +280,7 @@ def Cleanup : Pass<"cleanup", "func::FuncOp"> {
   let summary = "General IR cleanup e.g., canonicalization, CSE etc.";
 }
 
-def LowLevelParallelization : Pass<"low-level-paralle", "ModuleOp"> {
+def LowLevelParallelization : Pass<"low-level-parallel", "ModuleOp"> {
   let summary = "Low level parallelization (multi-threading, AMX config).";
   let dependentDialects = ["affine::AffineDialect",
                            "arith::ArithDialect",

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -135,8 +135,6 @@ private:
 
     // Partial Lowering
     pm.addPass(memref::createExpandStridedMetadataPass());
-    pm.addNestedPass<func::FuncOp>(createConvertPerfToLoops());
-    pm.addPass(tpp::createConvertPerfToFunc());
     pm.addPass(createConvertTensorToLinalgPass());
     pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
     if (defParallel)


### PR DESCRIPTION
The 2D parallelization and AMX tile config stuff were bundled into the local dialect lowering passes because that's "an XSMM thing". But that's changing, as we start working on multi-level loop parallelization, this will raise to tensor eventually and we need to separate the transform from the dialect.

This PR however, does none of that. It just separates the "bundles" to de-couple dialect lowering from the loop passes. Should not change a iota on the output.

Also removing a duplicated call to lower the `perf` dialect in the main pipeline.