### PR TITLE
[DLTI] Enable obtaining tile size from module-associated attr

### DIFF
--- a/test/Passes/tile-and-fuse-default.mlir
+++ b/test/Passes/tile-and-fuse-default.mlir
@@ -729,3 +729,58 @@ func.func @contraction(%arg0: tensor<16x1xf32>, %arg1: tensor<1x32xf32>) -> tens
 
 // CHECK-LABEL: contraction
 // CHECK-NOT: scf.for
+
+// -----
+
+// CHECK-LABEL: dlti_tile_size_32
+module attributes { dlti.target_system_spec = #dlti.target_system_spec<"CPU" : #dlti.target_device_spec<#dlti.dl_entry<"tile_size", 32 : i32>>> } {
+  func.func @dlti_tile_size_32(%arg0: tensor<2048x2048xf32>, %arg1: tensor<2048x2048xf32>, %arg2: tensor<2048x2048xf32>)
+      -> tensor<2048x2048xf32> {
+    // CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
+    // CHECK: scf.for %{{.+}} step %[[C32]]
+    // CHECK-NEXT: scf.for %{{.+}} step %[[C32]]
+    // CHECK: %{{.+}} = linalg.matmul ins(%{{.+}}, %{{.+}} : tensor<32x2048xf32>, tensor<2048x32xf32>)
+    // CHECK-SAME:                    outs(%{{.+}} : tensor<32x32xf32>)
+    %0 = linalg.matmul ins(%arg0, %arg1: tensor<2048x2048xf32>, tensor<2048x2048xf32>)
+                       outs(%arg2: tensor<2048x2048xf32>)
+      -> tensor<2048x2048xf32>
+    return %0 : tensor<2048x2048xf32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: dlti_tile_size_64
+module attributes { dlti.target_system_spec = #dlti.target_system_spec<"CPU" : #dlti.target_device_spec<#dlti.dl_entry<"tile_size", 64 : i32>>> } {
+  func.func @dlti_tile_size_64(%arg0: tensor<2048x2048xf32>, %arg1: tensor<2048x2048xf32>, %arg2: tensor<2048x2048xf32>)
+      -> tensor<2048x2048xf32> {
+    // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : index
+    // CHECK: scf.for %{{.+}} step %[[C64]]
+    // CHECK-NEXT: scf.for %{{.+}} step %[[C64]]
+    // CHECK: %{{.+}} = linalg.matmul ins(%{{.+}}, %{{.+}} : tensor<64x2048xf32>, tensor<2048x64xf32>)
+    // CHECK-SAME:                    outs(%{{.+}} : tensor<64x64xf32>)
+    %0 = linalg.matmul ins(%arg0, %arg1: tensor<2048x2048xf32>, tensor<2048x2048xf32>)
+                       outs(%arg2: tensor<2048x2048xf32>)
+      -> tensor<2048x2048xf32>
+    return %0 : tensor<2048x2048xf32>
+  }
+}
+
+
+// -----
+
+// CHECK-LABEL: dlti_tile_size_16
+module attributes { dlti.target_system_spec = #dlti.target_system_spec<"CPU" : #dlti.target_device_spec<#dlti.dl_entry<"tile_size", 16 : i32>>> } {
+  func.func @dlti_tile_size_16(%arg0: tensor<2048x2048xf32>, %arg1: tensor<2048x2048xf32>, %arg2: tensor<2048x2048xf32>)
+      -> tensor<2048x2048xf32> {
+    // CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+    // CHECK: scf.for %{{.+}} step %[[C16]]
+    // CHECK-NEXT: scf.for %{{.+}} step %[[C16]]
+    // CHECK: %{{.+}} = linalg.matmul ins(%{{.+}}, %{{.+}} : tensor<16x2048xf32>, tensor<2048x16xf32>)
+    // CHECK-SAME:                    outs(%{{.+}} : tensor<16x16xf32>)
+    %0 = linalg.matmul ins(%arg0, %arg1: tensor<2048x2048xf32>, tensor<2048x2048xf32>)
+                       outs(%arg2: tensor<2048x2048xf32>)
+      -> tensor<2048x2048xf32>
+    return %0 : tensor<2048x2048xf32>
+  }
+}


### PR DESCRIPTION
By way of demonstration, this change only enables obtaining the tile size in the -tile-consumer-and-fuse-producers pass.