### PR TITLE
Move `linalg-to-xsmm` before `linalg-to-vector` and add option to skip lowerings

### DIFF
--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -66,6 +66,10 @@ def LinalgLowering : Pass<"linalg-lowering", "func::FuncOp"> {
   let dependentDialects = ["xsmm::XsmmDialect",
                            "scf::SCFDialect",
                            "memref::MemRefDialect"];
+  let options = [
+    ListOption<"skipOperations", "skip-operations", "std::string",
+           "Operations to skip lowering linalg-to-xsmm directly.">
+  ];
 }
 
 def LowLevelParallelization : Pass<"low-level-parallel", "ModuleOp"> {

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -21,6 +21,10 @@ def ConvertLinalgToXsmm : Pass<"convert-linalg-to-xsmm", "func::FuncOp"> {
                            "linalg::LinalgDialect",
                            "xsmm::XsmmDialect",
                            "tensor::TensorDialect"];
+  let options = [
+    ListOption<"skipOperations", "skip-operations", "std::string",
+           "Operations to skip.">
+  ];
 }
 
 def VerifyXsmmCalls : Pass<"verify-xsmm-calls", "func::FuncOp"> {

--- a/include/TPP/Transforms/Transforms.h
+++ b/include/TPP/Transforms/Transforms.h
@@ -67,7 +67,7 @@ collapseIterators(RewriterBase &rewriter, linalg::GenericOp genericOp,
 } // namespace linalgx
 
 namespace tpp {
-void populateLinalgToXsmmPatterns(RewritePatternSet &patterns, ArrayRef<StringRef> skipOperations);
+void populateLinalgToXsmmPatterns(RewritePatternSet &patterns, ArrayRef<StringRef> skipPatterns);
 void populateSimplifyPacking(RewritePatternSet &patterns);
 void populateSinkPackPatterns(RewritePatternSet &patterns);
 } // namespace tpp

--- a/include/TPP/Transforms/Transforms.h
+++ b/include/TPP/Transforms/Transforms.h
@@ -67,7 +67,7 @@ collapseIterators(RewriterBase &rewriter, linalg::GenericOp genericOp,
 } // namespace linalgx
 
 namespace tpp {
-void populateLinalgToXsmmPatterns(RewritePatternSet &patterns);
+void populateLinalgToXsmmPatterns(RewritePatternSet &patterns, ArrayRef<StringRef> skipOperations);
 void populateSimplifyPacking(RewritePatternSet &patterns);
 void populateSinkPackPatterns(RewritePatternSet &patterns);
 } // namespace tpp

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -1159,12 +1159,14 @@ void mlir::tpp::populateLinalgToXsmmPatterns(
   // This is O(n^2), but the lists are small
   if (!skipPatterns.empty()) {
     assert(skipPatterns.size() <= 8);
-    std::remove_if(patternsToAdd.begin(), patternsToAdd.end(),
+    auto newEnd = std::remove_if(patternsToAdd.begin(), patternsToAdd.end(),
                    [&skipPatterns](StringRef elm) -> bool {
                      return std::find(skipPatterns.begin(),
                                       skipPatterns.end(),
                                       elm) != skipPatterns.end();
                    });
+    if (newEnd != patternsToAdd.end())
+      patternsToAdd.erase(newEnd, patternsToAdd.end());
   }
 
   // Now, add all the remaining patterns

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -111,12 +111,14 @@ private:
       // Lower Linalg to XSMM.
       pm.addNestedPass<func::FuncOp>(createLinalgLowering(linalgOptions));
 
-      // Vectorizes the remaining Linalg operations
-      pm.addNestedPass<func::FuncOp>(createVectorizationPass());
-      pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+      if (linalgToVector) {
+        // Vectorizes the remaining Linalg operations
+        pm.addNestedPass<func::FuncOp>(createVectorizationPass());
+        pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
-      // TODO: Add a flag for this pass so it doesn't conflate with other options.
-      pm.addNestedPass<func::FuncOp>(createVectorContractToOuterproduct());
+        // TODO: Add a flag for this pass so it doesn't conflate with other options.
+        pm.addNestedPass<func::FuncOp>(createVectorContractToOuterproduct());
+      }
 
       // Final cleanup.
       pm.addPass(createCleanup());

--- a/lib/TPP/PassBundles/LinalgLowering.cpp
+++ b/lib/TPP/PassBundles/LinalgLowering.cpp
@@ -47,7 +47,9 @@ struct LinalgLowering : public tpp::impl::LinalgLoweringBase<LinalgLowering>,
 
 private:
   void constructPipeline() override {
-    pm.addPass(createConvertLinalgToXsmm());
+    ConvertLinalgToXsmmOptions linalgOptions;
+    linalgOptions.skipOperations = skipOperations;
+    pm.addPass(createConvertLinalgToXsmm(linalgOptions));
     pm.addPass(createCombineXsmmOpPass());
     pm.addPass(createFoldXsmmFlags());
     pm.addPass(createVerifyXsmmCalls());

--- a/test/Passes/linalg-to-xsmm-skip.mlir
+++ b/test/Passes/linalg-to-xsmm-skip.mlir
@@ -1,0 +1,31 @@
+// RUN: tpp-opt %s -convert-linalg-to-xsmm -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -convert-linalg-to-xsmm="skip-operations=fill" -split-input-file | FileCheck %s --check-prefix=SKIP-FILL
+// RUN: tpp-opt %s -convert-linalg-to-xsmm="skip-operations=matmul" -split-input-file | FileCheck %s --check-prefix=SKIP-GEMM
+
+func.func @fill_op(%arg0: memref<32x32xf32>) {
+  %cst = arith.constant 0.0 : f32
+  linalg.fill ins(%cst : f32) outs(%arg0 : memref<32x32xf32>)
+  return
+}
+
+// CHECK-LABEL: fill_op
+// CHECK: xsmm.unary
+// SKIP-FILL: linalg.fill
+// SKIP-GEMM: xsmm.unary
+
+// -----
+
+func.func @simple_gemm(%arg0: memref<32x64xf32, strided<[64, 1], offset: ?>>,
+                       %arg1: memref<64x32xf32, strided<[32, 1], offset: ?>>,
+                       %arg2: memref<32x32xf32, strided<[32, 1], offset: ?>>) {
+  linalg.matmul ins(%arg0, %arg1 : memref<32x64xf32, strided<[64, 1], offset: ?>>,
+                                   memref<64x32xf32, strided<[32, 1], offset: ?>>)
+                outs(%arg2 : memref<32x32xf32, strided<[32, 1], offset: ?>>)
+  return
+}
+
+
+// CHECK-LABEL: simple_gemm
+// CHECK: xsmm.gemm
+// SKIP-FILL: xsmm.gemm
+// SKIP-GEMM: linalg.matmul


### PR DESCRIPTION
In order to proceed with separate vectorization paths, we need to improve the pipeline so that we can skip certain patterns to XSMM depending on the path we take.

Before this PR, the path is:
```
bufferization -> <vectorize?> -Y-> linalg-to-vector ... -> lower to LLVM
                             \-N-> linalg-to-xsmm ----------^
```

After this patch, i becomes:
```
bufferization -> linalg-to-xsmm (partial) -> <vectorize?> -Y-> linalg-to-vector ... -> lower to LLVM
                                                         \-N-> -------------------------^
```

The `partial` part is controlled by a new option (`skip-operations`), which can be passed via command line or changed in the pipeline builder function from other command line options (ex. `vector-to-function`, `vector-to-kernel`, etc.).

The state would end up as:
```
bufferization -> linalg-to-xsmm (partial) -> <vector-to-function?> -> linalg-to-vector -> vector-to-xsmm -> lower to LLVM
                                          | <vector-to-kernel> -> linalg-to-vector -> vector-to-kernel ------^
                                          \ <else> ----------------------------------------------------------^
```

Patterns that do not lower to neither XSMM, function or kernel will be lowered to loop by the final cleanups.

@KavithaTipturMadhu, this should allow you to add a new flag (ex. `vector-to-function`) where you enable only one operation at a time to lower from vector to function and disable that in `linalg-to-xsmm` at the same time. This helps #980.

@shahidact and @arun-thmn, similarly for #977 and #978, this should allow you two to have a shared pipeline that goes from linalg to vector all the way down to kernel but do so only for a single operation at a time, which can be _different_ than Kavitha's order, controlled by different lists from your different option.