### PR TITLE
Named ops benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(BENCH_CFGS
   ${CONFIG_DIR}/base/base.json
   ${CONFIG_DIR}/base/pack.json
   ${CONFIG_DIR}/base/mha.json
+  ${CONFIG_DIR}/base/named-ops.json
 )
 string(JOIN ',' BENCH_CFGS_STR ${BENCH_CFGS})
 # Run a small set of benchmarks with small iterations to test the benchmarks and run locally on small machines

--- a/benchmarks/config/base/named-ops.json
+++ b/benchmarks/config/base/named-ops.json
@@ -1,0 +1,33 @@
+[
+  {
+  "mlp_named_ops": {
+    "fp32_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--output=named --kernel=const --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "fp32_3x1024_args_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--output=named --kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "bf16_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--output=named --kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100"],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "bf16_3x1024_args_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--output=named --kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "environment": {},
+      "flags": [ "-n", "100"],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }}
+]

--- a/scripts/buildkite/benchmark.sh
+++ b/scripts/buildkite/benchmark.sh
@@ -98,6 +98,7 @@ if [ "$BENCH_BASE" ]; then
   benchmark base/base.json "Base Benchmarks"
   benchmark base/pack.json "Pack Benchmarks"
   benchmark base/mha.json "MHA Benchmarks"
+  benchmark base/named-ops.json "Named Ops Benchmarks"
 fi
 
 # PyTorch model benchmarks


### PR DESCRIPTION
Adds MLP model benchmarks generated by mlir-gen with named ops.

The goal is to establish baseline performance of the current pipeline on IR using only Linalg named operations.
For ease of comparison, the MLP models from base benchmarks are used.