### PR TITLE
Lower vector.contract to chain of vector.fma for matrix multiply.

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -62,6 +62,15 @@ def VectorContractToOuterproduct : Pass<
                            "vector::VectorDialect"];
 }
 
+def VectorContractToFMA : Pass<
+    "vector-contract-to-fma"> {
+  let summary = "Perform vector fma lowering of vector contraction ops";
+  let dependentDialects = ["memref::MemRefDialect",
+                           "scf::SCFDialect",
+                           "tensor::TensorDialect",
+                           "vector::VectorDialect",
+                           "arith::ArithDialect"];
+}
 
 def ConvertXsmmToFunc : Pass<"convert-xsmm-to-func", "ModuleOp"> {
   let summary = "Convert xsmm to func";

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ add_mlir_library(TPPTransforms
   Vectorization.cpp
   SplitReductionDim.cpp
   VectorContractToOuterproduct.cpp
+  VectorContractToFMA.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/Transforms/VectorContractToFMA.cpp
+++ b/lib/TPP/Transforms/VectorContractToFMA.cpp
@@ -1,0 +1,387 @@
+//===--------------- VectorContractToFMA.cpp ------------*- C++-*-===//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements lowering of vector contraction to vector fma.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "vector-contract-to-fma"
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_VECTORCONTRACTTOFMA
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace {
+/// Returns true if the \p map is transposed.
+static bool isTransposed(AffineMap map) {
+  auto results = map.getResults();
+  // Assert if the map does not have 3 inputs (m, n, k).
+  assert(map.getNumInputs() > 2 && "Al least 3 input dim expected");
+  // Assert if the result is not 2D.
+  assert(map.getNumResults() == 2 && "Only 2 output dim expected");
+
+  // Check the last two dimensions for transposition.
+  auto dimExpr0 = dyn_cast<AffineDimExpr>(results[0]);
+  auto dimExpr1 = dyn_cast<AffineDimExpr>(results[1]);
+  assert((dimExpr0 && dimExpr1) && "Unexpected dim expression");
+
+  // Exclude output map result.
+  bool isOutputResultMap =
+      dimExpr0 == mlir::getAffineDimExpr(0, map.getContext()) &&
+      dimExpr1 == mlir::getAffineDimExpr(1, map.getContext());
+  assert(!isOutputResultMap && "Output result map not expected");
+
+  // It's transposed if result found as (k, m) or (n, k), else not transposed.
+  if ((dimExpr0 == mlir::getAffineDimExpr(2, map.getContext()) &&
+       dimExpr1 == mlir::getAffineDimExpr(0, map.getContext())) ||
+      (dimExpr0 == mlir::getAffineDimExpr(1, map.getContext()) &&
+       dimExpr1 == mlir::getAffineDimExpr(2, map.getContext())))
+    return true;
+  return false;
+}
+} // namespace
+
+namespace mlir {
+namespace tpp {
+
+// Structure to hold transformation context
+struct TransformationContext {
+  scf::ForOp innerForOp;
+  scf::ForOp outerForOp;
+  scf::ForOp outermostLoop;
+};
+
+enum class MatMulType { Standard, Batch, BatchReduce };
+
+struct VectorContractToFMA
+    : public tpp::impl::VectorContractToFMABase<VectorContractToFMA> {
+
+  using VectorContractToFMABase::VectorContractToFMABase;
+
+  void runOnOperation() override;
+
+private:
+  TransformationContext ctx;
+};
+
+struct VectorContractToFMAPattern
+    : public OpRewritePattern<vector::ContractionOp> {
+  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
+  VectorContractToFMAPattern(MLIRContext *context, TransformationContext &ctx)
+      : OpRewritePattern<vector::ContractionOp>(context), ctx(ctx) {}
+
+  LogicalResult matchAndRewrite(vector::ContractionOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getKind() != vector::CombiningKind::ADD)
+      return rewriter.notifyMatchFailure(
+          op, "Unsupported combining kind, only supports ADD at the moment)");
+
+    auto maskableOp = cast<vector::MaskableOpInterface>(op.getOperation());
+    if (maskableOp.isMasked())
+      return rewriter.notifyMatchFailure(op, "Masked contractOp not supported");
+
+    SmallVector<AffineMap, 3> maps = op.getIndexingMapsArray();
+    if (llvm::any_of(
+            maps, [](AffineMap map) { return !map.isProjectedPermutation(); }))
+      return rewriter.notifyMatchFailure(op, "Unexpected map");
+
+    // Check for the variant of matrix multiply.
+    auto iteratorTypes = op.getIteratorTypesArray();
+    MatMulType matmulType;
+    unsigned outerDimIndex = 0;
+    if (iteratorTypes.size() > 3) {
+      outerDimIndex = iteratorTypes.size() - 4;
+      matmulType =
+          iteratorTypes[outerDimIndex] == vector::IteratorType::parallel
+              ? MatMulType::Batch
+              : MatMulType::BatchReduce;
+      outerDimIndex++;
+    } else if (iteratorTypes.size() == 3) {
+      matmulType = MatMulType::Standard;
+    } else {
+      return rewriter.notifyMatchFailure(op, "Not a gemm");
+    }
+
+    if (matmulType == MatMulType::Batch)
+      return rewriter.notifyMatchFailure(op, "Batch matmul not supported");
+    if (iteratorTypes[outerDimIndex] != vector::IteratorType::parallel ||
+        iteratorTypes[outerDimIndex + 1] != vector::IteratorType::parallel ||
+        iteratorTypes[outerDimIndex + 2] != vector::IteratorType::reduction)
+      return rewriter.notifyMatchFailure(op, "Not a gemm");
+
+    SmallVector<Value, 4> results;
+
+    auto lhs = op.getLhs();
+    auto rhs = op.getRhs();
+    auto acc = op.getAcc();
+    auto lhsDefiningOp = lhs.getDefiningOp<vector::TransferReadOp>();
+    auto rhsDefiningOp = rhs.getDefiningOp<vector::TransferReadOp>();
+    auto accDefiningOp = acc.getDefiningOp<vector::TransferReadOp>();
+    if (!lhsDefiningOp || !rhsDefiningOp)
+      return failure();
+
+    // Accumulator can be a TransferReadOp but must be coming from the chain of
+    // iterargs of nested loop.
+    if (accDefiningOp)
+      return failure();
+
+    // Make sure the inputs being read are whole tensor or subview.
+    if (!llvm::all_of(lhsDefiningOp.getIndices(), isZeroIndex) ||
+        !llvm::all_of(rhsDefiningOp.getIndices(), isZeroIndex)) {
+      return failure();
+    }
+
+    auto lhsType = cast<ShapedType>(lhsDefiningOp.getType());
+    auto rhsType = cast<ShapedType>(rhsDefiningOp.getType());
+    // auto accType = acc.getType();
+    //  auto accType = cast<ShapedType>(accDefiningOp.getType());
+
+    if (matmulType == MatMulType::BatchReduce &&
+        (lhsType.getRank() != 3 || rhsType.getRank() != 3))
+      return failure();
+
+    if (matmulType == MatMulType::Standard &&
+        (lhsType.getRank() != 2 || rhsType.getRank() != 2))
+      return failure();
+
+    // Check for non-transposed matrices.
+    auto mapLHS = maps[0];
+    auto mapRHS = maps[1];
+    if (matmulType == MatMulType::BatchReduce) {
+      mapLHS = mapLHS.dropResult(outerDimIndex);
+      mapRHS = mapRHS.dropResult(outerDimIndex);
+    }
+    if (isTransposed(mapLHS) || isTransposed(mapRHS))
+      return rewriter.notifyMatchFailure(
+          op, "Transposed matrices are not expected");
+
+    // Verify that the accumulator is coming through a chain of iterargs of
+    // nested loop and it is define by 'TransferReadOp'.
+    ctx.innerForOp = op->getParentOfType<scf::ForOp>();
+    if (!ctx.innerForOp)
+      return failure();
+    ctx.outerForOp = ctx.innerForOp->getParentOfType<scf::ForOp>();
+    if (!ctx.outerForOp)
+      return failure();
+    ctx.outermostLoop = ctx.outerForOp->getParentOfType<scf::ForOp>();
+    if (!ctx.outermostLoop)
+      return failure();
+
+    // Verify original inner loop has only one iterarg.
+    auto origIterArgs = ctx.innerForOp.getRegionIterArgs();
+    if (origIterArgs.size() != 1)
+      return failure();
+
+    // Verify chain, accumulator must be inner loop's iterarg.
+    auto bbArg = dyn_cast<BlockArgument>(acc);
+    if (!bbArg)
+      return failure();
+
+    // This block arg must be init arg, not induction variable.
+    if (bbArg.getOwner() != ctx.innerForOp.getBody() ||
+        bbArg.getArgNumber() == 0) {
+      return failure();
+    }
+
+    // This iterarg must be intialized by outer loop's iterarg.
+    auto innerInitValue =
+        ctx.innerForOp.getInitArgs()[bbArg.getArgNumber() - 1];
+    auto outerBBArg = dyn_cast<BlockArgument>(innerInitValue);
+    if (!outerBBArg)
+      return failure();
+
+    // This block arg must be init arg, not induction variable.
+    if (outerBBArg.getOwner() != ctx.outerForOp.getBody() ||
+        outerBBArg.getArgNumber() == 0) {
+      return failure();
+    }
+
+    // Outer loop's iterarg initializer must be a TransferReadOp.
+    acc = ctx.outerForOp.getInitArgs()[outerBBArg.getArgNumber() - 1];
+
+    //  This must be defined by vector.transfer_read
+    if (!acc.getDefiningOp<vector::TransferReadOp>())
+      return failure();
+
+    accDefiningOp = acc.getDefiningOp<vector::TransferReadOp>();
+    if (!accDefiningOp)
+      return failure();
+
+    // Only 2-D output expected.
+    auto accType = cast<ShapedType>(accDefiningOp.getType());
+    if (accType.getRank() != 2)
+      return failure();
+
+    int64_t M = accType.getDimSize(0);
+    int64_t N = accType.getDimSize(1);
+    int64_t K = lhsType.getDimSize(lhsType.getRank() - 1);
+
+    // K must be 1.
+    if (K != 1)
+      return failure();
+
+    auto accSubview = accDefiningOp.getSource();
+    Location loc = op.getLoc();
+
+    // Create M different <1xN> subviews.
+    auto memrefType = cast<MemRefType>(accSubview.getType());
+    auto elementType = memrefType.getElementType();
+    SmallVector<OpFoldResult> mixedSizes = {rewriter.getIndexAttr(K),
+                                            rewriter.getIndexAttr(N)};
+    SmallVector<OpFoldResult> mixedStrides = {rewriter.getIndexAttr(1),
+                                              rewriter.getIndexAttr(1)};
+
+    rewriter.setInsertionPoint(
+        ctx.outermostLoop.getBody(),
+        std::prev(ctx.outermostLoop.getBody()->end(), 1));
+
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    SmallVector<Value, 4> subview_2_splits;
+    for (int i = 0; i < M; i++) {
+      SmallVector<OpFoldResult> mixedOffsets = {
+          rewriter.getIndexAttr(i),
+          rewriter.getIndexAttr(0),
+      };
+      auto split = rewriter.create<memref::SubViewOp>(
+          loc, accSubview, mixedOffsets, mixedSizes, mixedStrides);
+      subview_2_splits.push_back(split);
+    }
+
+    // Intialize each accumulator with a vector of size N
+    SmallVector<Value, 4> initAccs;
+    for (auto subview : subview_2_splits) {
+      auto acc = rewriter.create<vector::LoadOp>(
+          loc, VectorType::get({N}, elementType), subview, ValueRange{c0, c0});
+      initAccs.push_back(acc);
+    }
+
+    // Create new outer loop with M different accumulators.
+    auto newOuterForOp = rewriter.create<scf::ForOp>(
+        loc, ctx.outerForOp.getLowerBound(), ctx.outerForOp.getUpperBound(),
+        ctx.outerForOp.getStep(), initAccs,
+        [&](OpBuilder &nestedBuilder, Location loc, Value iv,
+            ValueRange iterArgs) {
+          // Create new inner loop with M accumulators.
+          auto newInnerForOp = nestedBuilder.create<scf::ForOp>(
+              loc, ctx.innerForOp.getLowerBound(),
+              ctx.innerForOp.getUpperBound(), ctx.innerForOp.getStep(),
+              iterArgs,
+              [&](OpBuilder &innerBuilder, Location loc, Value innerIv,
+                  ValueRange innerIterArgs) {
+                IRMapping mapping;
+                mapping.map(
+                    lhsDefiningOp.getSource().getDefiningOp()->getOperand(1),
+                    iv);
+                mapping.map(
+                    lhsDefiningOp.getSource().getDefiningOp()->getOperand(3),
+                    innerIv);
+                auto lhsClone = innerBuilder.clone(
+                    *lhsDefiningOp.getSource().getDefiningOp(), mapping);
+
+                // Load and broadcast individual elements
+                SmallVector<Value, 4> broadcasts;
+                for (int i = 0; i < M; i++) {
+                  auto elem = innerBuilder.create<memref::LoadOp>(
+                      loc, lhsClone->getResult(0),
+                      ValueRange{
+                          c0,
+                          innerBuilder.create<arith::ConstantIndexOp>(loc, i),
+                          c0});
+                  auto bcast = innerBuilder.create<vector::BroadcastOp>(
+                      loc, VectorType::get({N}, elem.getType()), elem);
+                  broadcasts.push_back(bcast);
+                }
+
+                IRMapping rhsMapping;
+                rhsMapping.map(
+                    rhsDefiningOp.getSource().getDefiningOp()->getOperand(1),
+                    iv);
+                rhsMapping.map(
+                    rhsDefiningOp.getSource().getDefiningOp()->getOperand(2),
+                    innerIv);
+                auto rhsClone = innerBuilder.clone(
+                    *rhsDefiningOp.getSource().getDefiningOp(), rhsMapping);
+                auto rowVec = innerBuilder.create<vector::LoadOp>(
+                    loc, VectorType::get({N}, elementType),
+                    rhsClone->getResult(0), ValueRange{c0, c0, c0});
+
+                // Create M different FMAs using broadcasts and current
+                // accumulator values.
+                for (int i = 0; i < M; i++) {
+                  auto fma = innerBuilder.create<vector::FMAOp>(
+                      loc, broadcasts[i], rowVec, innerIterArgs[i]);
+                  results.push_back(fma);
+                }
+
+                // Yield all M results
+                innerBuilder.create<scf::YieldOp>(loc, results);
+              });
+
+          // Yield results from inner loop to outer loop
+          nestedBuilder.create<scf::YieldOp>(loc, newInnerForOp.getResults());
+        });
+
+    Value matResult = ctx.outerForOp.getResult(0);
+    Operation *writeOp;
+    for (auto user : matResult.getUsers()) {
+      writeOp = dyn_cast<vector::TransferWriteOp>(user);
+      if (writeOp)
+        break;
+    }
+
+    // Store final results back to original locations.
+    if (writeOp) {
+      for (int i = 0; i < M; i++) {
+        rewriter.create<vector::StoreOp>(loc, newOuterForOp.getResult(i),
+                                         subview_2_splits[i],
+                                         ValueRange{c0, c0});
+      }
+    }
+
+    // Erase original write.
+    if (writeOp)
+      rewriter.eraseOp(writeOp);
+
+    return success();
+  }
+
+private:
+  TransformationContext &ctx;
+};
+
+void VectorContractToFMA::runOnOperation() {
+  auto funcOp = getOperation();
+  MLIRContext *context = &getContext();
+
+  RewritePatternSet patterns(context);
+  patterns.add<VectorContractToFMAPattern>(context, ctx);
+
+  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    signalPassFailure();
+  }
+}
+
+} // namespace tpp
+} // namespace mlir
+
+std::unique_ptr<Pass> createVectorContractToFMA() {
+  return std::make_unique<VectorContractToFMA>();
+}

