### PR TITLE
Fold fill into max

### DIFF
--- a/lib/TPP/Transforms/FoldIntoEltwise.cpp
+++ b/lib/TPP/Transforms/FoldIntoEltwise.cpp
@@ -149,6 +149,8 @@ struct FillIntoMax : public OpRewritePattern<linalg::MaxOp> {
         continue;
       }
 
+      // TODO: Check if there is any benefit in this over passing scalar
+      //       as an input argument.
       // Store the constant separately to be later inserted directly into
       // generic's body.
       assert(fillOp.getInputs().size() == 1 &&

--- a/lib/TPP/Transforms/FoldIntoEltwise.cpp
+++ b/lib/TPP/Transforms/FoldIntoEltwise.cpp
@@ -152,7 +152,7 @@ struct FillIntoMax : public OpRewritePattern<linalg::MaxOp> {
       // Store the constant separately to be later inserted directly into
       // generic's body.
       assert(fillOp.getInputs().size() == 1 &&
-             "expect fill to have single inputs");
+             "expect fill to have single input");
       constants.push_back(fillOp.getInputs()[0]);
     }
 

--- a/test/Passes/pass-fold-into-eltwise.mlir
+++ b/test/Passes/pass-fold-into-eltwise.mlir
@@ -194,7 +194,7 @@ func.func @no_fold_non_eltwise(%arg0: tensor<16xf32>,
 
 // -----
 
-func.func @no_fold_non_tensor(%arg0: memref<8xf32>,
+func.func @no_broadcast_fold_non_tensor(%arg0: memref<8xf32>,
     %arg1: memref<8x4xf32>,
     %arg2: memref<8x4xf32>) {
   linalg.broadcast ins(%arg0 : memref<8xf32>) outs(%arg2 : memref<8x4xf32>) dimensions = [1]
@@ -203,7 +203,7 @@ func.func @no_fold_non_tensor(%arg0: memref<8xf32>,
   return
 }
 
-// CHECK-LABEL: @no_fold_non_tensor(
+// CHECK-LABEL: @no_broadcast_fold_non_tensor(
 // CHECK: linalg.broadcast
 // CHECK: linalg.add
 
@@ -295,3 +295,16 @@ func.func @double_fill_into_max(%cst: f32,
 // CHECK: linalg.generic{{.*}}indexing_maps = [#[[MAP]]]
 // CHECK: arith.maximumf %[[CST]], %[[CST1]]
 // CHECK: linalg.yield
+
+// -----
+
+func.func @no_fill_fold_non_tensor(%arg0: memref<8x4xf32>,
+    %arg1: memref<8x4xf32>, %cst: f32) {
+  linalg.fill ins(%cst : f32) outs(%arg1 : memref<8x4xf32>)
+  linalg.max ins(%arg0, %arg1 : memref<8x4xf32>, memref<8x4xf32>) outs(%arg1 : memref<8x4xf32>)
+  return
+}
+
+// CHECK-LABEL: @no_fill_fold_non_tensor(
+// CHECK: linalg.fill
+// CHECK: linalg.max


### PR DESCRIPTION
Adds pattern that folds linalg.fill into linalg.max and outputs combined linalg.generic.

A constant filled buffer is replaced by a single constant used directly in max operation on the elements of the other operand.
This allows to eliminate potential temporary buffer allocation and value initialization.