### PR TITLE
Update README.md - remove outdated command for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,6 @@ cmake --build . --target check-tpp
 popd
 ```
 
-To build the documentation from the TableGen description of the dialect
-operations, run:
-
-```sh
-cmake --build . --target mlir-doc
-```
-
 To enable experimental GPU support see: [GPU/README.md](lib/TPP/GPU/README.md)
 
 ### Conda Environment


### PR DESCRIPTION
Remove the directions for building TableGen-derived documentation as the indicated CMake target, `mlir-doc`, does not work.

When I run `cmake --build . --target mlir-doc`, I get the following error:

```
ninja: error: '/home/rolf/intel_code/tpp-mlir/include/TPP/Dialect/Check/CheckDialect.td', needed by 'include/TPP/Dialect/Check/CheckDialect.md', missing and no known rule to make it
```

To me this indicates that there are rules for this target but that they are currently broken (something wrong with the `CMakeLists.txt` for the `Check` dialect?). This PR only addresses the documentation aspect. We might want to fix the `mlir-doc` target (e.g. by removing it) in another PR.