### PR TITLE
Add a fold-add-into-dest pattern and pass

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -233,9 +233,11 @@ def ConstantFoldPack : Pass<"constant-fold-pack", "ModuleOp"> {
 }
 
 def FoldAddIntoDest : Pass<"fold-add-into-dest", "ModuleOp"> {
-  let summary = "TODO";
+  let summary = "Fold linalg.add into dest of contraction op";
   let description = [{
-    TODO.
+    Replace a linalg.add where its linalg-contraction operand - with a
+    zero-filled destination - is dominated by the `other` linalg operand,
+    by passing `other` as the destination of the contraction.
   }];
   let dependentDialects = ["linalg::LinalgDialect",
                            "tensor::TensorDialect",

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -232,6 +232,16 @@ def ConstantFoldPack : Pass<"constant-fold-pack", "ModuleOp"> {
                            "arith::ArithDialect"];
 }
 
+def FoldAddIntoDest : Pass<"fold-add-into-dest", "ModuleOp"> {
+  let summary = "TODO";
+  let description = [{
+    TODO.
+  }];
+  let dependentDialects = ["linalg::LinalgDialect",
+                           "tensor::TensorDialect",
+                           "arith::ArithDialect"];
+}
+
 def ElementWiseFusion : Pass<"element-wise-fusion", "func::FuncOp"> {
   let summary = "Run linalg element-wise fusion";
 }

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -235,9 +235,9 @@ def ConstantFoldPack : Pass<"constant-fold-pack", "ModuleOp"> {
 def FoldAddIntoDest : Pass<"fold-add-into-dest", "ModuleOp"> {
   let summary = "Fold linalg.add into dest of contraction op";
   let description = [{
-    Replace a linalg.add where its linalg-contraction operand - with a
-    zero-filled destination - is dominated by the `other` linalg operand,
-    by passing `other` as the destination of the contraction.
+    Replace a linalg.add with one operand the single user of a contraction,
+    which has a zero-filled, "identity-mapped" destination and is dominated by
+    the `other` operand, by the contraction with `other` as its dest.
   }];
   let dependentDialects = ["linalg::LinalgDialect",
                            "tensor::TensorDialect",

--- a/include/TPP/Transforms/Utils/ValueUtils.h
+++ b/include/TPP/Transforms/Utils/ValueUtils.h
@@ -12,6 +12,7 @@
 namespace mlir {
 class Value;
 class OpBuilder;
+class Operation;
 namespace utils {
 
 // Returns true if the value is a constant float or integer.
@@ -19,6 +20,9 @@ bool isValConstZero(Value val);
 
 // Returns true if the op defining `val` represents a zero filled tensor.
 bool isZeroTensor(Value val);
+
+// Returns true if the operation represents a zero filled tensor.
+bool isZeroOp(Operation *);
 
 // Returns the strides of `val`. The method returns something usefull
 // only if the `val` type is a strided memref and the strides are statically

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -68,6 +68,7 @@ struct DefaultTppPasses
 
 private:
   void constructPipeline() override {
+    pm.addPass(createFoldAddIntoDest());
     if (linalgToLoops) {
       // Lower linalg directly to loops.
       // Skip all TPP transformations.

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_mlir_library(TPPTransforms
   LinalgConvertCompareSelectToMaximumfPass.cpp
   ConvertLinalgToInplace.cpp
   FoldIntoEltwise.cpp
+  FoldAddIntoDest.cpp
   Vectorization.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/TPP/Transforms/FoldAddIntoDest.cpp
+++ b/lib/TPP/Transforms/FoldAddIntoDest.cpp
@@ -73,16 +73,14 @@ struct FoldAddIntoDestRewrite : public OpRewritePattern<linalg::AddOp> {
                        "destination-passing contraction");
 
     // To change the contraction's result, `addOp` must be its only user.
-    auto contractionUsers = dominatedOp->getResult(0).getUsers();
-    if (std::distance(contractionUsers.begin(), contractionUsers.end()) != 1)
+    if (!dominatedOp->getResult(0).hasOneUse())
       return rewriter.notifyMatchFailure(
           dominatedOp,
-          "expected linalg.add op to be single user of contraction's result");
+          "expected linalg.add to be single user of contraction's result");
 
     // As `dominatedOp` was already accumulating on its out argument, it is only
     // safe to no longer use its current out arg when it is the additive zero.
     auto *destOperand = dominatedDestOp.getDpsInitOperand(0);
-    ;
     if (!mlir::utils::isZeroOp(destOperand->get().getDefiningOp()))
       return rewriter.notifyMatchFailure(
           dominatedOp, "expected dominated op's dest to be additive zero");

--- a/lib/TPP/Transforms/FoldAddIntoDest.cpp
+++ b/lib/TPP/Transforms/FoldAddIntoDest.cpp
@@ -1,0 +1,101 @@
+//===- FoldAddIntoDest.cpp ---------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+#include "TPP/Transforms/Utils/ValueUtils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_FOLDADDINTODEST
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+/// Replace a linalg.add where its linalg-contraction operand - with a
+/// zero-filled destination - is dominated by the `other` linalg operand,
+/// by passing `other` as the destination of the contraction.
+struct FoldAddIntoDestRewrite : public OpRewritePattern<linalg::AddOp> {
+  using OpRewritePattern<linalg::AddOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::AddOp addOp,
+                                PatternRewriter &rewriter) const override {
+    Value dominatingOperand = nullptr;
+    linalg::LinalgOp dominatedOp = nullptr;
+    {
+      auto firstOperand = addOp.getOperand(0);
+      auto secondOperand = addOp.getOperand(1);
+
+      // Can only put one of addOp's operands in the dest/out arg of the other's
+      // defining op based on suitable dominance.
+      if (auto secondOp = secondOperand.getDefiningOp<linalg::LinalgOp>()) {
+        DominanceInfo domInfo(secondOp);
+        if (domInfo.properlyDominates(firstOperand, secondOp)) {
+          dominatingOperand = firstOperand;
+          dominatedOp = secondOp;
+        }
+      }
+      if (auto firstOp = firstOperand.getDefiningOp<linalg::LinalgOp>()) {
+        DominanceInfo domInfo(firstOp);
+        if (domInfo.properlyDominates(secondOperand, firstOp)) {
+          dominatingOperand = secondOperand;
+          dominatedOp = firstOp;
+        }
+      }
+      if (!dominatingOperand || !dominatedOp)
+        return failure();
+      // NB: As linalg.add's generalisation ignores the out argument in its
+      //     region there is no need to perform checks on addOp's out argument.
+    }
+
+    // When the dominated op has a single-result and is a contraction, the op
+    // accumulates on the out argument, starting from the supplied out argument.
+    // E.g., AddOp is not a contraction and hence ignores its out arg's value.
+    if (dominatedOp->getNumResults() != 1 ||
+        !linalg::isaContractionOpInterface(dominatedOp))
+      return rewriter.notifyMatchFailure(
+          dominatedOp, "expected dominated op to be single-result contraction");
+
+    // As the dominated op was already accumulating on its out argument, it is
+    // only safe to discard its current out arg when it is the additive zero.
+    auto *dominatedDest = dominatedOp->getOperand(2).getDefiningOp();
+    if (!mlir::utils::isZeroOp(dominatedDest))
+      return rewriter.notifyMatchFailure(
+          dominatedOp, "expected dominated op's dest to be additive zero");
+
+    // Replace the additive-zero out argument of the dominated op by the
+    // dominating summand. This makes the dominated op's result the sum of both
+    // of addOp's arguments - therefore we replace addOp and it uses by it.
+    rewriter.modifyOpInPlace(
+        dominatedOp, [&]() { dominatedOp->setOperand(2, dominatingOperand); });
+    rewriter.replaceAllOpUsesWith(addOp, dominatedOp->getResult(0));
+    return success();
+  }
+};
+
+/// Replace linalg.add when destination passing suffices for achieving the sum.
+struct FoldAddIntoDest
+    : public tpp::impl::FoldAddIntoDestBase<FoldAddIntoDest> {
+
+  void runOnOperation() override {
+    auto *ctx = &getContext();
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<FoldAddIntoDestRewrite>(ctx);
+
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace

--- a/lib/TPP/Transforms/FoldAddIntoDest.cpp
+++ b/lib/TPP/Transforms/FoldAddIntoDest.cpp
@@ -80,6 +80,8 @@ struct FoldAddIntoDestRewrite : public OpRewritePattern<linalg::AddOp> {
     if (!mlir::utils::isZeroOp(dominatedDest))
       return rewriter.notifyMatchFailure(
           dominatedOp, "expected dominated op's dest to be additive zero");
+    // TODO: If the other op is a contraction and has additive zero as dest, we
+    // can swap the dests and achieve the proper sum, given suitable dominance.
 
     // Replace the additive-zero out argument of the dominated op by the
     // dominating summand. This makes the dominated op's result the sum of both

--- a/lib/TPP/Transforms/Utils/ValueUtils.cpp
+++ b/lib/TPP/Transforms/Utils/ValueUtils.cpp
@@ -40,7 +40,7 @@ static bool isZeroAttr(Attribute attribute) {
 }
 
 // Prototypes
-static bool isZeroOp(Operation *);
+bool isZeroOp(Operation *);
 
 // Returns true if the value represents a zero filled tensor.
 // Recurse into isZeroOp for defining ops if not immediately obvious
@@ -70,7 +70,7 @@ bool isZeroTensor(Value val) {
 
 // Returns true if the operation represents a zero filled tensor
 // Recurses into isZeroTensor for operands and isZeroAttr for attributes
-static bool isZeroOp(Operation *defOp) {
+bool isZeroOp(Operation *defOp) {
   if (!defOp)
     return false;
 

--- a/test/Passes/fold-add-into-dest.mlir
+++ b/test/Passes/fold-add-into-dest.mlir
@@ -1,0 +1,135 @@
+// RUN: tpp-opt %s -fold-add-into-dest -cse -split-input-file | FileCheck %s
+
+!type = tensor<2048x2048xf32>
+func.func @expect_add_to_fold(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %4 = linalg.matmul ins(%arg1, %0 : !type, !type) outs(%2 : !type) -> !type
+  %5 = linalg.add ins(%3, %4 : !type, !type) outs(%1 : !type) -> !type
+  return %5 : !type
+}
+
+// CHECK-LABEL: func.func @expect_add_to_fold
+// CHECK: %[[ACC:.+]] = linalg.matmul
+// CHECK-NEXT: %[[RES:.+]] = linalg.matmul ins(%[[X:.+]]) outs(%[[ACC]]
+// CHECK-NEXT: return %[[RES]]
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_add_to_fold(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %5 = linalg.add ins(%3, %arg1 : !type, !type) outs(%1 : !type) -> !type
+  return %5 : !type
+}
+
+// CHECK-LABEL: func.func @expect_add_to_fold
+// CHECK: %[[RES:.+]] = linalg.matmul
+// CHECK-NEXT: return %[[RES]]
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_add_to_fold(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul_transpose_a ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %4 = linalg.matmul_transpose_b ins(%arg1, %0 : !type, !type) outs(%2 : !type) -> !type
+  %5 = linalg.add ins(%3, %4 : !type, !type) outs(%1 : !type) -> !type
+  return %5 : !type
+}
+
+// CHECK-LABEL: func.func @expect_add_to_fold
+// CHECK: %[[ACC:.+]] = linalg.matmul_transpose_a
+// CHECK-NEXT: %[[RES:.+]] = linalg.matmul_transpose_b ins(%[[X:.+]]) outs(%[[ACC]]
+// CHECK-NEXT: return %[[RES]]
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_add_to_not_fold(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul_transpose_b ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %4 = linalg.add ins(%3, %3 : !type, !type) outs(%1 : !type) -> !type
+  return %4 : !type
+}
+
+// CHECK-LABEL: func.func @expect_add_to_not_fold
+// CHECK: linalg.fill
+// CHECK-NEXT: linalg.matmul_transpose_b
+// CHECK-NEXT: linalg.add
+// CHECK-NEXT: return
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_no_fold_as_operands_do_not_dominate_each_other(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul_transpose_b ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %4 = linalg.add ins(%3, %3 : !type, !type) outs(%1 : !type) -> !type
+  return %4 : !type
+}
+
+
+// CHECK-LABEL: func.func @expect_no_fold_as_operands_do_not_dominate_each_other
+// CHECK: linalg.fill
+// CHECK-NEXT: linalg.matmul_transpose_b
+// CHECK-NEXT: linalg.add
+// CHECK-NEXT: return
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_no_fold_as_dominated_op_is_not_a_contraction(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %4 = linalg.sub ins(%arg1, %0 : !type, !type) outs(%2 : !type) -> !type
+  %5 = linalg.add ins(%3, %4 : !type, !type) outs(%1 : !type) -> !type
+  return %5 : !type
+}
+
+// CHECK-LABEL: func.func @expect_no_fold_as_dominated_op_is_not_a_contraction
+// CHECK: linalg.fill
+// CHECK-NEXT: linalg.matmul
+// CHECK-NEXT: linalg.sub
+// CHECK-NEXT: linalg.add
+// CHECK-NEXT: return
+
+// -----
+
+!type = tensor<2048x2048xf32>
+func.func @expect_no_fold_as_orig_dest_not_additive_zero(%arg0: !type, %arg1: !type) -> !type {
+  %0 = arith.constant dense<1.111111e+00> : !type
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = tensor.empty() : !type
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !type) -> !type
+  %3 = linalg.matmul ins(%arg0, %0 : !type, !type) outs(%2 : !type) -> !type
+  %4 = linalg.matmul ins(%arg1, %0 : !type, !type) outs(%0 : !type) -> !type
+  %5 = linalg.add ins(%3, %4 : !type, !type) outs(%1 : !type) -> !type
+  return %5 : !type
+}
+
+// CHECK-LABEL: func.func @expect_no_fold_as_orig_dest_not_additive_zero
+// CHECK: linalg.fill
+// CHECK-NEXT: linalg.matmul
+// CHECK-NEXT: linalg.matmul
+// CHECK-NEXT: linalg.add
+// CHECK-NEXT: return


### PR DESCRIPTION
Achieves the sum of linalg.add by relying on the accumulation semantics of contraction ops w.r.t. their out/dest argument. Main value is likely to come from that a buffer allocation can be elided, in case the contraction op had its own buffer.