### PR TITLE
Fix undefined reference when building pass bundles

### DIFF
--- a/lib/TPP/PassBundles/CMakeLists.txt
+++ b/lib/TPP/PassBundles/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_library(TPPPassBundles
 
   LINK_LIBS PUBLIC
     MLIRIR
+    TPPTransforms
     ${mlir_dialect_libs}
     ${conversion_libs}
   )


### PR DESCRIPTION
This PR fixs compilation errors shown as follows
```
/opt/rh/gcc-toolset-11/root/usr/bin/ld: lib/libTPPGPU.a(GpuPipeline.cpp.o): in function `(anonymous namespace)::GpuPipeline::constructPipeline()':
/home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/GPU/GpuPipeline.cpp:192: undefined reference to `mlir::tpp::createTileConsumerAndFuseProducers(mlir::tpp::TileConsumerAndFuseProducersOptions const&)'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/GPU/GpuPipeline.cpp:179: undefined reference to `mlir::tpp::createTileConsumerAndFuseProducers(mlir::tpp::TileConsumerAndFuseProducersOptions const&)'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/GPU/GpuPipeline.cpp:188: undefined reference to `mlir::tpp::createTileConsumerAndFuseProducers(mlir::tpp::TileConsumerAndFuseProducersOptions const&)'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: lib/libTPPPassBundles.a(LinalgLowering.cpp.o): in function `LinalgLowering::constructPipeline()':
/home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/PassBundles/LinalgLowering.cpp:51: undefined reference to `mlir::tpp::createCombineXsmmOpPass()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: lib/libTPPPassBundles.a(LinalgLowering.cpp.o): in function `non-virtual thunk to LinalgLowering::constructPipeline()':
/home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/PassBundles/LinalgLowering.cpp:54: undefined reference to `mlir::tpp::createCombineXsmmOpPass()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: lib/libTPPPassBundles.a(LinalgLowering.cpp.o): in function `LinalgLowering::constructPipeline()':
/home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/PassBundles/LinalgLowering.cpp:51: undefined reference to `mlir::tpp::createCombineXsmmOpPass()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: lib/libTPPPassBundles.a(LowLevelParallelization.cpp.o): in function `LowLevelParallelization::constructPipeline()':
/home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/PassBundles/LowLevelParallelization.cpp:68: undefined reference to `mlir::tpp::createSCFParallelLoopTiling(mlir::tpp::SCFParallelLoopTilingOptions const&)'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/PassBundles/LowLevelParallelization.cpp:70: undefined reference to `mlir::tpp::createIntelAMXTileConfigInsertionPass()'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /home/yifei/mlir_env/tpp-mlir/build/../lib/TPP/PassBundles/LowLevelParallelization.cpp:74: undefined reference to `mlir::tpp::createIntelAMXTileConfigHoistingPass()'
```