### PR TITLE
Allow packing matmul dims equal to block size

### DIFF
--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -515,7 +515,8 @@ struct PackMatmul : public tpp::impl::PackMatmulBase<PackMatmul> {
       size_t posK = 2 + inc;
       if (!linalgx::utils::validateFullTilesOnDims(
               cast<TilingInterface>(linalgOp.getOperation()),
-              {tileOnI, tileOnJ, tileOnK}, {posI, posJ, posK})) {
+              {tileOnI, tileOnJ, tileOnK}, {posI, posJ, posK},
+              /*minTileFactor=*/1)) {
         return std::nullopt;
       }
 

--- a/test/Passes/DefaultPipeline/default-tpp-passes.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes.mlir
@@ -219,16 +219,12 @@ func.func @softmax(%arg0: tensor<2x2x2x2xf32>, %arg1: tensor<2x2x2x2xf32>) -> te
 // CHECK-LABEL: batch_matmul_rewrite
 func.func @batch_matmul_rewrite(%arg0: tensor<512x32x64xf32>, %arg1: tensor<512x64x32xf32>) -> tensor<512x32x32xf32> {
   %0 = tensor.empty() : tensor<512x32x32xf32>
-  // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i64
-  // CHECK-DAG: %[[C32:.+]] = arith.constant 32 : i64
-  // CHECK-DAG: %[[C64:.+]] = arith.constant 64 : i64
-  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i64
   // CHECK-DAG: %[[C0_i:.+]] = arith.constant 0 : index
   // CHECK-DAG: %[[C1_i:.+]] = arith.constant 1 : index
   // CHECK-DAG: %[[C512_i:.+]] = arith.constant 512 : index
-  // CHECK: %{{.+}} = call @xsmm_gemm_dispatch(%[[C1]], %[[C32]], %[[C32]], %[[C64]], %[[C64]], %[[C32]], %[[C32]], %[[C0]])
+  // CHECK: %{{.+}} = call @xsmm_brgemm_dispatch
   // CHECK: scf.parallel{{.*}}(%[[C0_i]]) to (%[[C512_i]]) step (%[[C1_i]])
-  // CHECK: xsmm_gemm_invoke
+  // CHECK: xsmm_brgemm_invoke
   %1 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<512x32x64xf32>, tensor<512x64x32xf32>)
                            outs(%0 : tensor<512x32x32xf32>) -> tensor<512x32x32xf32>
   return %1 : tensor<512x32x32xf32>


### PR DESCRIPTION
Relaxes matmul packing blocked dimensions validation to allow packing when `matmul dims >= block factor`.