### PR TITLE
Split reduction dim pass

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -506,4 +506,20 @@ def FoldIntoEltwise : Pass<"fold-into-eltwise", "ModuleOp"> {
                            "affine::AffineDialect"];
 }
 
+def SplitReductionDim : Pass<"split-reduction-dim"> {
+  let summary = "Split innermost reduction dimension.";
+  let description = [{
+    Split innermost reduction dimension using serial loop.
+  }];
+  let dependentDialects = ["linalg::LinalgDialect",
+                           "scf::SCFDialect",
+                           "memref::MemRefDialect",
+                           "arith::ArithDialect"];
+  let options = [
+    Option<"tileSize", "tile", "int64_t",
+           /*default=*/"0",
+           "Reduction dimension tile size">,
+  ];
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -509,7 +509,8 @@ def FoldIntoEltwise : Pass<"fold-into-eltwise", "ModuleOp"> {
 def SplitReductionDim : Pass<"split-reduction-dim", "func::FuncOp"> {
   let summary = "Split innermost reduction dimension.";
   let description = [{
-    Split innermost reduction dimension using serial loop.
+    Split innermost reduction dimension and compute it sequentially
+    using a serial loop and in-place accumulation.
   }];
   let dependentDialects = ["linalg::LinalgDialect",
                            "scf::SCFDialect",

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -506,14 +506,16 @@ def FoldIntoEltwise : Pass<"fold-into-eltwise", "ModuleOp"> {
                            "affine::AffineDialect"];
 }
 
-def SplitReductionDim : Pass<"split-reduction-dim"> {
+def SplitReductionDim : Pass<"split-reduction-dim", "func::FuncOp"> {
   let summary = "Split innermost reduction dimension.";
   let description = [{
     Split innermost reduction dimension using serial loop.
   }];
   let dependentDialects = ["linalg::LinalgDialect",
                            "scf::SCFDialect",
+                           "tensor::TensorDialect",
                            "memref::MemRefDialect",
+                           "affine::AffineDialect",
                            "arith::ArithDialect"];
   let options = [
     Option<"tileSize", "tile", "int64_t",

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -64,6 +64,11 @@ llvm::cl::list<int64_t>
                 llvm::cl::list_init<int64_t>(SmallVector<int64_t>{8, 16, 16}),
                 llvm::cl::CommaSeparated);
 
+// Control GPU vectorization.
+llvm::cl::opt<bool> gpuVectorize("gpu-vectorize",
+                                 llvm::cl::desc("Vectorize GPU kernel"),
+                                 llvm::cl::init(false));
+
 namespace mlir {
 namespace tpp {
 #define GEN_PASS_DEF_GPUPIPELINE
@@ -181,6 +186,14 @@ private:
     threadTileOptions.minTileFactor = 1;
     pm.addPass(createTileConsumerAndFuseProducers(threadTileOptions));
     pm.addPass(createCleanup());
+
+    if (gpuVectorize) {
+      // Currently early reduction dimension splitting is incompatible with
+      // Linalg to XeGPU lowering that expects full GEMM.
+      // For now, enable only with vectorization passes.
+      pm.addPass(createSplitReductionDim(SplitReductionDimOptions{kTile}));
+      pm.addPass(createCleanup());
+    }
 
     // Preprocess and bufferize as further conversion requires memref
     // abstraction.

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -188,9 +188,9 @@ private:
     pm.addPass(createCleanup());
 
     if (gpuVectorize) {
-      // Currently early reduction dimension splitting is incompatible with
+      // Early reduction dimension splitting is incompatible with
       // Linalg to XeGPU lowering that expects full GEMM.
-      // For now, enable only with vectorization passes.
+      // For now, enable only with other vectorization passes.
       pm.addPass(createSplitReductionDim(SplitReductionDimOptions{kTile}));
       pm.addPass(createCleanup());
     }

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_library(TPPTransforms
   FoldIntoEltwise.cpp
   FoldAddIntoDest.cpp
   Vectorization.cpp
+  SplitReductionDim.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Transforms/SplitReductionDim.cpp
+++ b/lib/TPP/Transforms/SplitReductionDim.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Pass/Pass.h"
@@ -43,45 +44,6 @@ namespace tpp {
 
 namespace {
 
-// Returns sizes of an operand.
-static SmallVector<OpFoldResult> getOperandSizes(OpBuilder builder,
-                                                 Location loc, Value operand) {
-  SmallVector<Value> sizes;
-  auto type = operand.getType();
-  bool isTensor = isa<TensorType>(type);
-  unsigned rank = cast<ShapedType>(type).getRank();
-  for (unsigned i = 0; i < rank; ++i) {
-    Value dim;
-    if (isTensor)
-      dim = builder.create<tensor::DimOp>(loc, operand, i);
-    else
-      dim = builder.create<memref::DimOp>(loc, operand, i);
-    sizes.push_back(dim);
-  }
-  return getAsOpFoldResult(sizes);
-}
-
-// Returns strides for a partial view of an operand.
-static SmallVector<OpFoldResult>
-getOperandViewStrides(OpBuilder builder, Location loc, Value operand) {
-  // Apply unit strides for both tensor slice and memref subview.
-  auto type = cast<ShapedType>(operand.getType());
-  return SmallVector<OpFoldResult>(type.getRank(), builder.getIndexAttr(1));
-}
-
-// Returns partial view of an operand.
-static Value getPartialView(OpBuilder builder, Location loc, Value operand,
-                            ArrayRef<OpFoldResult> offsets,
-                            ArrayRef<OpFoldResult> sizes,
-                            ArrayRef<OpFoldResult> strides) {
-  if (isa<TensorType>(operand.getType()))
-    return builder.create<tensor::ExtractSliceOp>(loc, operand, offsets, sizes,
-                                                  strides);
-
-  return builder.create<memref::SubViewOp>(loc, operand, offsets, sizes,
-                                           strides);
-}
-
 // Split contraction's innermost reduction dimension.
 struct SplitContractionReduction
     : public OpInterfaceRewritePattern<linalg::LinalgOp> {
@@ -92,8 +54,6 @@ struct SplitContractionReduction
 
   LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
                                 PatternRewriter &rewriter) const override {
-    Location loc = linalgOp.getLoc();
-
     if (options.tileSize <= 0)
       return rewriter.notifyMatchFailure(linalgOp,
                                          "invalid reduction tile size");
@@ -103,125 +63,25 @@ struct SplitContractionReduction
     if (failed(dims))
       return rewriter.notifyMatchFailure(linalgOp, "not a contraction");
 
-    // Get loop bounds and iteration step for the innermost reduction dimension.
-    auto tileOp = cast<TilingInterface>(linalgOp.getOperation());
-    SmallVector<Range> iterationDomain = tileOp.getIterationDomain(rewriter);
-    unsigned kDimPos = dims->k.back();
-    Range reductionRange = iterationDomain[kDimPos];
-    Value offsetVal =
-        getValueOrCreateConstantIndexOp(rewriter, loc, reductionRange.offset);
-    Value sizeVal =
-        getValueOrCreateConstantIndexOp(rewriter, loc, reductionRange.size);
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, options.tileSize);
+    scf::SCFTilingOptions tilingOpts;
+    // Tile using a serial loop.
+    tilingOpts.setLoopType(scf::SCFTilingOptions::LoopType::ForOp);
+    // Tile only the innermost reduction dimension - disable tiling for all
+    // other dims.
+    SmallVector<OpFoldResult> tiles(
+        linalgOp.getNumLoops(),
+        getAsIndexOpFoldResult(rewriter.getContext(), 0));
+    tiles[dims->k.back()] =
+        getAsIndexOpFoldResult(rewriter.getContext(), options.tileSize);
+    tilingOpts.setTileSizes(tiles);
 
-    Value matA = linalgOp.getDpsInputs()[0];
-    Value matB = linalgOp.getDpsInputs()[1];
-    Value matC = linalgOp.getDpsInits()[0];
-    SmallVector<Value> iterArgs;
-    bool isTensor = linalgOp.hasPureTensorSemantics();
-    if (isTensor)
-      iterArgs.push_back(matC);
+    FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCF(
+        rewriter, cast<TilingInterface>(linalgOp.getOperation()), tilingOpts);
+    if (failed(tilingResult))
+      return rewriter.notifyMatchFailure(linalgOp,
+                                         "failed to tile contraction");
 
-    // Get reduction dimension position in operands.
-    // Corresponding slices' offsets and sizes have to be updated.
-    SmallVector<std::pair<Value, unsigned>, 2> kOperands;
-    unsigned kDimPosA;
-    unsigned kDimPosB;
-    linalgOp.mapIterationSpaceDimToAllOperandDims(kDimPos, kOperands);
-    for (auto [operand, pos] : kOperands) {
-      if (operand == matA)
-        kDimPosA = pos;
-      if (operand == matB)
-        kDimPosB = pos;
-    }
-
-    // Create a serial loop that iterates over the innermost reduction
-    // dimension.
-    auto loop = rewriter.create<scf::ForOp>(
-        loc, offsetVal, sizeVal, step, iterArgs,
-        [&](OpBuilder &builder, Location loc, Value iv, ValueRange args) {
-          MLIRContext *ctx = builder.getContext();
-
-          OpFoldResult kDimBound;
-          std::optional<int64_t> dimK =
-              linalgx::utils::getConstantRange(reductionRange);
-          if (dimK && (*dimK % options.tileSize == 0)) {
-            kDimBound = builder.getIndexAttr(options.tileSize);
-          } else {
-            // The tile size to use (to avoid out of bounds access) is  minimum
-            // of `tileSize` and `ub - iv`, where `iv` is the induction variable
-            // of the tiled loop.
-            AffineExpr s0, s1, d0;
-            bindDims(ctx, d0);
-            bindSymbols(ctx, s0, s1);
-            AffineMap minMap = AffineMap::get(/*dimCount=*/1, /*symbolCount=*/2,
-                                              {s0 - d0, s1}, ctx);
-            kDimBound = affine::makeComposedFoldedAffineMin(
-                builder, loc, minMap,
-                SmallVector<OpFoldResult>{iv, sizeVal, step});
-          }
-
-          // Get a slice of matrix A.
-          // Update operand's tiled reduction dim offset and size.
-          auto rankA = cast<ShapedType>(matA.getType()).getRank();
-          SmallVector<OpFoldResult> offsetsA(rankA, builder.getIndexAttr(0));
-          offsetsA[kDimPosA] = getAsOpFoldResult(iv);
-          SmallVector<OpFoldResult> sizesA =
-              getOperandSizes(builder, loc, matA);
-          sizesA[kDimPosA] = kDimBound;
-          SmallVector<OpFoldResult> stridesA =
-              getOperandViewStrides(builder, loc, matA);
-          Value sliceA =
-              getPartialView(builder, loc, matA, offsetsA, sizesA, stridesA);
-
-          // Get a slice of matrix B.
-          auto rankB = cast<ShapedType>(matB.getType()).getRank();
-          SmallVector<OpFoldResult> offsetsB(rankB, builder.getIndexAttr(0));
-          offsetsB[kDimPosB] = getAsOpFoldResult(iv);
-          SmallVector<OpFoldResult> sizesB =
-              getOperandSizes(builder, loc, matB);
-          sizesB[kDimPosB] = kDimBound;
-          SmallVector<OpFoldResult> stridesB =
-              getOperandViewStrides(builder, loc, matB);
-          Value sliceB =
-              getPartialView(builder, loc, matB, offsetsB, sizesB, stridesB);
-
-          // For tensor abstraction, the results have to be accumulated through
-          // iter_args. Otherwise, reuse the original matrix C directly.
-          Value accMat = args.empty() ? matC : args[0];
-
-          // Create a new contraction generic op with updated operands.
-          // TODO: Can named ops be preserved?
-          linalg::LinalgOp newContraction;
-          SmallVector<AffineMap> indexingMaps(linalgOp.getIndexingMapsArray());
-          SmallVector<utils::IteratorType> iteratorTypes(
-              linalgOp.getIteratorTypesArray());
-          if (isTensor) {
-            newContraction = builder.create<linalg::GenericOp>(
-                loc, ValueRange(linalgOp->getResults()).getTypes(),
-                ValueRange{sliceA, sliceB}, ValueRange{accMat}, indexingMaps,
-                iteratorTypes);
-          } else {
-            newContraction = builder.create<linalg::GenericOp>(
-                loc, ValueRange{sliceA, sliceB}, ValueRange{accMat},
-                indexingMaps, iteratorTypes);
-          }
-          IRMapping mapping;
-          linalgOp->getRegion(0).cloneInto(&newContraction->getRegion(0),
-                                           newContraction->getRegion(0).begin(),
-                                           mapping);
-
-          // Terminate the loop.
-          SmallVector<Value> results;
-          if (!args.empty())
-            results.push_back(newContraction->getResults()[0]);
-          builder.create<scf::YieldOp>(loc, results);
-        });
-
-    if (isTensor)
-      rewriter.replaceOp(linalgOp, loop);
-    else
-      rewriter.eraseOp(linalgOp);
+    rewriter.replaceOp(linalgOp, tilingResult->replacements);
 
     return success();
   }

--- a/lib/TPP/Transforms/SplitReductionDim.cpp
+++ b/lib/TPP/Transforms/SplitReductionDim.cpp
@@ -9,9 +9,12 @@
 #include "TPP/Passes.h"
 
 #include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Dialect.h"
@@ -32,63 +35,192 @@ namespace tpp {
 
 namespace {
 
-struct SplitReductionMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
-  using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
+static bool hasStaticStrides(Value operand) {
+  auto memrefTy = cast<MemRefType>(operand.getType());
+  if (!memrefTy.hasStaticShape())
+    return false;
+
+  int64_t offset = 0;
+  SmallVector<int64_t, 4> strides;
+  if (failed(getStridesAndOffset(memrefTy, strides, offset)))
+    return false;
+
+  return !llvm::any_of(
+      strides, [](int64_t stride) { return stride == ShapedType::kDynamic; });
+}
+
+// Returns sizes of an operand.
+static SmallVector<OpFoldResult> getSizes(OpBuilder builder, Location loc,
+                                          Value operand) {
+  SmallVector<Value> sizes;
+  auto type = operand.getType();
+  bool isTensor = isa<TensorType>(type);
+  unsigned rank = cast<ShapedType>(type).getRank();
+  for (unsigned i = 0; i < rank; ++i) {
+    Value dim;
+    if (isTensor)
+      dim = builder.create<tensor::DimOp>(loc, operand, i);
+    else
+      dim = builder.create<memref::DimOp>(loc, operand, i);
+    sizes.push_back(dim);
+  }
+  return getAsOpFoldResult(sizes);
+}
+
+// Returns strides of an operand.
+static SmallVector<OpFoldResult> getStrides(OpBuilder builder, Location loc,
+                                            Value operand) {
+  auto type = cast<ShapedType>(operand.getType());
+  // TODO: Relax stride check and account for variable strides.
+  return SmallVector<OpFoldResult>(type.getRank(), builder.getIndexAttr(1));
+}
+
+// Returns partial view of an operand.
+static Value getDataSlice(OpBuilder builder, Location loc, Value operand,
+                          ArrayRef<OpFoldResult> offsets,
+                          ArrayRef<OpFoldResult> sizes,
+                          ArrayRef<OpFoldResult> strides) {
+  if (isa<TensorType>(operand.getType()))
+    return builder.create<tensor::ExtractSliceOp>(loc, operand, offsets, sizes,
+                                                  strides);
+
+  return builder.create<memref::SubViewOp>(loc, operand, offsets, sizes,
+                                           strides);
+}
+
+struct SplitReductionMatmulOp
+    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
 
   SplitReductionMatmulOp(MLIRContext *ctx, SplitReductionDimOptions options)
-      : OpRewritePattern<linalg::MatmulOp>(ctx), options(options) {}
+      : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx), options(options) {}
 
-  LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
+  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
                                 PatternRewriter &rewriter) const override {
-    Location loc = matmulOp.getLoc();
+    Location loc = linalgOp.getLoc();
 
-    if (!matmulOp.hasPureBufferSemantics())
-      return rewriter.notifyMatchFailure(matmulOp, "Expect memref semantics");
-    if (matmulOp.hasDynamicShape())
-      return rewriter.notifyMatchFailure(matmulOp, "Expect static shapes");
+    if (options.tileSize <= 0)
+      return rewriter.notifyMatchFailure(linalgOp,
+                                         "invalid reduction tile size");
 
-    auto matA = matmulOp.getDpsInputs()[0];
-    auto matB = matmulOp.getDpsInputs()[1];
-    auto matC = matmulOp.getDpsInits()[0];
+    FailureOr<linalg::ContractionDimensions> dims =
+        linalg::inferContractionDims(linalgOp);
+    if (failed(dims))
+      return rewriter.notifyMatchFailure(linalgOp, "not a contraction");
 
-    auto typeA = cast<ShapedType>(matA.getType());
-    auto typeC = cast<ShapedType>(matC.getType());
+    bool isTensor = linalgOp.hasPureTensorSemantics();
+    if (!isTensor) {
+      for (Value operand : linalgOp->getOperands()) {
+        if (!hasStaticStrides(operand))
+          return rewriter.notifyMatchFailure(linalgOp,
+                                             "requires static strides");
+      }
+    }
 
-    auto kTile = options.tileSize;
-    int dimK = typeA.getShape().back();
-    if ((kTile <= 0) || (dimK % kTile != 0))
-      return rewriter.notifyMatchFailure(matmulOp,
-                                         "invalid matmul reduction tile size");
+    // Get loop bounds and iteration step for the innermost reduction dimension.
+    auto tileOp = cast<TilingInterface>(linalgOp.getOperation());
+    SmallVector<Range> iterationDomain = tileOp.getIterationDomain(rewriter);
+    unsigned kDimPos = dims->k.back();
+    Range reductionRange = iterationDomain[kDimPos];
+    Value offsetVal =
+        getValueOrCreateConstantIndexOp(rewriter, loc, reductionRange.offset);
+    Value sizeVal =
+        getValueOrCreateConstantIndexOp(rewriter, loc, reductionRange.size);
+    Value strideVal =
+        getValueOrCreateConstantIndexOp(rewriter, loc, reductionRange.stride);
+    Value tileCst =
+        rewriter.create<arith::ConstantIndexOp>(loc, options.tileSize);
+    Value step = rewriter.create<arith::MulIOp>(loc, strideVal, tileCst);
 
-    OpBuilder::InsertionGuard guard(rewriter);
+    Value matA = linalgOp.getDpsInputs()[0];
+    Value matB = linalgOp.getDpsInputs()[1];
+    Value matC = linalgOp.getDpsInits()[0];
+    SmallVector<Value> iterArgs;
+    if (isTensor)
+      iterArgs.push_back(matC);
 
-    Value zeroCst = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value ubCst = rewriter.create<arith::ConstantIndexOp>(loc, dimK);
-    Value stepCst = rewriter.create<arith::ConstantIndexOp>(loc, kTile);
-    scf::ForOp loopOp =
-        rewriter.create<scf::ForOp>(loc, zeroCst, ubCst, stepCst);
-    rewriter.setInsertionPointToStart(loopOp.getBody());
+    // Get reduction dimension position in operands.
+    // Corresponding slices' offsets and sizes have to be updated.
+    unsigned kDimPosA;
+    if (failed(
+            linalgOp.mapIterationSpaceDimToOperandDim(kDimPos, matA, kDimPosA)))
+      return failure();
+    unsigned kDimPosB;
+    if (failed(
+            linalgOp.mapIterationSpaceDimToOperandDim(kDimPos, matB, kDimPosB)))
+      return failure();
 
-    Value oneCst = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    auto strides = getAsOpFoldResult({oneCst, oneCst});
+    auto loop = rewriter.create<scf::ForOp>(
+        loc, offsetVal, sizeVal, step, iterArgs,
+        [&](OpBuilder &builder, Location loc, Value iv, ValueRange args) {
+          MLIRContext *ctx = builder.getContext();
+          // Compute min(size, dim - offset) to avoid out-of-bounds accesses.
+          auto minMap = AffineMap::get(
+              /*dimCount=*/3, /*symbolCount=*/0,
+              {getAffineDimExpr(/*position=*/0, ctx),
+               getAffineDimExpr(/*position=*/1, ctx) -
+                   getAffineDimExpr(/*position=*/2, ctx)},
+              ctx);
+          Value kDimBound = builder.create<affine::AffineMinOp>(
+              loc, builder.getIndexType(), minMap,
+              ValueRange{step, sizeVal, iv});
 
-    auto iv = loopOp.getInductionVar();
-    auto offsetsA = getAsOpFoldResult({zeroCst, iv});
-    auto sizesA = getAsOpFoldResult(
-        rewriter.getI64ArrayAttr({typeC.getShape()[0], kTile}));
-    auto subviewA = rewriter.create<memref::SubViewOp>(loc, matA, offsetsA,
-                                                       sizesA, strides);
+          // Get a slice of matrix A.
+          auto rankA = cast<ShapedType>(matA.getType()).getRank();
+          SmallVector<OpFoldResult> offsetsA(rankA, builder.getIndexAttr(0));
+          offsetsA[kDimPosA] = getAsOpFoldResult(iv);
+          SmallVector<OpFoldResult> sizesA = getSizes(builder, loc, matA);
+          sizesA[kDimPosA] = getAsOpFoldResult(kDimBound);
+          SmallVector<OpFoldResult> stridesA = getStrides(builder, loc, matA);
+          Value sliceA =
+              getDataSlice(builder, loc, matA, offsetsA, sizesA, stridesA);
 
-    auto offsetsB = getAsOpFoldResult({iv, zeroCst});
-    auto sizesB = getAsOpFoldResult(
-        rewriter.getI64ArrayAttr({kTile, typeC.getShape()[1]}));
-    auto subviewB = rewriter.create<memref::SubViewOp>(loc, matB, offsetsB,
-                                                       sizesB, strides);
+          // Get a slice of matrix B.
+          auto rankB = cast<ShapedType>(matB.getType()).getRank();
+          SmallVector<OpFoldResult> offsetsB(rankB, builder.getIndexAttr(0));
+          offsetsB[kDimPosB] = getAsOpFoldResult(iv);
+          SmallVector<OpFoldResult> sizesB = getSizes(builder, loc, matB);
+          sizesB[kDimPosB] = getAsOpFoldResult(kDimBound);
+          SmallVector<OpFoldResult> stridesB = getStrides(builder, loc, matB);
+          Value sliceB =
+              getDataSlice(builder, loc, matB, offsetsB, sizesB, stridesB);
 
-    rewriter.create<linalg::MatmulOp>(loc, ValueRange{subviewA, subviewB},
-                                      ValueRange{matC});
+          // For tensor abstraction, the results have to be accumulated through
+          // iter_args. Otherwise, reuse the original matrix C directly.
+          Value accMat = args.empty() ? matC : args[0];
 
-    rewriter.eraseOp(matmulOp);
+          // Create a new contraction generic op with updated operands.
+          // TODO: Can named ops be preserved?
+          linalg::LinalgOp newContraction;
+          SmallVector<AffineMap> indexingMaps(linalgOp.getIndexingMapsArray());
+          SmallVector<utils::IteratorType> iteratorTypes(
+              linalgOp.getIteratorTypesArray());
+          if (isTensor) {
+            newContraction = builder.create<linalg::GenericOp>(
+                loc, ValueRange(linalgOp->getResults()).getTypes(),
+                ValueRange{sliceA, sliceB}, ValueRange{accMat}, indexingMaps,
+                iteratorTypes);
+          } else {
+            newContraction = builder.create<linalg::GenericOp>(
+                loc, ValueRange{sliceA, sliceB}, ValueRange{accMat},
+                indexingMaps, iteratorTypes);
+          }
+          IRMapping mapping;
+          linalgOp->getRegion(0).cloneInto(&newContraction->getRegion(0),
+                                           newContraction->getRegion(0).begin(),
+                                           mapping);
+
+          // Terminate loop.
+          SmallVector<Value> results;
+          if (!args.empty())
+            results.push_back(newContraction->getResults()[0]);
+          builder.create<scf::YieldOp>(loc, results);
+        });
+
+    if (isTensor)
+      rewriter.replaceOp(linalgOp, loop);
+    else
+      rewriter.eraseOp(linalgOp);
 
     return success();
   }

--- a/lib/TPP/Transforms/SplitReductionDim.cpp
+++ b/lib/TPP/Transforms/SplitReductionDim.cpp
@@ -99,8 +99,6 @@ struct SplitContractionReduction
     if (failed(dims))
       return rewriter.notifyMatchFailure(linalgOp, "not a contraction");
 
-    bool isTensor = linalgOp.hasPureTensorSemantics();
-
     // Get loop bounds and iteration step for the innermost reduction dimension.
     auto tileOp = cast<TilingInterface>(linalgOp.getOperation());
     SmallVector<Range> iterationDomain = tileOp.getIterationDomain(rewriter);
@@ -116,6 +114,7 @@ struct SplitContractionReduction
     Value matB = linalgOp.getDpsInputs()[1];
     Value matC = linalgOp.getDpsInits()[0];
     SmallVector<Value> iterArgs;
+    bool isTensor = linalgOp.hasPureTensorSemantics();
     if (isTensor)
       iterArgs.push_back(matC);
 
@@ -159,6 +158,7 @@ struct SplitContractionReduction
           }
 
           // Get a slice of matrix A.
+          // Update operand's tiled reduction dim offset and size.
           auto rankA = cast<ShapedType>(matA.getType()).getRank();
           SmallVector<OpFoldResult> offsetsA(rankA, builder.getIndexAttr(0));
           offsetsA[kDimPosA] = getAsOpFoldResult(iv);

--- a/lib/TPP/Transforms/SplitReductionDim.cpp
+++ b/lib/TPP/Transforms/SplitReductionDim.cpp
@@ -1,0 +1,119 @@
+//===- SplitReductionDim.cpp -------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_SPLITREDUCTIONDIM
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+struct SplitReductionMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
+  using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
+
+  SplitReductionMatmulOp(MLIRContext *ctx, SplitReductionDimOptions options)
+      : OpRewritePattern<linalg::MatmulOp>(ctx), options(options) {}
+
+  LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = matmulOp.getLoc();
+
+    if (!matmulOp.hasPureBufferSemantics())
+      return rewriter.notifyMatchFailure(matmulOp, "Expect memref semantics");
+    if (matmulOp.hasDynamicShape())
+      return rewriter.notifyMatchFailure(matmulOp, "Expect static shapes");
+
+    auto matA = matmulOp.getDpsInputs()[0];
+    auto matB = matmulOp.getDpsInputs()[1];
+    auto matC = matmulOp.getDpsInits()[0];
+
+    auto typeA = cast<ShapedType>(matA.getType());
+    auto typeC = cast<ShapedType>(matC.getType());
+
+    auto kTile = options.tileSize;
+    int dimK = typeA.getShape().back();
+    if ((kTile <= 0) || (dimK % kTile != 0))
+      return rewriter.notifyMatchFailure(matmulOp,
+                                         "invalid matmul reduction tile size");
+
+    OpBuilder::InsertionGuard guard(rewriter);
+
+    Value zeroCst = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value ubCst = rewriter.create<arith::ConstantIndexOp>(loc, dimK);
+    Value stepCst = rewriter.create<arith::ConstantIndexOp>(loc, kTile);
+    scf::ForOp loopOp =
+        rewriter.create<scf::ForOp>(loc, zeroCst, ubCst, stepCst);
+    rewriter.setInsertionPointToStart(loopOp.getBody());
+
+    Value oneCst = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    auto strides = getAsOpFoldResult({oneCst, oneCst});
+
+    auto iv = loopOp.getInductionVar();
+    auto offsetsA = getAsOpFoldResult({zeroCst, iv});
+    auto sizesA = getAsOpFoldResult(
+        rewriter.getI64ArrayAttr({typeC.getShape()[0], kTile}));
+    auto subviewA = rewriter.create<memref::SubViewOp>(loc, matA, offsetsA,
+                                                       sizesA, strides);
+
+    auto offsetsB = getAsOpFoldResult({iv, zeroCst});
+    auto sizesB = getAsOpFoldResult(
+        rewriter.getI64ArrayAttr({kTile, typeC.getShape()[1]}));
+    auto subviewB = rewriter.create<memref::SubViewOp>(loc, matB, offsetsB,
+                                                       sizesB, strides);
+
+    rewriter.create<linalg::MatmulOp>(loc, ValueRange{subviewA, subviewB},
+                                      ValueRange{matC});
+
+    rewriter.eraseOp(matmulOp);
+
+    return success();
+  }
+
+private:
+  SplitReductionDimOptions options;
+};
+
+// Split innermost reduction dimension.
+struct SplitReductionDim
+    : public tpp::impl::SplitReductionDimBase<SplitReductionDim> {
+  using SplitReductionDimBase::SplitReductionDimBase;
+
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+
+    SplitReductionDimOptions options{tileSize};
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<SplitReductionMatmulOp>(ctx, options);
+    GreedyRewriteConfig config;
+    config.strictMode = GreedyRewriteStrictness::ExistingOps;
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                       config);
+  }
+};
+
+} // namespace

--- a/lib/TPP/Transforms/SplitReductionDim.cpp
+++ b/lib/TPP/Transforms/SplitReductionDim.cpp
@@ -5,6 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// This file implements serial reduction dimension splitting.
+//
+//===----------------------------------------------------------------------===//
 
 #include "TPP/Passes.h"
 #include "TPP/Transforms/Utils/TransformUtils.h"

--- a/test/Passes/split-reduction-dim.mlir
+++ b/test/Passes/split-reduction-dim.mlir
@@ -6,9 +6,6 @@ func.func @tile_matmul_memref(%A: memref<32x64xf32>, %B: memref<64x16xf32>,
   return
 }
 
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: @tile_matmul_memref(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<32x64xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<64x16xf32>
@@ -19,14 +16,9 @@ func.func @tile_matmul_memref(%A: memref<32x64xf32>, %B: memref<64x16xf32>,
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, 8] [1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [8, 16] [1, 1]
-// CHECK:   linalg.generic
-// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:   linalg.matmul
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
-// CHECK:      arith.mulf
-// CHECK:      arith.addf
-// CHECK:      linalg.yield
 
 // -----
 
@@ -37,9 +29,6 @@ func.func @tile_matmul_tensor(%A: tensor<32x64xf32>, %B: tensor<64x16xf32>,
   return %0 : tensor<32x16xf32>
 }
 
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: @tile_matmul_tensor(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: tensor<32x64xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: tensor<64x16xf32>
@@ -51,14 +40,9 @@ func.func @tile_matmul_tensor(%A: tensor<32x64xf32>, %B: tensor<64x16xf32>,
 // CHECK-SAME: iter_args(%[[ACC:.+]] = %[[C]])
 // CHECK:   %[[SLICE_A:.+]] = tensor.extract_slice %[[A]][0, %[[IV]]] [32, 8] [1, 1]
 // CHECK:   %[[SLICE_B:.+]] = tensor.extract_slice %[[B]][%[[IV]], 0] [8, 16] [1, 1]
-// CHECK:   %[[RES:.+]] = linalg.generic
-// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:   %[[RES:.+]] = linalg.matmul
 // CHECK-SAME: ins(%[[SLICE_A]], %[[SLICE_B]]
 // CHECK-SAME: outs(%[[ACC]]
-// CHECK:      arith.mulf
-// CHECK:      arith.addf
-// CHECK:      linalg.yield
 // CHECK:    scf.yield %[[RES]]
 
 // -----
@@ -81,7 +65,7 @@ func.func @tile_reduction_not_divisible(%A: memref<32x60xf32>, %B: memref<60x16x
 // CHECK:   %[[TILE_SIZE:.+]] = affine.min #[[TILE_MAP]](%[[IV]])
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, %[[TILE_SIZE]]] [1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [%[[TILE_SIZE]], 16] [1, 1]
-// CHECK:   linalg.generic
+// CHECK:   linalg.matmul
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
 
@@ -101,16 +85,17 @@ func.func @tile_dynamic_memref(%A: memref<?x?xf32>, %B: memref<?x?xf32>,
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
-// CHECK: %[[UB:.+]] = memref.dim %[[A]], %[[C1]]
+// CHECK-DAG: %[[UB:.+]] = memref.dim %[[A]], %[[C1]]
+// CHECK-DAG: %[[DIM_M:.+]] = memref.dim %[[A]], %[[C0]]
+// CHECK-DAG: %[[DIM_N:.+]] = memref.dim %[[B]], %[[C1]]
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[TILE_SIZE:.+]] = affine.min #[[TILE_MAP]](%[[IV]])[%[[UB]]]
-// CHECK:   %[[DIM_M:.+]] = memref.dim %[[A]], %[[C0]]
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [%[[DIM_M]], %[[TILE_SIZE]]] [1, 1]
-// CHECK:   %[[DIM_N:.+]] = memref.dim %[[B]], %[[C1]]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [%[[TILE_SIZE]], %[[DIM_N]]] [1, 1]
-// CHECK:   linalg.generic
+// CHECK:   %[[SUBVIEW_C:.+]] = memref.subview %[[C]][0, 0] [%[[DIM_M]], %[[DIM_N]]] [1, 1]
+// CHECK:   linalg.matmul
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
-// CHECK-SAME: outs(%[[C]]
+// CHECK-SAME: outs(%[[SUBVIEW_C]]
 
 // -----
 
@@ -129,18 +114,21 @@ func.func @tile_dynamic_tensor(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>,
 // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
-// CHECK: %[[UB:.+]] = tensor.dim %[[A]], %[[C1]]
+// CHECK-DAG: %[[UB:.+]] = tensor.dim %[[A]], %[[C1]]
+// CHECK-DAG: %[[DIM_M:.+]] = tensor.dim %[[A]], %[[C0]]
+// CHECK-DAG: %[[DIM_N:.+]] = tensor.dim %[[B]], %[[C1]]
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]]
 // CHECK-SAME: iter_args(%[[ACC:.+]] = %[[C]])
 // CHECK:   %[[TILE_SIZE:.+]] = affine.min #[[TILE_MAP]](%[[IV]])[%[[UB]]]
-// CHECK:   %[[DIM_M:.+]] = tensor.dim %[[A]], %[[C0]]
 // CHECK:   %[[SLICE_A:.+]] = tensor.extract_slice %[[A]][0, %[[IV]]] [%[[DIM_M]], %[[TILE_SIZE]]] [1, 1]
-// CHECK:   %[[DIM_N:.+]] = tensor.dim %[[B]], %[[C1]]
 // CHECK:   %[[SLICE_B:.+]] = tensor.extract_slice %[[B]][%[[IV]], 0] [%[[TILE_SIZE]], %[[DIM_N]]] [1, 1]
-// CHECK:   %[[RES:.+]] = linalg.generic
+// CHECK:   %[[SLICE_C:.+]] = tensor.extract_slice %[[ACC]][0, 0] [%[[DIM_M]], %[[DIM_N]]] [1, 1]
+// CHECK:   %[[RES:.+]] = linalg.matmul
 // CHECK-SAME: ins(%[[SLICE_A]], %[[SLICE_B]]
-// CHECK-SAME: outs(%[[ACC]]
-// CHECK:   scf.yield %[[RES]]
+// CHECK-SAME: outs(%[[SLICE_C]]
+// CHECK:   %[[UPDATE_C:.+]] = tensor.insert_slice %[[RES]]
+// CHECK-SAME: into %[[ACC]][0, 0] [%[[DIM_M]], %[[DIM_N]]] [1, 1]
+// CHECK:   scf.yield %[[UPDATE_C]]
 
 // -----
 
@@ -151,9 +139,6 @@ func.func @tile_batch_matmul(%A: memref<2x32x64xf32>, %B: memref<2x64x16xf32>,
   return
 }
 
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-LABEL: @tile_batch_matmul(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<2x32x64xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<2x64x16xf32>
@@ -164,9 +149,7 @@ func.func @tile_batch_matmul(%A: memref<2x32x64xf32>, %B: memref<2x64x16xf32>,
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, 0, %[[IV]]] [2, 32, 8] [1, 1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][0, %[[IV]], 0] [2, 8, 16] [1, 1, 1]
-// CHECK:   linalg.generic
-// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK:   linalg.batch_matmul
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
 
@@ -179,9 +162,6 @@ func.func @tile_batch_reduce_matmul(%A: memref<2x32x64xf32>, %B: memref<2x64x16x
   return
 }
 
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
 // CHECK-LABEL: @tile_batch_reduce_matmul(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<2x32x64xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<2x64x16xf32>
@@ -192,9 +172,7 @@ func.func @tile_batch_reduce_matmul(%A: memref<2x32x64xf32>, %B: memref<2x64x16x
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, 0, %[[IV]]] [2, 32, 8] [1, 1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][0, %[[IV]], 0] [2, 8, 16] [1, 1, 1]
-// CHECK:   linalg.generic
-// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME: iterator_types = ["reduction", "parallel", "parallel", "reduction"]
+// CHECK:   linalg.batch_reduce_matmul
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
 
@@ -207,9 +185,6 @@ func.func @tile_matmul_transpose_a(%A: memref<64x32xf32>, %B: memref<64x16xf32>,
   return
 }
 
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d2, d0)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: @tile_matmul_transpose_a(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<64x32xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<64x16xf32>
@@ -220,9 +195,7 @@ func.func @tile_matmul_transpose_a(%A: memref<64x32xf32>, %B: memref<64x16xf32>,
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][%[[IV]], 0] [8, 32] [1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [8, 16] [1, 1]
-// CHECK:   linalg.generic
-// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:   linalg.matmul_transpose_a
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
 
@@ -235,9 +208,6 @@ func.func @tile_matmul_transpose_b(%A: memref<32x64xf32>, %B: memref<16x64xf32>,
   return
 }
 
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-LABEL: @tile_matmul_transpose_b(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<32x64xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<16x64xf32>
@@ -248,9 +218,7 @@ func.func @tile_matmul_transpose_b(%A: memref<32x64xf32>, %B: memref<16x64xf32>,
 // CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, 8] [1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][0, %[[IV]]] [16, 8] [1, 1]
-// CHECK:   linalg.generic
-// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK:   linalg.matmul_transpose_b
 // CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
 

--- a/test/Passes/split-reduction-dim.mlir
+++ b/test/Passes/split-reduction-dim.mlir
@@ -1,0 +1,52 @@
+// RUN: tpp-opt %s -split-reduction-dim=tile=8 -split-input-file | FileCheck %s
+
+func.func @tile_matmul(%A: memref<32x64xf32>, %B: memref<64x16xf32>, %C: memref<32x16xf32>) {
+  linalg.matmul ins(%A, %B: memref<32x64xf32>, memref<64x16xf32>) outs(%C: memref<32x16xf32>)
+  return
+}
+
+// CHECK-LABEL: @tile_matmul(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<32x64xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<64x16xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<32x16xf32>
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] ={{.*}}step %[[K_TILE]]
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, 8] [1, 1]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [8, 16] [1, 1]
+// CHECK:   linalg.matmul ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]
+
+// -----
+
+func.func @no_tile_tensor(%A: tensor<32x64xf32>, %B: tensor<64x16xf32>, %C: tensor<32x16xf32>)
+    -> tensor<32x16xf32> {
+  %0 = linalg.matmul ins(%A, %B: tensor<32x64xf32>, tensor<64x16xf32>)
+    outs(%C: tensor<32x16xf32>) -> tensor<32x16xf32>
+  return %0 : tensor<32x16xf32>
+}
+
+// CHECK-LABEL: @no_tile_tensor
+// CHECK-NOT: scf.for
+// CHECK:   linalg.matmul
+
+// -----
+
+func.func @no_tile_reduction_not_divisible(%A: memref<32x60xf32>, %B: memref<60x16xf32>, %C: memref<32x16xf32>) {
+  linalg.matmul ins(%A, %B: memref<32x60xf32>, memref<60x16xf32>) outs(%C: memref<32x16xf32>)
+  return
+}
+
+// CHECK-LABEL: @no_tile_reduction_not_divisible
+// CHECK-NOT: scf.for
+// CHECK:   linalg.matmul
+
+// -----
+
+func.func @no_tile_dynamic(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
+  linalg.matmul ins(%A, %B: memref<?x?xf32>, memref<?x?xf32>) outs(%C: memref<?x?xf32>)
+  return
+}
+
+// CHECK-LABEL: @no_tile_dynamic
+// CHECK-NOT: scf.for
+// CHECK:   linalg.matmul

--- a/test/Passes/split-reduction-dim.mlir
+++ b/test/Passes/split-reduction-dim.mlir
@@ -1,52 +1,249 @@
-// RUN: tpp-opt %s -split-reduction-dim=tile=8 -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -split-reduction-dim=tile=8 -canonicalize -split-input-file | FileCheck %s
 
-func.func @tile_matmul(%A: memref<32x64xf32>, %B: memref<64x16xf32>, %C: memref<32x16xf32>) {
+func.func @tile_matmul_memref(%A: memref<32x64xf32>, %B: memref<64x16xf32>,
+    %C: memref<32x16xf32>) {
   linalg.matmul ins(%A, %B: memref<32x64xf32>, memref<64x16xf32>) outs(%C: memref<32x16xf32>)
   return
 }
 
-// CHECK-LABEL: @tile_matmul(
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-LABEL: @tile_matmul_memref(
 // CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<32x64xf32>
 // CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<64x16xf32>
 // CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 64 : index
 // CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
-// CHECK: scf.for %[[IV:.+]] ={{.*}}step %[[K_TILE]]
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
 // CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, 8] [1, 1]
 // CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [8, 16] [1, 1]
-// CHECK:   linalg.matmul ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK:   linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
 // CHECK-SAME: outs(%[[C]]
 
 // -----
 
-func.func @no_tile_tensor(%A: tensor<32x64xf32>, %B: tensor<64x16xf32>, %C: tensor<32x16xf32>)
-    -> tensor<32x16xf32> {
+func.func @tile_matmul_tensor(%A: tensor<32x64xf32>, %B: tensor<64x16xf32>,
+    %C: tensor<32x16xf32>) -> tensor<32x16xf32> {
   %0 = linalg.matmul ins(%A, %B: tensor<32x64xf32>, tensor<64x16xf32>)
     outs(%C: tensor<32x16xf32>) -> tensor<32x16xf32>
   return %0 : tensor<32x16xf32>
 }
 
-// CHECK-LABEL: @no_tile_tensor
-// CHECK-NOT: scf.for
-// CHECK:   linalg.matmul
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-LABEL: @tile_matmul_tensor(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: tensor<32x64xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: tensor<64x16xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: tensor<32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]]
+// CHECK-SAME: iter_args(%[[ACC:.+]] = %[[C]])
+// CHECK:   %[[SLICE_A:.+]] = tensor.extract_slice %[[A]][0, %[[IV]]] [32, 8] [1, 1]
+// CHECK:   %[[SLICE_B:.+]] = tensor.extract_slice %[[B]][%[[IV]], 0] [8, 16] [1, 1]
+// CHECK:   %[[RES:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SLICE_A]], %[[SLICE_B]]
+// CHECK-SAME: outs(%[[ACC]]
+// CHECK:    scf.yield %[[RES]]
 
 // -----
 
-func.func @no_tile_reduction_not_divisible(%A: memref<32x60xf32>, %B: memref<60x16xf32>, %C: memref<32x16xf32>) {
+func.func @tile_reduction_not_divisible(%A: memref<32x60xf32>, %B: memref<60x16xf32>,
+    %C: memref<32x16xf32>) {
   linalg.matmul ins(%A, %B: memref<32x60xf32>, memref<60x16xf32>) outs(%C: memref<32x16xf32>)
   return
 }
 
-// CHECK-LABEL: @no_tile_reduction_not_divisible
-// CHECK-NOT: scf.for
-// CHECK:   linalg.matmul
+// CHECK-DAG: #[[TILE_MAP:.+]] = affine_map<(d0) -> (-d0 + 60, 8)>
+// CHECK-LABEL: @tile_reduction_not_divisible(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<32x60xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<60x16xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 60 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
+// CHECK:   %[[TILE_SIZE:.+]] = affine.min #[[TILE_MAP]](%[[IV]])
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, %[[TILE_SIZE]]] [1, 1]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [%[[TILE_SIZE]], 16] [1, 1]
+// CHECK:   linalg.generic
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]
 
 // -----
 
-func.func @no_tile_dynamic(%A: memref<?x?xf32>, %B: memref<?x?xf32>, %C: memref<?x?xf32>) {
+func.func @tile_dynamic_memref(%A: memref<?x?xf32>, %B: memref<?x?xf32>,
+    %C: memref<?x?xf32>) {
   linalg.matmul ins(%A, %B: memref<?x?xf32>, memref<?x?xf32>) outs(%C: memref<?x?xf32>)
   return
 }
 
-// CHECK-LABEL: @no_tile_dynamic
-// CHECK-NOT: scf.for
-// CHECK:   linalg.matmul
+// CHECK-DAG: #[[TILE_MAP:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 8)>
+// CHECK-LABEL: @tile_dynamic_memref(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<?x?xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<?x?xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<?x?xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: %[[UB:.+]] = memref.dim %[[A]], %[[C1]]
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
+// CHECK:   %[[TILE_SIZE:.+]] = affine.min #[[TILE_MAP]](%[[IV]])[%[[UB]]]
+// CHECK:   %[[DIM_M:.+]] = memref.dim %[[A]], %[[C0]]
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [%[[DIM_M]], %[[TILE_SIZE]]] [1, 1]
+// CHECK:   %[[DIM_N:.+]] = memref.dim %[[B]], %[[C1]]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [%[[TILE_SIZE]], %[[DIM_N]]] [1, 1]
+// CHECK:   linalg.generic
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]
+
+// -----
+
+func.func @tile_dynamic_tensor(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>,
+    %C: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.matmul ins(%A, %B: tensor<?x?xf32>, tensor<?x?xf32>)
+    outs(%C: tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// CHECK-DAG: #[[TILE_MAP:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 8)>
+// CHECK-LABEL: @tile_dynamic_tensor(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: tensor<?x?xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: tensor<?x?xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: tensor<?x?xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: %[[UB:.+]] = tensor.dim %[[A]], %[[C1]]
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]]
+// CHECK-SAME: iter_args(%[[ACC:.+]] = %[[C]])
+// CHECK:   %[[TILE_SIZE:.+]] = affine.min #[[TILE_MAP]](%[[IV]])[%[[UB]]]
+// CHECK:   %[[DIM_M:.+]] = tensor.dim %[[A]], %[[C0]]
+// CHECK:   %[[SLICE_A:.+]] = tensor.extract_slice %[[A]][0, %[[IV]]] [%[[DIM_M]], %[[TILE_SIZE]]] [1, 1]
+// CHECK:   %[[DIM_N:.+]] = tensor.dim %[[B]], %[[C1]]
+// CHECK:   %[[SLICE_B:.+]] = tensor.extract_slice %[[B]][%[[IV]], 0] [%[[TILE_SIZE]], %[[DIM_N]]] [1, 1]
+// CHECK:   %[[RES:.+]] = linalg.generic
+// CHECK-SAME: ins(%[[SLICE_A]], %[[SLICE_B]]
+// CHECK-SAME: outs(%[[ACC]]
+// CHECK:   scf.yield %[[RES]]
+
+// -----
+
+func.func @tile_batch_matmul(%A: memref<2x32x64xf32>, %B: memref<2x64x16xf32>,
+    %C: memref<2x32x16xf32>) {
+  linalg.batch_matmul ins(%A, %B: memref<2x32x64xf32>, memref<2x64x16xf32>)
+    outs(%C: memref<2x32x16xf32>)
+  return
+}
+
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-LABEL: @tile_batch_matmul(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<2x32x64xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<2x64x16xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<2x32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, 0, %[[IV]]] [2, 32, 8] [1, 1, 1]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][0, %[[IV]], 0] [2, 8, 16] [1, 1, 1]
+// CHECK:   linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]
+
+// -----
+
+func.func @tile_batch_reduce_matmul(%A: memref<2x32x64xf32>, %B: memref<2x64x16xf32>,
+    %C: memref<32x16xf32>) {
+  linalg.batch_reduce_matmul ins(%A, %B: memref<2x32x64xf32>, memref<2x64x16xf32>)
+    outs(%C: memref<32x16xf32>)
+  return
+}
+
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// CHECK-LABEL: @tile_batch_reduce_matmul(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<2x32x64xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<2x64x16xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, 0, %[[IV]]] [2, 32, 8] [1, 1, 1]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][0, %[[IV]], 0] [2, 8, 16] [1, 1, 1]
+// CHECK:   linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["reduction", "parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]
+
+// -----
+
+func.func @tile_matmul_transpose_a(%A: memref<64x32xf32>, %B: memref<64x16xf32>,
+    %C: memref<32x16xf32>) {
+  linalg.matmul_transpose_a ins(%A, %B: memref<64x32xf32>, memref<64x16xf32>)
+    outs(%C: memref<32x16xf32>)
+  return
+}
+
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d2, d0)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-LABEL: @tile_matmul_transpose_a(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<64x32xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<64x16xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][%[[IV]], 0] [8, 32] [1, 1]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][%[[IV]], 0] [8, 16] [1, 1]
+// CHECK:   linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]
+
+// -----
+
+func.func @tile_matmul_transpose_b(%A: memref<32x64xf32>, %B: memref<16x64xf32>,
+    %C: memref<32x16xf32>) {
+  linalg.matmul_transpose_b ins(%A, %B: memref<32x64xf32>, memref<16x64xf32>)
+    outs(%C: memref<32x16xf32>)
+  return
+}
+
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-LABEL: @tile_matmul_transpose_b(
+// CHECK-SAME:  %[[A:[0-9a-z]+]]: memref<32x64xf32>
+// CHECK-SAME:  %[[B:[0-9a-z]+]]: memref<16x64xf32>
+// CHECK-SAME:  %[[C:[0-9a-z]+]]: memref<32x16xf32>
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[UB:.+]] = arith.constant 64 : index
+// CHECK-DAG: %[[K_TILE:.+]] = arith.constant 8 : index
+// CHECK: scf.for %[[IV:.+]] = %[[C0]] to %[[UB]] step %[[K_TILE]] {
+// CHECK:   %[[SUBVIEW_A:.+]] = memref.subview %[[A]][0, %[[IV]]] [32, 8] [1, 1]
+// CHECK:   %[[SUBVIEW_B:.+]] = memref.subview %[[B]][0, %[[IV]]] [16, 8] [1, 1]
+// CHECK:   linalg.generic
+// CHECK-SAME: indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[SUBVIEW_A]], %[[SUBVIEW_B]]
+// CHECK-SAME: outs(%[[C]]


### PR DESCRIPTION
Adds a pass to allow tiling contraction's innermost reduction dimension using serial loop with in-place accumulation.

Compared to other available transformations, this rewrite computes reduction sequentially with in-place accumulation which avoids temporary allocation and separate reduction operation. This tiling strategy is more friendly in terms of register and memory pressure more suitable for low-level GPU kernel generation. Similarly, restriction to the innermost dimension is there to simplify both usage and pass logic as the rewrite is geared toward progressive GEMM lowering.

Additionally, a GPU vectorization control flag is added to allow grouping of passes which target lowering through vector operations and might not be compatible with other existing lowering strategies.
Effectively, this pass perform separate K-dim split which is currently baked into linalg-to-xegpu lowering, and the two are not fully compatible.