--- a/test/Integration/vector-contract-to-fma.mlir
+++ b/test/Integration/vector-contract-to-fma.mlir
@@ -1,6 +1,7 @@
 // RUN: tpp-opt %s  | tpp-run -e entry --entry-point-result=void -seed 123 -print > %t.1
 // RUN: tpp-opt %s  --vector-contract-to-fma  | tpp-run -e entry --entry-point-result=void -seed 123 -print > %t.2
-// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF --allow-empty
+// RUN: diff %t.1 %t.2
+// RUN: rm %t.1 %t.2
 
 // DIFF-NOT: {{.}}
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>

--- a/test/Integration/vector-contract-to-fma.mlir
+++ b/test/Integration/vector-contract-to-fma.mlir
@@ -1,0 +1,49 @@
+// RUN: tpp-opt %s  | tpp-run -e entry --entry-point-result=void -seed 123 -print > %t.1
+// RUN: tpp-opt %s  --vector-contract-to-fma  | tpp-run -e entry --entry-point-result=void -seed 123 -print > %t.2
+// RUN: diff %t.1 %t.2 | FileCheck %s --check-prefix=DIFF --allow-empty
+
+// DIFF-NOT: {{.}}
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+module {
+  func.func @entry(%arg0: memref<8x16x32x64xf32>, %arg1: memref<16x16x64x64xf32>, %arg2: memref<8x16x32x64xf32>) -> memref<8x16x32x64xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    scf.forall (%arg3, %arg4) in (8, 16) {
+      %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 16, 32, 64] [1, 1, 1, 1] : memref<8x16x32x64xf32> to memref<16x32x64xf32, strided<[2048, 64, 1], offset: ?>>
+      %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<16x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+      %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 64] [1, 1, 1, 1] : memref<8x16x32x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>
+      scf.for %arg5 = %c0 to %c32 step %c4 {
+        
+        scf.for %arg6 = %c0 to %c64 step %c64 {
+          %subview_2 = memref.subview %subview_1[%arg5, %arg6] [4, 64] [1, 1] : memref<32x64xf32, strided<[64, 1], offset: ?>> to memref<4x64xf32, strided<[64, 1], offset: ?>>
+          %2 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x64xf32, strided<[64, 1], offset: ?>>, vector<4x64xf32>
+
+          %con = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%argcon = %2) -> vector<4x64xf32> {
+
+            %con1 = scf.for %arg8 = %c0 to %c64 step %c1 iter_args(%argcon1 = %argcon) -> vector<4x64xf32> {
+              %subview_3 = memref.subview %subview[%arg7, %arg5, %arg8] [1, 4, 1] [1, 1, 1] : memref<16x32x64xf32, strided<[2048, 64, 1], offset: ?>> to memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+              %subview_4 = memref.subview %subview_0[%arg7, %arg8, %arg6] [1, 1, 64] [1, 1, 1] : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>> to memref<1x1x64xf32, strided<[4096, 64, 1], offset: ?>>
+              %0 = vector.transfer_read %subview_3[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>, vector<1x4x1xf32>
+              %1 = vector.transfer_read %subview_4[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x1x64xf32, strided<[4096, 64, 1], offset: ?>>, vector<1x1x64xf32>       
+              %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %argcon1 : vector<1x4x1xf32>, vector<1x1x64xf32> into vector<4x64xf32>
+			  scf.yield %3 : vector<4x64xf32>
+            }
+			scf.yield %con1 : vector<4x64xf32>
+          }
+          vector.transfer_write %con, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, memref<4x64xf32, strided<[64, 1], offset: ?>>
+          
+        }
+      }
+    }
+    return %arg2 : memref<8x16x32x64xf32>
+  }
+}
+
+// -----

