### PR TITLE
Vector-to-{XSMM, Kernel} bundles

### DIFF
--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -38,6 +38,12 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     Option<"linalgToVector", "linalg-to-vector",
            "bool", /*default=*/"false",
            "Lower linalg directly to vector.">,
+    Option<"vectorToXSMM", "vector-to-xsmm",
+           "bool", /*default=*/"false",
+           "Lower vector patterns to XSMM calls.">,
+    Option<"vectorToKernel", "vector-to-kernel",
+           "bool", /*default=*/"false",
+           "Lower vector patterns to micro-kernels.">,
     Option<"lowerPackUnpackWithoutTranspose", "lower-pack-unpack-without-transpose",
            "bool", /*default=*/"false",
            "Lower non-constant packs and unpacks reverting any dim permutations.">

--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -72,6 +72,18 @@ def LinalgLowering : Pass<"linalg-lowering", "func::FuncOp"> {
   ];
 }
 
+def VectorToXSMM : Pass<"vector-to-xsmm", "ModuleOp"> {
+  let summary = "Lower Vector operations to XSMM functions.";
+  let dependentDialects = ["vector::VectorDialect",
+                           "scf::SCFDialect"];
+}
+
+def VectorToKernel : Pass<"vector-to-kernel", "ModuleOp"> {
+  let summary = "Lower Vector operations to micro-kernel special lowering.";
+  let dependentDialects = ["vector::VectorDialect",
+                           "scf::SCFDialect"];
+}
+
 def LowLevelParallelization : Pass<"low-level-parallel", "ModuleOp"> {
   let summary = "Low level parallelization (multi-threading, AMX config).";
   let dependentDialects = ["affine::AffineDialect",

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -72,6 +72,10 @@ namespace tensor {
 class TensorDialect;
 } // namespace tensor
 
+namespace vector {
+class VectorDialect;
+} // namespace tensor
+
 namespace tpp {
 
 // Testing passes.

--- a/lib/TPP/PassBundles/CMakeLists.txt
+++ b/lib/TPP/PassBundles/CMakeLists.txt
@@ -8,6 +8,8 @@ add_mlir_library(TPPPassBundles
   LowLevelParallelization.cpp
   PostProcessing.cpp
   TppMapping.cpp
+  VectorToXSMM.cpp
+  VectorToKernel.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/PassBundles/VectorToKernel.cpp
+++ b/lib/TPP/PassBundles/VectorToKernel.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "llvm/Support/Debug.h"
 
 #include "TPP/PassBundles.h"
 #include "TPP/PassUtils.h"
@@ -26,8 +27,10 @@ namespace tpp {
 } // namespace tpp
 } // namespace mlir
 
-// Apply collection of high-level passes that map operations to
-// TPP-compatible forms.
+#define DEBUG_TYPE "convert-vector-to-kernels"
+
+// Apply collection of vector-level passes that map vector patterns to
+// specialized micro-kernels akin to libxsmm kernels.
 struct VectorToKernel : public tpp::impl::VectorToKernelBase<VectorToKernel>,
                     PassBundle<ModuleOp> {
   void runOnOperation() override {
@@ -45,6 +48,8 @@ struct VectorToKernel : public tpp::impl::VectorToKernelBase<VectorToKernel>,
 
 private:
   void constructPipeline() override {
-    // Not Implemented Yet.
+    LLVM_DEBUG(llvm::dbgs() << "Adding vector-to-kernel passes\n");
+    // TODO: Add all the others
+    pm.addNestedPass<func::FuncOp>(createVectorContractToOuterproduct());
   }
 };

--- a/lib/TPP/PassBundles/VectorToKernel.cpp
+++ b/lib/TPP/PassBundles/VectorToKernel.cpp
@@ -1,0 +1,50 @@
+//===- VectorToKernel.cpp ------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "TPP/PassBundles.h"
+#include "TPP/PassUtils.h"
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_VECTORTOKERNEL
+#include "TPP/PassBundles.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+// Apply collection of high-level passes that map operations to
+// TPP-compatible forms.
+struct VectorToKernel : public tpp::impl::VectorToKernelBase<VectorToKernel>,
+                    PassBundle<ModuleOp> {
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    // Initialize the pipeline if needed.
+    // Otherwise, just run the cached one.
+    if (pm.empty())
+      constructPipeline();
+
+    if (failed(runPipeline(pm, module))) {
+      return signalPassFailure();
+    }
+  }
+
+private:
+  void constructPipeline() override {
+    // Not Implemented Yet.
+  }
+};

--- a/lib/TPP/PassBundles/VectorToXSMM.cpp
+++ b/lib/TPP/PassBundles/VectorToXSMM.cpp
@@ -1,0 +1,50 @@
+//===- VectorToXSMM.cpp ------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "TPP/PassBundles.h"
+#include "TPP/PassUtils.h"
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_VECTORTOXSMM
+#include "TPP/PassBundles.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+// Apply collection of high-level passes that map operations to
+// TPP-compatible forms.
+struct VectorToXSMM : public tpp::impl::VectorToXSMMBase<VectorToXSMM>,
+                    PassBundle<ModuleOp> {
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    // Initialize the pipeline if needed.
+    // Otherwise, just run the cached one.
+    if (pm.empty())
+      constructPipeline();
+
+    if (failed(runPipeline(pm, module))) {
+      return signalPassFailure();
+    }
+  }
+
+private:
+  void constructPipeline() override {
+    // Not Implemented Yet.
+  }
+};

--- a/lib/TPP/PassBundles/VectorToXSMM.cpp
+++ b/lib/TPP/PassBundles/VectorToXSMM.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "llvm/Support/Debug.h"
 
 #include "TPP/PassBundles.h"
 #include "TPP/PassUtils.h"
@@ -26,8 +27,10 @@ namespace tpp {
 } // namespace tpp
 } // namespace mlir
 
-// Apply collection of high-level passes that map operations to
-// TPP-compatible forms.
+#define DEBUG_TYPE "convert-vector-to-xsmm"
+
+// Apply collection of vector-level passes that map vector patterns to
+// libxsmm call pairs (dispatch, invoke).
 struct VectorToXSMM : public tpp::impl::VectorToXSMMBase<VectorToXSMM>,
                     PassBundle<ModuleOp> {
   void runOnOperation() override {
@@ -45,6 +48,7 @@ struct VectorToXSMM : public tpp::impl::VectorToXSMMBase<VectorToXSMM>,
 
 private:
   void constructPipeline() override {
+    LLVM_DEBUG(llvm::dbgs() << "Adding vector-to-xsmm passes\n");
     // Not Implemented Yet.
   }
 };


### PR DESCRIPTION
Adding two new bundles enabled by their own flags and turning on linalg vectorization on demand. Future PRs on each side should add their passes to the respective bundles and add benchmark updates to show their performance on CI.