### PR TITLE
Update README.md - include using ldd for linking of ttp-mlir

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ cmake -G Ninja .. \
    -DMLIR_DIR=$CUSTOM_LLVM_ROOT/lib/cmake/mlir \
    -DLLVM_EXTERNAL_LIT=$CUSTOM_LLVM_ROOT/bin/llvm-lit \
    -DCMAKE_C_COMPILER=clang \
-   -DCMAKE_CXX_COMPILER=clang++ 
+   -DCMAKE_CXX_COMPILER=clang++ \
+   -DLLVM_USE_LINKER=lld
 cmake --build . --target check-tpp
 
 popd


### PR DESCRIPTION
Without `-DLLVM_USE_LINKER=lld`, there's a linking issue for `bin/tpp-opt`.

Closes #935.