### PR TITLE
mlir-gen - use empty as outs for named eltwise operations

### DIFF
--- a/test/BF16/Integration/mlir-gen-fc-bf16.mlir
+++ b/test/BF16/Integration/mlir-gen-fc-bf16.mlir
@@ -84,9 +84,9 @@
 // GENERIC:           } -> tensor<2x16x64x48xbf16>
 // GENERIC:           %[[VAL_10:.*]] = tensor.empty() : tensor<2x16x64x48xbf16>
 // GENERIC:           %[[VAL_11:.*]] = linalg.broadcast ins(%[[VAL_2]] : tensor<16x48xbf16>) outs(%[[VAL_10]] : tensor<2x16x64x48xbf16>) dimensions = [0, 2]
-// GENERIC:           %[[VAL_12:.*]] = linalg.add ins(%[[VAL_11]], %[[VAL_4]] : tensor<2x16x64x48xbf16>, tensor<2x16x64x48xbf16>) outs(%[[VAL_3]] : tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
+// GENERIC:           %[[VAL_12:.*]] = linalg.add ins(%[[VAL_11]], %[[VAL_4]] : tensor<2x16x64x48xbf16>, tensor<2x16x64x48xbf16>) outs(%[[VAL_10]] : tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
 // GENERIC:           %[[VAL_13:.*]] = arith.constant 0.000000e+00 : bf16
 // GENERIC:           %[[VAL_14:.*]] = tensor.empty() : tensor<2x16x64x48xbf16>
 // GENERIC:           %[[VAL_15:.*]] = linalg.fill ins(%[[VAL_13]] : bf16) outs(%[[VAL_14]] : tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
-// GENERIC:           %[[VAL_16:.*]] = linalg.max ins(%[[VAL_12]], %[[VAL_15]] : tensor<2x16x64x48xbf16>, tensor<2x16x64x48xbf16>) outs(%[[VAL_3]] : tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
+// GENERIC:           %[[VAL_16:.*]] = linalg.max ins(%[[VAL_12]], %[[VAL_15]] : tensor<2x16x64x48xbf16>, tensor<2x16x64x48xbf16>) outs(%[[VAL_14]] : tensor<2x16x64x48xbf16>) -> tensor<2x16x64x48xbf16>
 // GENERIC:           return %[[VAL_16]] : tensor<2x16x64x48xbf16>

--- a/test/Integration/mlir-gen-named.mlir
+++ b/test/Integration/mlir-gen-named.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=2304,768 2>&1 | FileCheck %s
+
+// CHECK: // RUN{{.*}}tpp-run %s -n {{\d*}}
+// CHECK: // RUN{{.*}}-e entry -entry-point-result=void
+// CHECK: // BENCH_TOTAL_FLOPS: 453181440
+// CHECK:     func.func @entry(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<128x2304xf32>, %[[ARG1:.+]]: tensor<2304x768xf32>,
+// CHECK-SAME:  %[[ARG2:.+]]: tensor<768xf32>, %[[ARG3:.+]]: tensor<128x768xf32>) -> tensor<128x768xf32>
+// CHECK:     %[[MATMUL:.+]] = linalg.matmul ins(%[[ARG0]], %[[ARG1]] :{{.*}}) outs(%[[ARG3]] :{{.*}})
+// CHECK:     %[[EMPTY_BIAS:.+]] = tensor.empty() : tensor<128x768xf32>
+// CHECK:     %[[BROADCAST:.+]] = linalg.broadcast ins(%[[ARG2]] :{{.*}}) outs(%[[EMPTY_BIAS]] :{{.*}})
+// CHECK:     %[[ADD:.+]] = linalg.add ins(%[[BROADCAST]], %[[MATMUL]] :{{.*}}) outs(%[[EMPTY_BIAS]] :{{.*}})
+// CHECK:     %[[C0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:     %[[EMPTY_RELU:.+]] = tensor.empty() : tensor<128x768xf32>
+// CHECK:     %[[FILL:.+]] = linalg.fill ins(%[[C0]] :{{.*}}) outs(%[[EMPTY_RELU]] :{{.*}})
+// CHECK:     %[[MAX:.+]] = linalg.max ins(%[[ADD]], %[[FILL]] :{{.*}}) outs(%[[EMPTY_RELU]] :{{.*}})
+// CHECK:     return %[[MAX]]

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -461,7 +461,7 @@ Value MLIRGenerator::lowerNamedBiasAdd(Value input, Value bias, Value output) {
   Value biasAdd = builder
                       .create<linalg::AddOp>(loc, TypeRange{output.getType()},
                                              ValueRange{broadcast, input},
-                                             ValueRange{output})
+                                             ValueRange{emptyTensor})
                       .getResult(0);
 
   computeBiasOrReluFlops(outTy);
@@ -480,7 +480,7 @@ Value MLIRGenerator::lowerNamedRelu(Value input, Value output) {
   Value relu =
       builder
           .create<linalg::MaxOp>(loc, TypeRange{output.getType()},
-                                 ValueRange{input, fill}, ValueRange{output})
+                                 ValueRange{input, fill}, ValueRange{emptyTensor})
           .getResult(0);
 
   computeBiasOrReluFlops(outTy);
@@ -800,4 +800,3 @@ Value MLIRGenerator::getZeroInitTensor(TensorType type) {
   tensor = builder.create<linalg::FillOp>(loc, zero, tensor).getResult(0);
   return tensor;
 }
-


### PR DESCRIPTION
Adjusts mlir-gen named ops generation to use tensor.empty as output destination.

For linalg named eltwise operations, outs value is write only. Using empty as a destination placeholder instead of zero initialized value improves bufferization and overall IR quality.