### PR TITLE
Lower vector.contract to vector.outerproduct.

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -53,6 +53,15 @@ def VectorizationPass : Pass<"vectorization-pass",
   let dependentDialects = [ "memref::MemRefDialect", "linalg::LinalgDialect", "vector::VectorDialect" ];
 }
 
+def VectorContractToOuterproduct : Pass<
+    "vector-contract-to-outerproduct"> {
+  let summary = "Perform outerproduct lowering of vector contraction ops";
+  let dependentDialects = ["memref::MemRefDialect",
+                           "scf::SCFDialect",
+                           "tensor::TensorDialect",
+                           "vector::VectorDialect"];
+}
+
 
 def ConvertXsmmToFunc : Pass<"convert-xsmm-to-func", "ModuleOp"> {
   let summary = "Convert xsmm to func";

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -106,6 +106,7 @@ private:
       if (linalgToVector) {
         pm.addNestedPass<func::FuncOp>(createVectorizationPass());
         pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+        pm.addNestedPass<func::FuncOp>(createVectorContractToOuterproduct());
       } else {
         // Lower all Tile operations.
         pm.addNestedPass<func::FuncOp>(createLinalgLowering());

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_library(TPPTransforms
   FoldAddIntoDest.cpp
   Vectorization.cpp
   SplitReductionDim.cpp
+  VectorContractToOuterproduct.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Transforms/VectorContractToOuterproduct.cpp
+++ b/lib/TPP/Transforms/VectorContractToOuterproduct.cpp
@@ -1,0 +1,283 @@
+//===--------------- VectorContractToOuterproduct.cpp ------------*- C++-*-===//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements lowering of vector contraction to vector outerproduct.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/VectorInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+#include <cmath>
+#include <cstdint>
+
+#define DEBUG_TYPE "vector-contract-to-outerproduct"
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_VECTORCONTRACTTOOUTERPRODUCT
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace {
+/// Returns true if the \p map is transposed.
+static bool isTransposed(AffineMap map) {
+  auto results = map.getResults();
+  // Assert if the map does not have 3 inputs (m, n, k).
+  assert(map.getNumInputs() > 2 && "Al least 3 input dim expected");
+  // Assert if the result is not 2D.
+  assert(map.getNumResults() == 2 && "Only 2 output dim expected");
+
+  // Check the last two dimensions for transposition.
+  auto dimExpr0 = dyn_cast<AffineDimExpr>(results[0]);
+  auto dimExpr1 = dyn_cast<AffineDimExpr>(results[1]);
+  assert((dimExpr0 && dimExpr1) && "Unexpected dim expression");
+
+  // Exclude output map result.
+  bool isOutputResultMap =
+      dimExpr0 == mlir::getAffineDimExpr(0, map.getContext()) &&
+      dimExpr1 == mlir::getAffineDimExpr(1, map.getContext());
+  assert(!isOutputResultMap && "Output result map not expected");
+
+  // It's transposed if result found as (k, m) or (n, k), else not transposed.
+  if ((dimExpr0 == mlir::getAffineDimExpr(2, map.getContext()) &&
+       dimExpr1 == mlir::getAffineDimExpr(0, map.getContext())) ||
+      (dimExpr0 == mlir::getAffineDimExpr(1, map.getContext()) &&
+       dimExpr1 == mlir::getAffineDimExpr(2, map.getContext())))
+    return true;
+  return false;
+}
+} // namespace
+
+namespace mlir {
+namespace tpp {
+// Enum to represent the type of matmul operation
+enum class MatMulType { Standard, Batch, BatchReduce };
+
+struct VectorContractToOuterproductPattern
+    : public OpRewritePattern<vector::ContractionOp> {
+  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
+                                PatternRewriter &rewriter) const override {
+
+    if (contractOp.getKind() != vector::CombiningKind::ADD)
+      return rewriter.notifyMatchFailure(
+          contractOp,
+          "Unsupported combining kind, only supports ADD at the moment)");
+
+    SmallVector<AffineMap, 3> maps = contractOp.getIndexingMapsArray();
+    if (llvm::any_of(
+            maps, [](AffineMap map) { return !map.isProjectedPermutation(); }))
+      return rewriter.notifyMatchFailure(contractOp, "Unexpected map");
+
+    // Check for the variant of matrix multiply.
+    auto iteratorTypes = contractOp.getIteratorTypesArray();
+    MatMulType matmulType;
+    unsigned outerDimIndex = 0;
+    if (iteratorTypes.size() > 3) {
+      outerDimIndex = iteratorTypes.size() - 4;
+      matmulType =
+          iteratorTypes[outerDimIndex] == vector::IteratorType::parallel
+              ? MatMulType::Batch
+              : MatMulType::BatchReduce;
+      outerDimIndex++;
+    } else if (iteratorTypes.size() == 3) {
+      matmulType = MatMulType::Standard;
+    } else {
+      return rewriter.notifyMatchFailure(contractOp, "Not a gemm");
+    }
+
+    if (matmulType == MatMulType::Batch)
+      return rewriter.notifyMatchFailure(contractOp,
+                                         "Batch matmul not supported");
+    if (iteratorTypes[outerDimIndex] != vector::IteratorType::parallel ||
+        iteratorTypes[outerDimIndex + 1] != vector::IteratorType::parallel ||
+        iteratorTypes[outerDimIndex + 2] != vector::IteratorType::reduction)
+      return rewriter.notifyMatchFailure(contractOp, "Not a gemm");
+
+    Value acc = contractOp.getAcc();
+    // Find the original tensor operands
+    auto lhsDefiningOp =
+        contractOp.getLhs().getDefiningOp<vector::TransferReadOp>();
+    auto rhsDefiningOp =
+        contractOp.getRhs().getDefiningOp<vector::TransferReadOp>();
+    auto accDefiningOp = acc.getDefiningOp<vector::TransferReadOp>();
+    if (!lhsDefiningOp || !rhsDefiningOp || !accDefiningOp)
+      return failure();
+
+    // Make sure the inputs being read are whole tensor or subview.
+    if (!llvm::all_of(lhsDefiningOp.getIndices(), isZeroIndex) ||
+        !llvm::all_of(rhsDefiningOp.getIndices(), isZeroIndex)) {
+      return failure();
+    }
+
+    auto lhsType = cast<ShapedType>(lhsDefiningOp.getType());
+    auto rhsType = cast<ShapedType>(rhsDefiningOp.getType());
+    auto accType = cast<ShapedType>(accDefiningOp.getType());
+
+    if (matmulType == MatMulType::BatchReduce &&
+        (lhsType.getRank() != 3 || rhsType.getRank() != 3))
+      return failure();
+
+    if (matmulType == MatMulType::Standard &&
+        (lhsType.getRank() != 2 || rhsType.getRank() != 2))
+      return failure();
+
+    // Only 2-D output expected.
+    if (accType.getRank() != 2)
+      return failure();
+
+    // Handle 3D subviews
+    auto mapLHS = maps[0];
+    auto mapRHS = maps[1];
+    if (matmulType == MatMulType::BatchReduce) {
+      mapLHS = mapLHS.dropResult(outerDimIndex);
+      mapRHS = mapRHS.dropResult(outerDimIndex);
+    }
+
+    int64_t M = accType.getDimSize(0);
+    int64_t N = accType.getDimSize(1);
+    int64_t K = !isTransposed(mapLHS)
+                    ? lhsType.getDimSize(lhsType.getRank() - 1)
+                    : lhsType.getDimSize(lhsType.getRank() - 2);
+
+    // Create constants
+    Location loc = contractOp.getLoc();
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value cK = rewriter.create<arith::ConstantIndexOp>(loc, K);
+
+    auto elementType = lhsType.getElementType();
+    FloatType floatType = cast<FloatType>(elementType);
+    Value f0 = rewriter.create<arith::ConstantFloatOp>(
+        loc, APFloat::getZero(floatType.getFloatSemantics()), floatType);
+
+    // Create the outer scf.for loop
+    auto forOp = rewriter.create<scf::ForOp>(
+        loc, c0, cK, c1, ValueRange{acc},
+        [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
+            ValueRange iterArgs) {
+          // Prepare indices and map to iterate over rows/colums and read
+          // slices of lhs/rhs input operands.
+          SmallVector<Value, 3> lhsIndices, rhsIndices;
+          AffineMap lhsMap, rhsMap;
+          for (int i = 0; i < lhsType.getRank() - 2; ++i)
+            lhsIndices.push_back(c0);
+          // LHS operand
+          if (!isTransposed(mapLHS)) {
+            // If not transposed, iterate over colums and read each column
+            // using map.
+            lhsIndices.push_back(c0);
+            lhsIndices.push_back(iv);
+            lhsMap = AffineMap::get(lhsType.getRank(), 0,
+                                    {nestedBuilder.getAffineDimExpr(0)},
+                                    nestedBuilder.getContext());
+          } else {
+            // If transposed, iterate over rows and read each row with default
+            // map.
+            lhsIndices.push_back(iv);
+            lhsIndices.push_back(c0);
+            lhsMap = AffineMap::get(lhsType.getRank(), 0,
+                                    {nestedBuilder.getAffineDimExpr(1)},
+                                    nestedBuilder.getContext());
+          }
+
+          for (int i = 0; i < rhsType.getRank() - 2; ++i)
+            rhsIndices.push_back(c0);
+          // RHS operand
+          if (!isTransposed(mapRHS)) {
+            // If not transposed, iterate over rows and read each row using
+            // default map.
+            rhsIndices.push_back(iv);
+            rhsIndices.push_back(c0);
+            rhsMap = AffineMap::get(rhsType.getRank(), 0,
+                                    {nestedBuilder.getAffineDimExpr(1)},
+                                    nestedBuilder.getContext());
+          } else {
+            // If transposed, iterate over columns and read each column with
+            // default map.
+            rhsIndices.push_back(c0);
+            rhsIndices.push_back(iv);
+            rhsMap = AffineMap::get(rhsType.getRank(), 0,
+                                    {nestedBuilder.getAffineDimExpr(0)},
+                                    nestedBuilder.getContext());
+          }
+
+          Value lhsTensor = lhsDefiningOp.getSource();
+          Value rhsTensor = rhsDefiningOp.getSource();
+          // Read vector slices using TransferReadOp
+          auto lhsSlice = nestedBuilder.create<vector::TransferReadOp>(
+              nestedLoc, VectorType::get({M}, lhsType.getElementType()),
+              lhsTensor, lhsIndices, AffineMapAttr::get(lhsMap), f0, Value(),
+              rewriter.getBoolArrayAttr({true}));
+
+          auto rhsSlice = nestedBuilder.create<vector::TransferReadOp>(
+              nestedLoc, VectorType::get({N}, rhsType.getElementType()),
+              rhsTensor, rhsIndices, rhsMap, f0, Value(),
+              rewriter.getBoolArrayAttr({true}));
+
+          // Perform outer product
+          auto outerProduct = nestedBuilder.create<vector::OuterProductOp>(
+              nestedLoc, accType, lhsSlice, rhsSlice, iterArgs[0],
+              vector::CombiningKind::ADD);
+
+          // Yield the result
+          nestedBuilder.create<scf::YieldOp>(nestedLoc,
+                                             ValueRange{outerProduct});
+        });
+
+    // Replace the original contraction with the result of the loop
+    rewriter.replaceOp(contractOp, forOp.getResults());
+
+    return success();
+  }
+};
+
+struct VectorContractToOuterproduct
+    : public tpp::impl::VectorContractToOuterproductBase<
+          VectorContractToOuterproduct> {
+
+  using VectorContractToOuterproductBase::VectorContractToOuterproductBase;
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<VectorContractToOuterproductPattern>(context);
+
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace tpp
+} // namespace mlir

--- a/test/Integration/vector-contract-to-outerproduct.mlir
+++ b/test/Integration/vector-contract-to-outerproduct.mlir
@@ -1,0 +1,97 @@
+// RUN: tpp-opt %s  | tpp-run -e entry --entry-point-result=void -seed 123 -print > %t.1
+// RUN: tpp-opt %s  --vector-contract-to-outerproduct  | tpp-run -e entry --entry-point-result=void -seed 123 -print > %t.2
+// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF --allow-empty
+
+// RUN: tpp-opt %s  | tpp-run -e permA --entry-point-result=void -seed 123 -print > %t.1
+// RUN: tpp-opt %s  --vector-contract-to-outerproduct  | tpp-run -e permA --entry-point-result=void -seed 123 -print > %t.2
+// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF-PERMA --allow-empty
+
+// RUN: tpp-opt %s  | tpp-run -e permB --entry-point-result=void -seed 123 -print > %t.1
+// RUN: tpp-opt %s  --vector-contract-to-outerproduct  | tpp-run -e permB --entry-point-result=void -seed 123 -print > %t.2
+// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF-PERMA --allow-empty
+
+// RUN: tpp-opt %s  | tpp-run -e permAB --entry-point-result=void -seed 123 -print > %t.1
+// RUN: tpp-opt %s  --vector-contract-to-outerproduct  | tpp-run -e permAB --entry-point-result=void -seed 123 -print > %t.2
+// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF-PERMAB --allow-empty
+
+
+// DIFF-NOT: {{.}}
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+  func.func @entry(%arg0: tensor<16x16xf32>, %arg1: tensor<16x16xf32>, %arg2: tensor<16x16xf32>) -> tensor<16x16xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<16x16xf32>, vector<16x16xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<16x16xf32>, vector<16x16xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<16x16xf32>, vector<16x16xf32>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #vector.kind<add>} %0, %1, %2
+      : vector<16x16xf32>, vector<16x16xf32> into vector<16x16xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<16x16xf32>, tensor<16x16xf32>
+    return %4 : tensor<16x16xf32>
+  }
+
+// -----
+
+// DIFF-PERMA-NOT: {{.}}
+#permA0 = affine_map<(d0, d1, d2) -> (d2, d0)>
+#permA1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#permA2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+  func.func @permA(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>, %arg2: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %3 = vector.contract {indexing_maps = [#permA0, #permA1, #permA2],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #vector.kind<add>} %0, %1, %2
+      : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x4xf32>, tensor<4x4xf32>
+    return %4 : tensor<4x4xf32>
+  }
+
+// -----
+
+// DIFF-PERMB-NOT: {{.}}
+#permB0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#permB1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#permB2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+  func.func @permB(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>, %arg2: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %3 = vector.contract {indexing_maps = [#permB0, #permB1, #permB2],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #vector.kind<add>} %0, %1, %2
+      : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x4xf32>, tensor<4x4xf32>
+    return %4 : tensor<4x4xf32>
+  }
+
+// -----
+
+// DIFF-PERMAB-NOT: {{.}}
+#permAB0 = affine_map<(d0, d1, d2) -> (d2, d0)>
+#permAB1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#permAB2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+  func.func @permAB(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>, %arg2: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x4xf32>
+    %3 = vector.contract {indexing_maps = [#permAB0, #permAB1, #permAB2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x4xf32>, tensor<4x4xf32>
+    return %4 : tensor<4x4xf32>
+  }
+
+// -----

--- a/test/Passes/pass-vector-contract-to-outerproduct.mlir
+++ b/test/Passes/pass-vector-contract-to-outerproduct.mlir
@@ -1,0 +1,319 @@
+// RUN: tpp-opt %s  --vector-contract-to-outerproduct --split-input-file | FileCheck %s
+
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+module {
+  func.func @matmul_k_one(%arg0: tensor<4x1xf32>, %arg1: tensor<1x64xf32>, %arg2: tensor<4x64xf32>) -> tensor<4x64xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x1xf32>, vector<4x1xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x64xf32>, vector<1x64xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x64xf32>, vector<4x64xf32>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x1xf32>, vector<1x64xf32> into vector<4x64xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, tensor<4x64xf32>
+    return %4 : tensor<4x64xf32>
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL:   func.func @matmul_k_one(
+// CHECK-SAME:                            %[[VAL_0:.*]]: tensor<4x1xf32>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: tensor<1x64xf32>,
+// CHECK-SAME:                            %[[VAL_2:.*]]: tensor<4x64xf32>) -> tensor<4x64xf32> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_6:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true, true]} : tensor<4x64xf32>, vector<4x64xf32>
+// CHECK:           %[[VAL_7:.*]] = scf.for %[[VAL_8:.*]] = %[[VAL_4]] to %[[VAL_3]] step %[[VAL_3]] iter_args(%[[VAL_9:.*]] = %[[VAL_6]]) -> (vector<4x64xf32>) {
+// CHECK:             %[[VAL_10:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_8]]], %[[VAL_5]] {in_bounds = [true], permutation_map = #[[$ATTR_0]]} : tensor<4x1xf32>, vector<4xf32>
+// CHECK:             %[[VAL_11:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_8]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true]} : tensor<1x64xf32>, vector<64xf32>
+// CHECK:             %[[VAL_12:.*]] = vector.outerproduct %[[VAL_10]], %[[VAL_11]], %[[VAL_9]] {kind = #{{.*}}<add>} : vector<4xf32>, vector<64xf32>
+// CHECK:             scf.yield %[[VAL_12]] : vector<4x64xf32>
+// CHECK:           }
+// CHECK:           %[[VAL_13:.*]] = vector.transfer_write %[[VAL_7]], %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]] {in_bounds = [true, true]} : vector<4x64xf32>, tensor<4x64xf32>
+// CHECK:           return %[[VAL_13]] : tensor<4x64xf32>
+// CHECK:         }
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+module {
+  func.func @matmul_k_one_bf16(%arg0: tensor<4x1xbf16>, %arg1: tensor<1x64xbf16>, %arg2: tensor<4x64xbf16>) -> tensor<4x64xbf16> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x1xbf16>, vector<4x1xbf16>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x64xbf16>, vector<1x64xbf16>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x64xbf16>, vector<4x64xbf16>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x1xbf16>, vector<1x64xbf16> into vector<4x64xbf16>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xbf16>, tensor<4x64xbf16>
+    return %4 : tensor<4x64xbf16>
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL:   func.func @matmul_k_one_bf16(
+// CHECK-SAME:                            %[[VAL_0:.*]]: tensor<4x1xbf16>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: tensor<1x64xbf16>,
+// CHECK-SAME:                            %[[VAL_2:.*]]: tensor<4x64xbf16>) -> tensor<4x64xbf16> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[VAL_6:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true, true]} : tensor<4x64xbf16>, vector<4x64xbf16>
+// CHECK:           %[[VAL_7:.*]] = scf.for %[[VAL_8:.*]] = %[[VAL_4]] to %[[VAL_3]] step %[[VAL_3]] iter_args(%[[VAL_9:.*]] = %[[VAL_6]]) -> (vector<4x64xbf16>) {
+// CHECK:             %[[VAL_10:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_8]]], %[[VAL_5]] {in_bounds = [true], permutation_map = #[[$ATTR_0]]} : tensor<4x1xbf16>, vector<4xbf16>
+// CHECK:             %[[VAL_11:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_8]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true]} : tensor<1x64xbf16>, vector<64xbf16>
+// CHECK:             %[[VAL_12:.*]] = vector.outerproduct %[[VAL_10]], %[[VAL_11]], %[[VAL_9]] {kind = #{{.*}}<add>} : vector<4xbf16>, vector<64xbf16>
+// CHECK:             scf.yield %[[VAL_12]] : vector<4x64xbf16>
+// CHECK:           }
+// CHECK:           %[[VAL_13:.*]] = vector.transfer_write %[[VAL_7]], %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]] {in_bounds = [true, true]} : vector<4x64xbf16>, tensor<4x64xbf16>
+// CHECK:           return %[[VAL_13]] : tensor<4x64xbf16>
+// CHECK:         }
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+module {
+  func.func @matmul_k_one_memref(%arg0: memref<4x1xf32>, %arg1: memref<1x64xf32>, %arg2: memref<4x64xf32>) {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x1xf32>, vector<4x1xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : memref<1x64xf32>, vector<1x64xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x64xf32>, vector<4x64xf32>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x1xf32>, vector<1x64xf32> into vector<4x64xf32>
+    vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, memref<4x64xf32>
+    return
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL:   func.func @matmul_k_one_memref(
+// CHECK-SAME:                            %[[VAL_0:.*]]: memref<4x1xf32>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: memref<1x64xf32>,
+// CHECK-SAME:                            %[[VAL_2:.*]]: memref<4x64xf32>) {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_6:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true, true]} : memref<4x64xf32>, vector<4x64xf32>
+// CHECK:           %[[VAL_7:.*]] = scf.for %[[VAL_8:.*]] = %[[VAL_4]] to %[[VAL_3]] step %[[VAL_3]] iter_args(%[[VAL_9:.*]] = %[[VAL_6]]) -> (vector<4x64xf32>) {
+// CHECK:             %[[VAL_10:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_8]]], %[[VAL_5]] {in_bounds = [true], permutation_map = #[[$ATTR_0]]} : memref<4x1xf32>, vector<4xf32>
+// CHECK:             %[[VAL_11:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_8]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true]} : memref<1x64xf32>, vector<64xf32>
+// CHECK:             %[[VAL_12:.*]] = vector.outerproduct %[[VAL_10]], %[[VAL_11]], %[[VAL_9]] {kind = #{{.*}}<add>} : vector<4xf32>, vector<64xf32>
+// CHECK:             scf.yield %[[VAL_12]] : vector<4x64xf32>
+// CHECK:           }
+// CHECK:           vector.transfer_write %[[VAL_7]], %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]] {in_bounds = [true, true]} : vector<4x64xf32>, memref<4x64xf32>
+// CHECK:           return
+// CHECK:         }
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+module {
+  func.func @matmul_any_k(%arg0: tensor<4x2xf32>, %arg1: tensor<2x64xf32>, %arg2: tensor<4x64xf32>) -> tensor<4x64xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x2xf32>, vector<4x2xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<2x64xf32>, vector<2x64xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x64xf32>, vector<4x64xf32>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x2xf32>, vector<2x64xf32> into vector<4x64xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, tensor<4x64xf32>
+    return %4 : tensor<4x64xf32>
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL:   func.func @matmul_any_k(
+// CHECK-SAME:                      %[[VAL_0:.*]]: tensor<4x2xf32>,
+// CHECK-SAME:                      %[[VAL_1:.*]]: tensor<2x64xf32>,
+// CHECK-SAME:                      %[[VAL_2:.*]]: tensor<4x64xf32>) -> tensor<4x64xf32> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_7:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_5]], %[[VAL_5]]], %[[VAL_6]] {in_bounds = [true, true]} : tensor<4x64xf32>, vector<4x64xf32>
+// CHECK:           %[[VAL_8:.*]] = scf.for %[[VAL_9:.*]] = %[[VAL_5]] to %[[VAL_3]] step %[[VAL_4]] iter_args(%[[VAL_10:.*]] = %[[VAL_7]]) -> (vector<4x64xf32>) {
+// CHECK:             %[[VAL_11:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_5]], %[[VAL_9]]], %[[VAL_6]] {in_bounds = [true], permutation_map = #[[$ATTR_0]]} : tensor<4x2xf32>, vector<4xf32>
+// CHECK:             %[[VAL_12:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_9]], %[[VAL_5]]], %[[VAL_6]] {in_bounds = [true]} : tensor<2x64xf32>, vector<64xf32>
+// CHECK:             %[[VAL_13:.*]] = vector.outerproduct %[[VAL_11]], %[[VAL_12]], %[[VAL_10]] {kind = #{{.*}}<add>} : vector<4xf32>, vector<64xf32>
+// CHECK:             scf.yield %[[VAL_13]] : vector<4x64xf32>
+// CHECK:           }
+// CHECK:           %[[VAL_14:.*]] = vector.transfer_write %[[VAL_8]], %[[VAL_2]]{{\[}}%[[VAL_5]], %[[VAL_5]]] {in_bounds = [true, true]} : vector<4x64xf32>, tensor<4x64xf32>
+// CHECK:           return %[[VAL_14]] : tensor<4x64xf32>
+// CHECK:         }
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+module {
+  func.func @batch_reduce_matmul_tiled(%arg0: memref<16x32x16x32xf32>, %arg1: memref<32x32x32x32xf32>, %arg2: memref<16x32x16x32xf32>) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c4 = arith.constant 4 : index
+    %c16 = arith.constant 16 : index
+    %c0 = arith.constant 0 : index
+    scf.forall (%arg3, %arg4) in (16, 32) {
+      %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
+      %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+      %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<16x32xf32, strided<[32, 1], offset: ?>>
+      scf.for %arg5 = %c0 to %c16 step %c4 {  // m-loop
+        scf.for %arg6 = %c0 to %c32 step %c16 { //n-loop
+          scf.for %arg7 = %c0 to %c32 step %c1 { //BRGEMM-loop
+            scf.for %arg8 = %c0 to %c32 step %c8 { //k-loop
+              %subview_2 = memref.subview %subview[%arg7, %arg5, %arg8] [1, 4, 4] [1, 1, 1] : memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>> to memref<1x4x4xf32, strided<[512, 32, 1], offset: ?>>
+              %subview_3 = memref.subview %subview_0[%arg7, %arg8, %arg6] [1, 4, 2] [1, 1, 1] : memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>
+              %subview_4 = memref.subview %subview_1[%arg5, %arg6] [4, 2] [1, 1] : memref<16x32xf32, strided<[32, 1], offset: ?>> to memref<4x2xf32, strided<[32, 1], offset: ?>>
+              %0 = vector.transfer_read %subview_2[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x4xf32, strided<[512, 32, 1], offset: ?>>, vector<1x4x4xf32>
+              %1 = vector.transfer_read %subview_3[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>, vector<1x4x2xf32>
+              %2 = vector.transfer_read %subview_4[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x2xf32, strided<[32, 1], offset: ?>>, vector<4x2xf32>
+              %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<1x4x4xf32>, vector<1x4x2xf32> into vector<4x2xf32>
+              vector.transfer_write %3, %subview_4[%c0, %c0] {in_bounds = [true, true]} : vector<4x2xf32>, memref<4x2xf32, strided<[32, 1], offset: ?>>
+            }
+          }
+        }
+      }
+    }
+    return
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2) -> (d0)>
+// CHECK: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2) -> (d1)>
+// CHECK-LABEL:   func.func @batch_reduce_matmul_tiled(
+// CHECK-SAME:                     %[[VAL_0:.*]]: memref<16x32x16x32xf32>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: memref<32x32x32x32xf32>,
+// CHECK-SAME:                     %[[VAL_2:.*]]: memref<16x32x16x32xf32>) {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_4:.*]] = arith.constant 8 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 32 : index
+// CHECK:           %[[VAL_7:.*]] = arith.constant 4 : index
+// CHECK:           %[[VAL_8:.*]] = arith.constant 16 : index
+// CHECK:           %[[VAL_9:.*]] = arith.constant 0 : index
+// CHECK:           scf.forall (%[[VAL_10:.*]], %[[VAL_11:.*]]) in (16, 32) {
+// CHECK:             %[[VAL_12:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_10]], 0, 0, 0] [1, 32, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>>
+// CHECK:             %[[VAL_13:.*]] = memref.subview %[[VAL_1]]{{\[}}%[[VAL_11]], 0, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : memref<32x32x32x32xf32> to memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:             %[[VAL_14:.*]] = memref.subview %[[VAL_2]]{{\[}}%[[VAL_10]], %[[VAL_11]], 0, 0] [1, 1, 16, 32] [1, 1, 1, 1] : memref<16x32x16x32xf32> to memref<16x32xf32, strided<[32, 1], offset: ?>>
+// CHECK:             scf.for %[[VAL_15:.*]] = %[[VAL_9]] to %[[VAL_8]] step %[[VAL_7]] {
+// CHECK:               scf.for %[[VAL_16:.*]] = %[[VAL_9]] to %[[VAL_6]] step %[[VAL_8]] {
+// CHECK:                 scf.for %[[VAL_17:.*]] = %[[VAL_9]] to %[[VAL_6]] step %[[VAL_5]] {
+// CHECK:                   scf.for %[[VAL_18:.*]] = %[[VAL_9]] to %[[VAL_6]] step %[[VAL_4]] {
+// CHECK:                     %[[VAL_19:.*]] = memref.subview %[[VAL_12]]{{\[}}%[[VAL_17]], %[[VAL_15]], %[[VAL_18]]] [1, 4, 4] [1, 1, 1] : memref<32x16x32xf32, strided<[512, 32, 1], offset: ?>> to memref<1x4x4xf32, strided<[512, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_20:.*]] = memref.subview %[[VAL_13]]{{\[}}%[[VAL_17]], %[[VAL_18]], %[[VAL_16]]] [1, 4, 2] [1, 1, 1] : memref<32x32x32xf32, strided<[1024, 32, 1], offset: ?>> to memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>
+// CHECK:                     %[[VAL_21:.*]] = memref.subview %[[VAL_14]]{{\[}}%[[VAL_15]], %[[VAL_16]]] [4, 2] [1, 1] : memref<16x32xf32, strided<[32, 1], offset: ?>> to memref<4x2xf32, strided<[32, 1], offset: ?>>
+// CHECK:                     %[[VAL_22:.*]] = vector.transfer_read %[[VAL_21]]{{\[}}%[[VAL_9]], %[[VAL_9]]], %[[VAL_3]] {in_bounds = [true, true]} : memref<4x2xf32, strided<[32, 1], offset: ?>>, vector<4x2xf32>
+// CHECK:                     %[[VAL_23:.*]] = scf.for %[[VAL_24:.*]] = %[[VAL_9]] to %[[VAL_7]] step %[[VAL_5]] iter_args(%[[VAL_25:.*]] = %[[VAL_22]]) -> (vector<4x2xf32>) {
+// CHECK:                       %[[VAL_26:.*]] = vector.transfer_read %[[VAL_19]]{{\[}}%[[VAL_9]], %[[VAL_9]], %[[VAL_24]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #[[$ATTR_0]]} : memref<1x4x4xf32, strided<[512, 32, 1], offset: ?>>, vector<4xf32>
+// CHECK:                       %[[VAL_27:.*]] = vector.transfer_read %[[VAL_20]]{{\[}}%[[VAL_9]], %[[VAL_24]], %[[VAL_9]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #[[$ATTR_1]]} : memref<1x4x2xf32, strided<[1024, 32, 1], offset: ?>>, vector<2xf32>
+// CHECK:                       %[[VAL_28:.*]] = vector.outerproduct %[[VAL_26]], %[[VAL_27]], %[[VAL_25]] {kind = #{{.*}}<add>} : vector<4xf32>, vector<2xf32>
+// CHECK:                       scf.yield %[[VAL_28]] : vector<4x2xf32>
+// CHECK:                     }
+// CHECK:                     vector.transfer_write %[[VAL_23]], %[[VAL_21]]{{\[}}%[[VAL_9]], %[[VAL_9]]] {in_bounds = [true, true]} : vector<4x2xf32>, memref<4x2xf32, strided<[32, 1], offset: ?>>
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  func.func @entry(%arg0: tensor<4x4xf32>, %arg1: tensor<8x64xf32>,
+      %arg2: tensor<8x64xf32>) -> tensor<8x64xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0],
+      %cst {in_bounds = [true, true]} : tensor<4x4xf32>, vector<4x2xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0],
+      %cst {in_bounds = [true, true]} : tensor<8x64xf32>, vector<2x64xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0],
+      %cst {in_bounds = [true, true]} : tensor<8x64xf32>, vector<4x64xf32>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #vector.kind<add>} %0, %1, %2 : vector<4x2xf32>, vector<2x64xf32>
+      into vector<4x64xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]}
+      : vector<4x64xf32>, tensor<8x64xf32>
+    return %4 : tensor<8x64xf32>
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d0)>
+
+// CHECK-LABEL:   func.func @entry(
+// CHECK-SAME:                     %[[VAL_0:.*]]: tensor<4x4xf32>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: tensor<8x64xf32>,
+// CHECK-SAME:                     %[[VAL_2:.*]]: tensor<8x64xf32>) -> tensor<8x64xf32> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_7:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_5]], %[[VAL_5]]], %[[VAL_6]] {in_bounds = [true, true]} : tensor<8x64xf32>, vector<4x64xf32>
+// CHECK:           %[[VAL_8:.*]] = scf.for %[[VAL_9:.*]] = %[[VAL_5]] to %[[VAL_3]] step %[[VAL_4]] iter_args(%[[VAL_10:.*]] = %[[VAL_7]]) -> (vector<4x64xf32>) {
+// CHECK:             %[[VAL_11:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_5]], %[[VAL_9]]], %[[VAL_6]] {in_bounds = [true], permutation_map = #[[$ATTR_0]]} : tensor<4x4xf32>, vector<4xf32>
+// CHECK:             %[[VAL_12:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_9]], %[[VAL_5]]], %[[VAL_6]] {in_bounds = [true]} : tensor<8x64xf32>, vector<64xf32>
+// CHECK:             %[[VAL_13:.*]] = vector.outerproduct %[[VAL_11]], %[[VAL_12]], %[[VAL_10]] {kind = #{{.*}}<add>} : vector<4xf32>, vector<64xf32>
+// CHECK:             scf.yield %[[VAL_13]] : vector<4x64xf32>
+// CHECK:           }
+// CHECK:           %[[VAL_14:.*]] = vector.transfer_write %[[VAL_8]], %[[VAL_2]]{{\[}}%[[VAL_5]], %[[VAL_5]]] {in_bounds = [true, true]} : vector<4x64xf32>, tensor<8x64xf32>
+// CHECK:           return %[[VAL_14]] : tensor<8x64xf32>
+// CHECK:         }
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  func.func @gemm_non_zero_offset(%arg0: tensor<8x8xf32>, %arg1: tensor<8x8xf32>, %arg2: tensor<8x8xf32>) -> tensor<8x8xf32> {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c4, %c0], %cst {in_bounds = [true, true]} : tensor<8x8xf32>, vector<4x4xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c4], %cst {in_bounds = [true, true]} : tensor<8x8xf32>, vector<4x4xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<8x8xf32>, vector<4x4xf32>
+    %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
+    %4 = vector.transfer_write %3, %arg2[%c4, %c4] {in_bounds = [true, true]} : vector<4x4xf32>, tensor<8x8xf32>
+    return %4 : tensor<8x8xf32>
+  }
+}
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$ATTR_2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL:   func.func @gemm_non_zero_offset(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<8x8xf32>, %[[VAL_1:.*]]: tensor<8x8xf32>,
+// CHECK-SAME:                                    %[[VAL_2:.*]]: tensor<8x8xf32>) -> tensor<8x8xf32> {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 4 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_6:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_3]]], %[[VAL_5]] {in_bounds = [true, true]} : tensor<8x8xf32>, vector<4x4xf32>
+// CHECK:           %[[VAL_7:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_3]], %[[VAL_4]]], %[[VAL_5]] {in_bounds = [true, true]} : tensor<8x8xf32>, vector<4x4xf32>
+// CHECK:           %[[VAL_8:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_3]], %[[VAL_3]]], %[[VAL_5]] {in_bounds = [true, true]} : tensor<8x8xf32>, vector<4x4xf32>
+// CHECK:           %[[VAL_9:.*]] = vector.contract {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]], iterator_types = ["parallel", "parallel", "reduction"], kind = #{{.*}}<add>} %[[VAL_6]], %[[VAL_7]], %[[VAL_8]] : vector<4x4xf32>, vector<4x4xf32> into vector<4x4xf32>
+// CHECK:           %[[VAL_10:.*]] = vector.transfer_write %[[VAL_9]], %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_4]]] {in_bounds = [true, true]} : vector<4x4xf32>, tensor<8x8xf32>
+// CHECK:           return %[[VAL_10]] : tensor<8x8xf32>
+// CHECK:         }
+
+// -----


### PR DESCRIPTION
Implements the lowering of vector contraction op to vector outerproduct wrapped inside an scf.forloop. with iterargs to accumulate the result of each outerproduct corresponding to the K dimension size. The idea is to exploit the AVX feature to generate optimal vector code. Outerproduct gets lowered to FMAs X86 assembly through llvm intrinsic "llvm.intr.fmuladd".