--- a/test/Passes/pass-vector-contract-to-fma.mlir
+++ b/test/Passes/pass-vector-contract-to-fma.mlir
@@ -120,3 +120,43 @@ module {
 }
 
 // CHECK-NOT: vector.fma
+
+//-----
+
+#mapTransposeB = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+
+module {
+  func.func @entry(%arg0: memref<16x32x128xf32>, %arg1: memref<16x128x64xf32>, %arg2: memref<32x64xf32>) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+
+    scf.for %arg5 = %c0 to %c32 step %c4 {
+      scf.for %arg6 = %c0 to %c128 step %c64 {
+        %subview_2 = memref.subview %arg2[%arg5, %arg6] [4, 64] [1, 1] : memref<32x64xf32> to memref<4x64xf32, strided<[64, 1], offset: ?>>
+        %2 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x64xf32, strided<[64, 1], offset: ?>>, vector<4x64xf32>
+        %con = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%argcon = %2) -> vector<4x64xf32> {
+          %con1 = scf.for %arg8 = %c0 to %c64 step %c1 iter_args(%argcon1 = %argcon) -> vector<4x64xf32> {
+            %subview_3 = memref.subview %arg0[%arg7, %arg5, %arg8] [1, 4, 1] [1, 1, 1] : memref<16x32x128xf32> to memref<1x4x1xf32, strided<[4096, 128, 1], offset: ?>>
+            %subview_4 = memref.subview %arg1[%arg7, %arg8, %arg6] [1, 1, 64] [1, 1, 1] : memref<16x128x64xf32> to memref<1x1x64xf32, strided<[8192, 64, 1], offset: ?>>
+            %0 = vector.transfer_read %subview_3[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x1xf32, strided<[4096, 128, 1], offset: ?>>, vector<1x4x1xf32>
+            %1 = vector.transfer_read %subview_4[%c0, %c0, %c0], %cst {permutation_map = affine_map<(d0, d1, d2) -> (d0, d2, d1)>, in_bounds = [true, true, true]} : memref<1x1x64xf32, strided<[8192, 64, 1], offset: ?>>, vector<1x64x1xf32>
+            %3 = vector.contract {indexing_maps = [#map, #mapTransposeB, #map2], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %argcon1 : vector<1x4x1xf32>, vector<1x64x1xf32> into vector<4x64xf32>
+            scf.yield %3 : vector<4x64xf32>
+          }
+          scf.yield %con1 : vector<4x64xf32>
+        }
+        vector.transfer_write %con, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, memref<4x64xf32, strided<[64, 1], offset: ?>>
+      }
+    }
+    return
+  }
+}
+
+// CHECK-NOT: vector.fma
+

--- a/test/Passes/pass-vector-contract-to-fma.mlir
+++ b/test/Passes/pass-vector-contract-to-fma.mlir
@@ -1,0 +1,122 @@
+// RUN: tpp-opt %s  --vector-contract-to-fma --split-input-file | FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+module {
+  func.func @entry(%arg0: memref<8x16x32x64xf32>, %arg1: memref<16x16x64x64xf32>, %arg2: memref<8x16x32x64xf32>) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    scf.forall (%arg3, %arg4) in (8, 16) {
+      %subview = memref.subview %arg0[%arg3, 0, 0, 0] [1, 16, 32, 64] [1, 1, 1, 1] : memref<8x16x32x64xf32> to memref<16x32x64xf32, strided<[2048, 64, 1], offset: ?>>
+      %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<16x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+      %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 32, 64] [1, 1, 1, 1] : memref<8x16x32x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>
+      scf.for %arg5 = %c0 to %c32 step %c4 {
+        
+        scf.for %arg6 = %c0 to %c64 step %c64 {
+          %subview_2 = memref.subview %subview_1[%arg5, %arg6] [4, 64] [1, 1] : memref<32x64xf32, strided<[64, 1], offset: ?>> to memref<4x64xf32, strided<[64, 1], offset: ?>>
+          %2 = vector.transfer_read %subview_2[%c0, %c0], %cst {in_bounds = [true, true]} : memref<4x64xf32, strided<[64, 1], offset: ?>>, vector<4x64xf32>
+
+          %con = scf.for %arg7 = %c0 to %c16 step %c1 iter_args(%argcon = %2) -> vector<4x64xf32> {
+
+            %con1 = scf.for %arg8 = %c0 to %c64 step %c1 iter_args(%argcon1 = %argcon) -> vector<4x64xf32> {
+              %subview_3 = memref.subview %subview[%arg7, %arg5, %arg8] [1, 4, 1] [1, 1, 1] : memref<16x32x64xf32, strided<[2048, 64, 1], offset: ?>> to memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+              %subview_4 = memref.subview %subview_0[%arg7, %arg8, %arg6] [1, 1, 64] [1, 1, 1] : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>> to memref<1x1x64xf32, strided<[4096, 64, 1], offset: ?>>
+              %0 = vector.transfer_read %subview_3[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>, vector<1x4x1xf32>
+              %1 = vector.transfer_read %subview_4[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x1x64xf32, strided<[4096, 64, 1], offset: ?>>, vector<1x1x64xf32>       
+              %3 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %argcon1 : vector<1x4x1xf32>, vector<1x1x64xf32> into vector<4x64xf32>
+			  scf.yield %3 : vector<4x64xf32>
+            }
+			scf.yield %con1 : vector<4x64xf32>
+          }
+          vector.transfer_write %con, %subview_2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, memref<4x64xf32, strided<[64, 1], offset: ?>>
+        }
+      }
+    }
+    return
+  }
+}
+
+// CHECK-LABEL:   func.func @entry(
+// CHECK-SAME:                     %[[VAL_0:.*]]: memref<8x16x32x64xf32>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: memref<16x16x64x64xf32>,
+// CHECK-SAME:                     %[[VAL_2:.*]]: memref<8x16x32x64xf32>) {
+// CHECK:           %[[VAL_3:.*]] = arith.constant 3 : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 16 : index
+// CHECK:           %[[VAL_7:.*]] = arith.constant 64 : index
+// CHECK:           %[[VAL_8:.*]] = arith.constant 4 : index
+// CHECK:           %[[VAL_9:.*]] = arith.constant 32 : index
+// CHECK:           %[[VAL_10:.*]] = arith.constant 0 : index
+// CHECK:           scf.forall (%[[VAL_11:.*]], %[[VAL_12:.*]]) in (8, 16) {
+// CHECK:             %[[VAL_13:.*]] = memref.subview %[[VAL_0]]{{\[}}%[[VAL_11]], 0, 0, 0] [1, 16, 32, 64] [1, 1, 1, 1] : memref<8x16x32x64xf32> to memref<16x32x64xf32, strided<[2048, 64, 1], offset: ?>>
+// CHECK:             %[[VAL_14:.*]] = memref.subview %[[VAL_1]]{{\[}}%[[VAL_12]], 0, 0, 0] [1, 16, 64, 64] [1, 1, 1, 1] : memref<16x16x64x64xf32> to memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>>
+// CHECK:             %[[VAL_15:.*]] = memref.subview %[[VAL_2]]{{\[}}%[[VAL_11]], %[[VAL_12]], 0, 0] [1, 1, 32, 64] [1, 1, 1, 1] : memref<8x16x32x64xf32> to memref<32x64xf32, strided<[64, 1], offset: ?>>
+// CHECK:             scf.for %[[VAL_16:.*]] = %[[VAL_10]] to %[[VAL_9]] step %[[VAL_8]] {
+// CHECK:               scf.for %[[VAL_17:.*]] = %[[VAL_10]] to %[[VAL_7]] step %[[VAL_7]] {
+// CHECK:                 %[[VAL_18:.*]] = memref.subview %[[VAL_15]]{{\[}}%[[VAL_16]], %[[VAL_17]]] [4, 64] [1, 1] : memref<32x64xf32, strided<[64, 1], offset: ?>> to memref<4x64xf32, strided<[64, 1], offset: ?>>
+// CHECK:                 %[[VAL_19:.*]] = memref.subview %[[VAL_18]][0, 0] [1, 64] [1, 1] : memref<4x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+// CHECK:                 %[[VAL_20:.*]] = memref.subview %[[VAL_18]][1, 0] [1, 64] [1, 1] : memref<4x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+// CHECK:                 %[[VAL_21:.*]] = memref.subview %[[VAL_18]][2, 0] [1, 64] [1, 1] : memref<4x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+// CHECK:                 %[[VAL_22:.*]] = memref.subview %[[VAL_18]][3, 0] [1, 64] [1, 1] : memref<4x64xf32, strided<[64, 1], offset: ?>> to memref<1x64xf32, strided<[64, 1], offset: ?>>
+// CHECK:                 %[[VAL_23:.*]] = vector.load %[[VAL_19]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 %[[VAL_24:.*]] = vector.load %[[VAL_20]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 %[[VAL_25:.*]] = vector.load %[[VAL_21]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 %[[VAL_26:.*]] = vector.load %[[VAL_22]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 %[[VAL_27:.*]]:4 = scf.for %[[VAL_28:.*]] = %[[VAL_10]] to %[[VAL_6]] step %[[VAL_5]] iter_args(%[[VAL_29:.*]] = %[[VAL_23]], %[[VAL_30:.*]] = %[[VAL_24]], %[[VAL_31:.*]] = %[[VAL_25]], %[[VAL_32:.*]] = %[[VAL_26]]) -> (vector<64xf32>, vector<64xf32>, vector<64xf32>, vector<64xf32>) {
+// CHECK:                   %[[VAL_33:.*]]:4 = scf.for %[[VAL_34:.*]] = %[[VAL_10]] to %[[VAL_7]] step %[[VAL_5]] iter_args(%[[VAL_35:.*]] = %[[VAL_29]], %[[VAL_36:.*]] = %[[VAL_30]], %[[VAL_37:.*]] = %[[VAL_31]], %[[VAL_38:.*]] = %[[VAL_32]]) -> (vector<64xf32>, vector<64xf32>, vector<64xf32>, vector<64xf32>) {
+// CHECK:                     %[[VAL_39:.*]] = memref.subview %[[VAL_13]]{{\[}}%[[VAL_28]], %[[VAL_16]], %[[VAL_34]]] [1, 4, 1] [1, 1, 1] : memref<16x32x64xf32, strided<[2048, 64, 1], offset: ?>> to memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+// CHECK:                     %[[VAL_40:.*]] = memref.load %[[VAL_39]]{{\[}}%[[VAL_10]], %[[VAL_10]], %[[VAL_10]]] : memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+// CHECK:                     %[[VAL_41:.*]] = vector.broadcast %[[VAL_40]] : f32 to vector<64xf32>
+// CHECK:                     %[[VAL_42:.*]] = memref.load %[[VAL_39]]{{\[}}%[[VAL_10]], %[[VAL_5]], %[[VAL_10]]] : memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+// CHECK:                     %[[VAL_43:.*]] = vector.broadcast %[[VAL_42]] : f32 to vector<64xf32>
+// CHECK:                     %[[VAL_44:.*]] = memref.load %[[VAL_39]]{{\[}}%[[VAL_10]], %[[VAL_4]], %[[VAL_10]]] : memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+// CHECK:                     %[[VAL_45:.*]] = vector.broadcast %[[VAL_44]] : f32 to vector<64xf32>
+// CHECK:                     %[[VAL_46:.*]] = memref.load %[[VAL_39]]{{\[}}%[[VAL_10]], %[[VAL_3]], %[[VAL_10]]] : memref<1x4x1xf32, strided<[2048, 64, 1], offset: ?>>
+// CHECK:                     %[[VAL_47:.*]] = vector.broadcast %[[VAL_46]] : f32 to vector<64xf32>
+// CHECK:                     %[[VAL_48:.*]] = memref.subview %[[VAL_14]]{{\[}}%[[VAL_28]], %[[VAL_34]], %[[VAL_17]]] [1, 1, 64] [1, 1, 1] : memref<16x64x64xf32, strided<[4096, 64, 1], offset: ?>> to memref<1x1x64xf32, strided<[4096, 64, 1], offset: ?>>
+// CHECK:                     %[[VAL_49:.*]] = vector.load %[[VAL_48]]{{\[}}%[[VAL_10]], %[[VAL_10]], %[[VAL_10]]] : memref<1x1x64xf32, strided<[4096, 64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                     %[[VAL_50:.*]] = vector.fma %[[VAL_41]], %[[VAL_49]], %[[VAL_35]] : vector<64xf32>
+// CHECK:                     %[[VAL_51:.*]] = vector.fma %[[VAL_43]], %[[VAL_49]], %[[VAL_36]] : vector<64xf32>
+// CHECK:                     %[[VAL_52:.*]] = vector.fma %[[VAL_45]], %[[VAL_49]], %[[VAL_37]] : vector<64xf32>
+// CHECK:                     %[[VAL_53:.*]] = vector.fma %[[VAL_47]], %[[VAL_49]], %[[VAL_38]] : vector<64xf32>
+// CHECK:                     scf.yield %[[VAL_50]], %[[VAL_51]], %[[VAL_52]], %[[VAL_53]] : vector<64xf32>, vector<64xf32>, vector<64xf32>, vector<64xf32>
+// CHECK:                   }
+// CHECK:                   scf.yield %[[VAL_54:.*]]#0, %[[VAL_54]]#1, %[[VAL_54]]#2, %[[VAL_54]]#3 : vector<64xf32>, vector<64xf32>, vector<64xf32>, vector<64xf32>
+// CHECK:                 }
+// CHECK:                 vector.store %[[VAL_55:.*]]#0, %[[VAL_19]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 vector.store %[[VAL_55]]#1, %[[VAL_20]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 vector.store %[[VAL_55]]#2, %[[VAL_21]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:                 vector.store %[[VAL_55]]#3, %[[VAL_22]]{{\[}}%[[VAL_10]], %[[VAL_10]]] : memref<1x64xf32, strided<[64, 1], offset: ?>>, vector<64xf32>
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+//-----
+
+#mapA = affine_map<(d0, d1, d2) -> (d0, d2)>
+#mapB = affine_map<(d0, d1, d2) -> (d2, d1)>
+#mapC = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+module {
+  func.func @matmul_without_iterarg_accumulator(%arg0: tensor<4x1xf32>, %arg1: tensor<1x64xf32>, %arg2: tensor<4x64xf32>) -> tensor<4x64xf32> {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x1xf32>, vector<4x1xf32>
+    %1 = vector.transfer_read %arg1[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<1x64xf32>, vector<1x64xf32>
+    %2 = vector.transfer_read %arg2[%c0, %c0], %cst {in_bounds = [true, true]} : tensor<4x64xf32>, vector<4x64xf32>
+    %3 = vector.contract {indexing_maps = [#mapA, #mapB, #mapC], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %0, %1, %2 : vector<4x1xf32>, vector<1x64xf32> into vector<4x64xf32>
+    %4 = vector.transfer_write %3, %arg2[%c0, %c0] {in_bounds = [true, true]} : vector<4x64xf32>, tensor<4x64xf32>
+    return %4 : tensor<4x64xf32>
+  }
+}
+
+// CHECK-NOT: vector.fma


### PR DESCRIPTION
Implements the lowering of vector contraction op for GEMM of size MxN to sequence of vector FMAs wrapped inside scf.for loop with iterargs to accumulate the result of FMAs.The K dimension size is expected to be 1. The idea is to exploit the AVX-512 feature to generate optimal vector code.