### PR TITLE
Transposed matmul block packing

### DIFF
--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -454,7 +454,9 @@ getDefaultBlockingFactors(linalg::LinalgOp linalgOp) {
     return {32, 32};
   }
   assert(isa<linalg::MatmulOp>(linalgOp) ||
-         isa<linalg::BatchMatmulOp>(linalgOp));
+         isa<linalg::BatchMatmulOp>(linalgOp) ||
+         isa<linalg::MatmulTransposeAOp>(linalgOp) ||
+         isa<linalg::MatmulTransposeBOp>(linalgOp));
   return {32, 32, 32};
 }
 
@@ -482,6 +484,8 @@ struct PackMatmul : public tpp::impl::PackMatmulBase<PackMatmul> {
 
       // Pack only these two named matmul variants.
       if (!(isa<linalg::MatmulOp>(linalgOp) ||
+            isa<linalg::MatmulTransposeAOp>(linalgOp) ||
+            isa<linalg::MatmulTransposeBOp>(linalgOp) ||
             isa<linalg::BatchMatmulOp>(linalgOp))) {
         return std::nullopt;
       }

--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -482,7 +482,7 @@ struct PackMatmul : public tpp::impl::PackMatmulBase<PackMatmul> {
         -> std::optional<linalg::BlockPackMatmulOptions> {
       linalg::BlockPackMatmulOptions options;
 
-      // Pack only these two named matmul variants.
+      // Pack only these named matmul variants.
       if (!(isa<linalg::MatmulOp>(linalgOp) ||
             isa<linalg::MatmulTransposeAOp>(linalgOp) ||
             isa<linalg::MatmulTransposeBOp>(linalgOp) ||

--- a/test/Passes/DefaultPipeline/linalg-matmul-variants.mlir
+++ b/test/Passes/DefaultPipeline/linalg-matmul-variants.mlir
@@ -1,0 +1,95 @@
+// RUN: tpp-opt %s -default-tpp-passes -split-input-file | FileCheck %s
+
+func.func @matmul(%arg0: tensor<2048x2048xbf16>, %arg1: tensor<2048x2048xbf16>, %arg2: tensor<2048x2048xbf16>)
+    -> tensor<2048x2048xbf16> {
+  %0 = linalg.matmul ins(%arg0, %arg1: tensor<2048x2048xbf16>, tensor<2048x2048xbf16>)
+                     outs(%arg2: tensor<2048x2048xbf16>)
+    -> tensor<2048x2048xbf16>
+  return %0 : tensor<2048x2048xbf16>
+}
+
+// CHECK-LABEL: @matmul(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>,
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>,
+// CHECK-SAME: %[[ARG2:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>
+// CHECK: memref.subview %[[ARG0]]
+// CHECK: call @xsmm_unary_invoke
+// CHECK: memref.subview %[[ARG1]]
+// CHECK: call @xsmm_unary_invoke
+// CHECK: memref.subview %[[ARG2]]
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+// CHECK: call @xsmm_brgemm_invoke
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+
+// -----
+
+func.func @matmul_transpose_a(%arg0: tensor<2048x2048xbf16>, %arg1: tensor<2048x2048xbf16>, %arg2: tensor<2048x2048xbf16>)
+    -> tensor<2048x2048xbf16> {
+  %0 = linalg.matmul_transpose_a ins(%arg0, %arg1: tensor<2048x2048xbf16>, tensor<2048x2048xbf16>)
+                                 outs(%arg2: tensor<2048x2048xbf16>)
+    -> tensor<2048x2048xbf16>
+  return %0 : tensor<2048x2048xbf16>
+}
+
+// CHECK-LABEL: @matmul_transpose_a(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>,
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>,
+// CHECK-SAME: %[[ARG2:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>
+// CHECK: memref.subview %[[ARG0]]
+// CHECK: linalg.transpose
+// CHECK: memref.subview %[[ARG1]]
+// CHECK: call @xsmm_unary_invoke
+// CHECK: memref.subview %[[ARG2]]
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+// CHECK: call @xsmm_brgemm_invoke
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+
+// -----
+
+func.func @matmul_transpose_b(%arg0: tensor<2048x2048xbf16>, %arg1: tensor<2048x2048xbf16>, %arg2: tensor<2048x2048xbf16>)
+    -> tensor<2048x2048xbf16> {
+  %0 = linalg.matmul_transpose_b ins(%arg0, %arg1: tensor<2048x2048xbf16>, tensor<2048x2048xbf16>)
+                                 outs(%arg2: tensor<2048x2048xbf16>)
+    -> tensor<2048x2048xbf16>
+  return %0 : tensor<2048x2048xbf16>
+}
+
+// CHECK-LABEL: @matmul_transpose_b(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>,
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>,
+// CHECK-SAME: %[[ARG2:[a-zA-Z0-9]+]]: memref<2048x2048xbf16>
+// CHECK: memref.subview %[[ARG0]]
+// CHECK: call @xsmm_unary_invoke
+// CHECK: memref.subview %[[ARG1]]
+// CHECK: linalg.transpose
+// CHECK: memref.subview %[[ARG2]]
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+// CHECK: call @xsmm_brgemm_invoke
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+
+// -----
+
+func.func @batch_matmul(%arg0: tensor<8x2048x2048xbf16>, %arg1: tensor<8x2048x2048xbf16>, %arg2: tensor<8x2048x2048xbf16>)
+    -> tensor<8x2048x2048xbf16> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1: tensor<8x2048x2048xbf16>, tensor<8x2048x2048xbf16>)
+                           outs(%arg2: tensor<8x2048x2048xbf16>)
+    -> tensor<8x2048x2048xbf16>
+  return %0 : tensor<8x2048x2048xbf16>
+}
+
+// CHECK-LABEL: @batch_matmul(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: memref<8x2048x2048xbf16>,
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: memref<8x2048x2048xbf16>,
+// CHECK-SAME: %[[ARG2:[a-zA-Z0-9]+]]: memref<8x2048x2048xbf16>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+// CHECK: scf.parallel{{.*}}= (%[[C0]]) to (%[[C8]])
+// CHECK: %[[BATCH_SUBVIEW:.+]] = memref.subview %[[ARG2]]
+// CHECK: memref.subview %[[ARG0]]
+// CHECK: call @xsmm_unary_invoke
+// CHECK: memref.subview %[[ARG1]]
+// CHECK: call @xsmm_unary_invoke
+// CHECK: memref.subview %[[BATCH_SUBVIEW]]
+// CHECK: call @xsmm_intel_amx_tile_config_invoke
+// CHECK: call @xsmm_brgemm_invoke
+// CHECK: call @xsmm_intel_amx_tile_config_invoke

--- a/test/Passes/pass-matmul-blocking-default.mlir
+++ b/test/Passes/pass-matmul-blocking-default.mlir
@@ -3,7 +3,7 @@
 func.func @block_linalg_matmul(
   %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>)
     -> tensor<128x128xf32> {
-  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+  %0 = linalg.matmul ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
                      outs(%arg2: tensor<128x128xf32>)
     -> tensor<128x128xf32>
   return %0 : tensor<128x128xf32>
@@ -21,6 +21,64 @@ func.func @block_linalg_matmul(
 // CHECK: %[[PACK0:.+]] = tensor.pack %[[ARG0]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF0]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
 // CHECK: %[[BUF1:.*]] = tensor.empty() : tensor<4x4x32x32xf32>
 // CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]] outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF1]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF2]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[VAL:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP4]], #[[MAP5]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[PACK0]], %[[PACK1]] : tensor<4x4x32x32xf32>, tensor<4x4x32x32xf32>) outs(%[[PACK2]] : tensor<4x4x32x32xf32>)
+// CHECK: %[[OUT:.+]] = tensor.unpack %[[VAL]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[ARG2]] : tensor<4x4x32x32xf32> -> tensor<128x128xf32>
+// CHECK: return %[[OUT]] : tensor<128x128xf32>
+
+// -----
+
+func.func @block_linalg_matmul_transpose_a(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32> {
+  %0 = linalg.matmul_transpose_a ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                                 outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+// CHECK-DAG: #[[MAP3:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// CHECK-DAG: #[[MAP4:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// CHECK-DAG: #[[MAP5:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+// CHECK-LABEL: func @block_linalg_matmul_transpose_a(
+// CHECK-SAME:    %[[ARG0:[0-9a-z]+]]: tensor<128x128xf32>
+// CHECK-SAME:    %[[ARG1:[0-9a-z]+]]: tensor<128x128xf32>
+// CHECK-SAME:    %[[ARG2:[0-9a-z]+]]: tensor<128x128xf32>) -> tensor<128x128xf32> {
+// CHECK: %[[BUF0:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK0:.+]] = tensor.pack %[[ARG0]] outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [32, 32] into %[[BUF0]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[BUF1:.*]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]] outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF1]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF2]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[VAL:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP4]], #[[MAP5]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[PACK0]], %[[PACK1]] : tensor<4x4x32x32xf32>, tensor<4x4x32x32xf32>) outs(%[[PACK2]] : tensor<4x4x32x32xf32>)
+// CHECK: %[[OUT:.+]] = tensor.unpack %[[VAL]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[ARG2]] : tensor<4x4x32x32xf32> -> tensor<128x128xf32>
+// CHECK: return %[[OUT]] : tensor<128x128xf32>
+
+// -----
+
+func.func @block_linalg_matmul_transpose_b(
+  %arg0: tensor<128x128xf32>, %arg1: tensor<128x128xf32>, %arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32> {
+  %0 = linalg.matmul_transpose_b ins(%arg0, %arg1: tensor<128x128xf32>, tensor<128x128xf32>)
+                                 outs(%arg2: tensor<128x128xf32>)
+    -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+// CHECK-DAG: #[[MAP3:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// CHECK-DAG: #[[MAP4:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+// CHECK-DAG: #[[MAP5:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+
+// CHECK-LABEL: func @block_linalg_matmul_transpose_b(
+// CHECK-SAME:    %[[ARG0:[0-9a-z]+]]: tensor<128x128xf32>
+// CHECK-SAME:    %[[ARG1:[0-9a-z]+]]: tensor<128x128xf32>
+// CHECK-SAME:    %[[ARG2:[0-9a-z]+]]: tensor<128x128xf32>) -> tensor<128x128xf32> {
+// CHECK: %[[BUF0:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK0:.+]] = tensor.pack %[[ARG0]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF0]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+// CHECK: %[[BUF1:.*]] = tensor.empty() : tensor<4x4x32x32xf32>
+// CHECK: %[[PACK1:.+]] = tensor.pack %[[ARG1]] outer_dims_perm = [0, 1] inner_dims_pos = [1, 0] inner_tiles = [32, 32] into %[[BUF1]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
 // CHECK: %[[BUF2:.+]] = tensor.empty() : tensor<4x4x32x32xf32>
 // CHECK: %[[PACK2:.+]] = tensor.pack %[[ARG2]] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %[[BUF2]] : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
 // CHECK: %[[VAL:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP4]], #[[MAP5]]], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%[[PACK0]], %[[PACK1]] : tensor<4x4x32x32xf32>, tensor<4x4x32x32xf32>) outs(%[[PACK2]] : tensor<4x4x32x32xf32>)


### PR DESCRIPTION
Enables pack-matmul driver to handle transpose matmul variants.

PyTorch nn.Linear layer by default transposes matrix B (weights). This change allows accelerating also these workload by using upstream block packing capability to handle multiple matmul variants. After packing, matmuls are represented by the same generic format accepted by the current XSMM lowering.

A small performance hit compared to standard linalg.matmul is due to a linalg.transpose of a matmul_tranpose_a|b input matrix not being lowered to XSMM.