### PR TITLE
Common CLI flags registry

### DIFF
--- a/include/TPP/Options/GpuOptions.h
+++ b/include/TPP/Options/GpuOptions.h
@@ -1,4 +1,4 @@
-//===- GpuOptions.h ----------------------------------------*- C++ -*-===//
+//===- GpuOptions.h ---------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/TPP/Options/GpuOptions.h
+++ b/include/TPP/Options/GpuOptions.h
@@ -22,11 +22,11 @@ namespace tpp {
 namespace opt {
 
 // Select target GPU backend for the pipeline.
-extern llvm::cl::opt<std::string> defGpuBackend;
+extern llvm::cl::opt<std::string> gpuBackend;
 
 // Kernel buffers - arguments and return values - are expected to be allocated
 // on GPU.
-extern llvm::cl::opt<bool> defGpuArgs;
+extern llvm::cl::opt<bool> gpuArgs;
 
 extern llvm::cl::list<int64_t> gpuBlockTile;
 

--- a/include/TPP/Options/GpuOptions.h
+++ b/include/TPP/Options/GpuOptions.h
@@ -1,0 +1,49 @@
+//===- GpuOptions.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Collection of CLI flags controlling GPU pipeline.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_OPTIONS_GPUOPTIONS_H
+#define TPP_OPTIONS_GPUOPTIONS_H
+
+#include "llvm/Support/CommandLine.h"
+
+#include <string>
+
+namespace mlir {
+namespace tpp {
+namespace opt {
+
+// Select target GPU backend for the pipeline.
+extern llvm::cl::opt<std::string> defGpuBackend;
+
+// Kernel buffers - arguments and return values - are expected to be allocated
+// on GPU.
+extern llvm::cl::opt<bool> defGpuArgs;
+
+extern llvm::cl::list<int64_t> gpuBlockTile;
+
+extern llvm::cl::list<int64_t> gpuThreadTile;
+
+extern llvm::cl::opt<int64_t> kTile;
+
+extern llvm::cl::opt<int64_t> stages;
+
+// DPAS size defaults to PVC.
+extern llvm::cl::list<int64_t> gpuDpasTile;
+
+// Control GPU vectorization.
+extern llvm::cl::opt<bool> gpuVector;
+
+} // namespace opt
+} // namespace tpp
+} // namespace mlir
+
+#endif // TPP_OPTIONS_GPUOPTIONS_H

--- a/include/TPP/Options/PipelineOptions.h
+++ b/include/TPP/Options/PipelineOptions.h
@@ -5,6 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Collection of common CLI flags controlling lowering pipeline.
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef TPP_OPTIONS_PIPELINEOPTIONS_H
 #define TPP_OPTIONS_PIPELINEOPTIONS_H

--- a/include/TPP/Options/PipelineOptions.h
+++ b/include/TPP/Options/PipelineOptions.h
@@ -35,6 +35,10 @@ extern llvm::cl::list<unsigned> parallelTaskGrid;
 
 extern llvm::cl::opt<bool> linalgToVector;
 
+extern llvm::cl::opt<bool> vectorToXSMM;
+
+extern llvm::cl::opt<bool> vectorToKernel;
+
 extern llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose;
 
 // Lhs tile sizes for linalg-to-vector.

--- a/include/TPP/Options/PipelineOptions.h
+++ b/include/TPP/Options/PipelineOptions.h
@@ -1,0 +1,46 @@
+//===- PipelineOptions.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_OPTIONS_PIPELINEOPTIONS_H
+#define TPP_OPTIONS_PIPELINEOPTIONS_H
+
+#include "llvm/Support/CommandLine.h"
+
+#include <string>
+
+namespace mlir {
+namespace tpp {
+namespace opt {
+
+// Print MLIR before lowering
+extern llvm::cl::opt<std::string> printMLIR;
+
+// Lower Linalg directly to loops without TPP (for validation purposes)
+extern llvm::cl::opt<bool> linalgToLoops;
+
+// Control parallelism.
+extern llvm::cl::opt<bool> defParallel;
+
+// Control grid parallelism sizes.
+extern llvm::cl::list<unsigned> parallelTaskGrid;
+
+extern llvm::cl::opt<bool> linalgToVector;
+
+extern llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose;
+
+// Lhs tile sizes for linalg-to-vector.
+extern llvm::cl::list<unsigned> lhsTile;
+
+// Rhs tile sizes for linalg-to-vector
+extern llvm::cl::list<unsigned> rhsTile;
+
+} // namespace opt
+} // namespace tpp
+} // namespace mlir
+
+#endif // TPP_OPTIONS_PIPELINEOPTIONS_H

--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -16,11 +16,6 @@ def DefaultPipeline : Pass<"default-pipeline", "ModuleOp"> {
   let description = [{
     A collection of passes that lower everything to MLIR LLVM IR.
   }];
-  let options = [
-    Option<"gpuBackend", "gpu", "std::string",
-            /*default=*/"\"\"",
-           "Optional target GPU backend.">,
-  ];
 }
 
 def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
@@ -29,30 +24,6 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     A collection of passes that lower everything TPP-related
     to standard low-level dialects.
   }];
-  let options= [
-    Option<"linalgToLoops", "linalg-to-loops",
-           "bool", /*default=*/"false",
-           "Skip all TPP transformations. Lower linalg directly to loops.">,
-    ListOption<"parallelTaskGrid", "parallel-task-grid",
-           "unsigned", "Grid-sizes for parallel tasks.">,
-    Option<"linalgToVector", "linalg-to-vector",
-           "bool", /*default=*/"false",
-           "Lower linalg directly to vector.">,
-    Option<"vectorToXSMM", "vector-to-xsmm",
-           "bool", /*default=*/"false",
-           "Lower vector patterns to XSMM calls.">,
-    Option<"vectorToKernel", "vector-to-kernel",
-           "bool", /*default=*/"false",
-           "Lower vector patterns to micro-kernels.">,
-    Option<"lowerPackUnpackWithoutTranspose", "lower-pack-unpack-without-transpose",
-           "bool", /*default=*/"false",
-           "Lower non-constant packs and unpacks reverting any dim permutations.">,
-    ListOption<"lhsTile", "lhsTile",
-           "unsigned", "Lhs tile size for brgemm operation.">,
-    ListOption<"rhsTile", "rhsTile",
-           "unsigned", "Rhs tile size for brgemm operation.">,
-
-  ];
 }
 
 def TppMapping : Pass<"tpp-mapping", "ModuleOp"> {
@@ -65,11 +36,6 @@ def TppMapping : Pass<"tpp-mapping", "ModuleOp"> {
                            "memref::MemRefDialect",
                            "scf::SCFDialect",
                            "tensor::TensorDialect"];
-  let options= [
-    Option<"lowerPackUnpackWithoutTranspose", "lower-pack-unpack-without-transpose",
-           "bool", /*default=*/"false",
-           "Lower non-constant packs and unpacks reverting any dim permutations.">
-  ];
 }
 
 def LinalgLowering : Pass<"linalg-lowering", "func::FuncOp"> {
@@ -104,11 +70,6 @@ def LowLevelParallelization : Pass<"low-level-parallel", "ModuleOp"> {
                            "scf::SCFDialect",
                            "xsmm::XsmmDialect",
                            "LLVM::LLVMDialect"];
-  let options = [
-    ListOption<"parallelTaskGrid", "parallel-task-grid",
-           "unsigned", "Grid-sizes for parallel tasks.">
-
-  ];
 }
 
 def LocalDialectsLowering : Pass<"lower-local-dialects", "ModuleOp"> {
@@ -142,11 +103,6 @@ def Cleanup : Pass<"cleanup"> {
 
 def GpuPipeline : Pass<"gpu-pipeline", "ModuleOp"> {
   let summary = "Lower all eligible operations into GPU compatible IR";
-  let options = [
-    Option<"gpuBackend", "gpu", "std::string",
-            /*default=*/"\"cuda\"",
-           "Target GPU backend for lowering (cuda).">,
-  ];
 }
 
 def GpuConversion : Pass<"gpu-conversion", "ModuleOp"> {
@@ -159,19 +115,6 @@ def GpuConversion : Pass<"gpu-conversion", "ModuleOp"> {
                            "scf::SCFDialect",
                            "memref::MemRefDialect",
                            "xegpu::XeGPUDialect"];
-  let options = [
-    Option<"isIntel", "intel",
-           "bool", /*default=*/"false",
-           "Convert for Intel GPU">,
-    Option<"kTile", "k-tile", "int64_t",
-           /*default=*/"32",
-           "GEMM tile size for reduction dimension.">,
-    Option<"stages", "stages", "int64_t",
-           /*default=*/"1",
-           "Number of cooperative prefetch stages.">,
-    ListOption<"dpasTile", "dpas-tile", "int64_t",
-               "DPAS register block sizes MxNxK">,
-  ];
 }
 
 def GpuToCuda : Pass<"gpu-to-cuda", "ModuleOp"> {

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(GPU)
 add_subdirectory(IR)
+add_subdirectory(Options)
 add_subdirectory(PassBundles)
 add_subdirectory(Runner)
 add_subdirectory(Transforms)
@@ -26,4 +27,5 @@ add_mlir_library(TPPPipeline
     ${conversion_libs}
     TPPGPU
     TPPPassBundles
+    TPPOptions
   )

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -21,6 +21,7 @@
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Perf/PerfOps.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Options/PipelineOptions.h"
 #include "TPP/PassUtils.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -28,53 +29,7 @@
 
 using namespace mlir;
 using namespace mlir::tpp;
-
-// Print MLIR before lowering
-llvm::cl::opt<std::string>
-    printMLIR("print-mlir",
-              llvm::cl::desc("Print MLIR to stdout (early, mid, late, llvm)"),
-              llvm::cl::init(""));
-
-// Lower Linalg directly to loops without TPP (for validation purposes)
-llvm::cl::opt<bool> linalgToLoops("linalg-to-loops",
-                                  llvm::cl::desc("Lower linalg to loops"),
-                                  llvm::cl::init(false));
-
-// Control parallelism.
-llvm::cl::opt<bool>
-    defParallel("def-parallel",
-                llvm::cl::desc("Default pipeline - enable parallel execution"),
-                llvm::cl::init(false));
-
-// Control grid parallelism sizes.
-llvm::cl::list<unsigned>
-    parallelTaskGrid("parallel-task-grid",
-                     llvm::cl::desc("Grid-sizes for parallel tasks"),
-                     llvm::cl::list_init<unsigned>(SmallVector<unsigned>{2, 8}),
-                     llvm::cl::CommaSeparated);
-
-llvm::cl::opt<bool> linalgToVector("linalg-to-vector",
-                                   llvm::cl::desc("Lower linalg to vector"),
-                                   llvm::cl::init(false));
-
-llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose(
-    "lower-pack-unpack-without-transpose",
-    llvm::cl::desc("Lower packs and unpacks reverting any dim permutations"),
-    llvm::cl::init(false));
-
-// Lhs tile sizes for linalg-to-vector.
-llvm::cl::list<unsigned>
-    lhsTile("lhsTile",
-                     llvm::cl::desc("Lhs tile size for brgemm operation"),
-                     llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 8}),
-                     llvm::cl::CommaSeparated);
-
-// Rhs tile sizes for linalg-to-vector
-llvm::cl::list<unsigned>
-    rhsTile("rhsTile",
-                     llvm::cl::desc("Rhs tile size for brgemm operation"),
-                     llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 16}),
-                     llvm::cl::CommaSeparated);
+using namespace mlir::tpp::opt;
 
 namespace mlir {
 namespace tpp {

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -21,6 +21,7 @@
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Perf/PerfOps.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Options/GpuOptions.h"
 #include "TPP/Options/PipelineOptions.h"
 #include "TPP/PassUtils.h"
 #include "mlir/Transforms/Passes.h"
@@ -99,18 +100,10 @@ private:
 
     if (!gpuBackend.empty()) {
       // Apply the custom GPU lowering pipeline
-      pm.addPass(createGpuPipeline(GpuPipelineOptions{gpuBackend}));
+      pm.addPass(createGpuPipeline());
     } else {
-      // Apply the default preprocessing pass
-      DefaultTppPassesOptions tppDefaultOptions; 
-          tppDefaultOptions.linalgToLoops = linalgToLoops;
-	  tppDefaultOptions.parallelTaskGrid = parallelTaskGrid;
-	  tppDefaultOptions.linalgToVector = linalgToVector;
-          tppDefaultOptions.lowerPackUnpackWithoutTranspose = lowerPackUnpackWithoutTranspose;
-	  tppDefaultOptions.lhsTile = lhsTile;
-	  tppDefaultOptions.rhsTile = rhsTile;
-
-      pm.addPass(createDefaultTppPasses(tppDefaultOptions));
+      // Apply the default lowering passes
+      pm.addPass(createDefaultTppPasses());
     }
 
     if (print == PrintStage::Mid)

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -20,11 +20,13 @@
 #include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Options/PipelineOptions.h"
 #include "TPP/PassUtils.h"
 #include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
 using namespace mlir::tpp;
+using namespace mlir::tpp::opt;
 
 namespace mlir {
 namespace tpp {
@@ -113,8 +115,7 @@ private:
       pm.addPass(createRewriteBatchMatmulToMatmul());
 
       // Applies a set of passes at the linalg level to fuse and pack.
-      TppMappingOptions tppMappingOptions{lowerPackUnpackWithoutTranspose};
-      pm.addPass(createTppMapping(tppMappingOptions));
+      pm.addPass(createTppMapping());
 
       // Generalize tensor.pack and tensor.unpack.
       pm.addPass(createLowerPacksAndUnPacks());
@@ -155,15 +156,14 @@ private:
     // Convert forAll to parallel loops should run after bufferization
     // as scf.parallel does not handle tensor.
     pm.addPass(createConvertForAllToParallelOp());
-    LowLevelParallelizationOptions LowLevelParallelization{parallelTaskGrid};
 
     if (linalgToVector) {
       pm.addPass(createConvertVectorToSCFPass());
       // Low level parallelization passes.
-      pm.addPass(createLowLevelParallelization(LowLevelParallelization));
+      pm.addPass(createLowLevelParallelization());
     } else {
       // Low level parallelization passes.
-      pm.addPass(createLowLevelParallelization(LowLevelParallelization));
+      pm.addPass(createLowLevelParallelization());
       // TODO: These passes have been moved out of low level parallelization
       // pass since these apply on xsmm dialect. They'll be moved back in
       // subsequent commits.

--- a/lib/TPP/GPU/CMakeLists.txt
+++ b/lib/TPP/GPU/CMakeLists.txt
@@ -30,6 +30,7 @@ add_mlir_library(TPPGPU
     MLIRControlFlowToSPIRV
     MLIRMemRefTransforms
     TPPIR
+    TPPOptions
 )
 
 if (TPP_GPU MATCHES "cuda")

--- a/lib/TPP/GPU/GpuConversion.cpp
+++ b/lib/TPP/GPU/GpuConversion.cpp
@@ -21,12 +21,14 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "TPP/Options/GpuOptions.h"
 #include "TPP/PassUtils.h"
 
 #include <optional>
 
 using namespace mlir;
 using namespace mlir::tpp;
+using namespace mlir::tpp::opt;
 
 namespace mlir {
 namespace tpp {
@@ -64,9 +66,9 @@ private:
     // First lower linalg using custom patterns then fall back to
     // the default lowering for any remaining ops.
     pm.addNestedPass<func::FuncOp>(createLinalgDeGeneralize());
-    if (isIntel) {
-      pm.addNestedPass<func::FuncOp>(
-          createLinalgToXeGPU(LinalgToXeGPUOptions{kTile, stages, dpasTile}));
+    if (gpuBackend == "intel") {
+      pm.addNestedPass<func::FuncOp>(createLinalgToXeGPU(
+          LinalgToXeGPUOptions{kTile, stages, gpuDpasTile}));
     }
     pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
     pm.addPass(createCleanup());

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -32,6 +32,7 @@
 #include "TPP/Dialect/Perf/BufferizableOpInterfaceImpl.h"
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Options/GpuOptions.h"
 #include "TPP/PassUtils.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -40,34 +41,7 @@
 
 using namespace mlir;
 using namespace mlir::tpp;
-
-llvm::cl::list<int64_t>
-    gpuBlockTile("gpu-block-tile", llvm::cl::desc("GPU block tile size"),
-                 llvm::cl::list_init<int64_t>(SmallVector<int64_t>{128, 128}),
-                 llvm::cl::CommaSeparated);
-
-llvm::cl::list<int64_t>
-    gpuThreadTile("gpu-thread-tile", llvm::cl::desc("GPU thread tile size"),
-                  llvm::cl::list_init<int64_t>(SmallVector<int64_t>{32, 32}),
-                  llvm::cl::CommaSeparated);
-
-llvm::cl::opt<int64_t> kTile("k-tile", llvm::cl::desc("GEMM K dim tiling size"),
-                             llvm::cl::init(32));
-
-llvm::cl::opt<int64_t> stages("stages",
-                              llvm::cl::desc("GEMM coop prefetch stages"),
-                              llvm::cl::init(1));
-
-// DPAS size defaults to PVC.
-llvm::cl::list<int64_t>
-    gpuDpasTile("dpas-tile", llvm::cl::desc("DPAS register block sizes MxNxK"),
-                llvm::cl::list_init<int64_t>(SmallVector<int64_t>{8, 16, 16}),
-                llvm::cl::CommaSeparated);
-
-// Control GPU vectorization.
-llvm::cl::opt<bool> gpuVector("gpu-vector",
-                              llvm::cl::desc("Vectorize GPU kernel"),
-                              llvm::cl::init(false));
+using namespace mlir::tpp::opt;
 
 namespace mlir {
 namespace tpp {

--- a/lib/TPP/GPU/GpuPipeline.cpp
+++ b/lib/TPP/GPU/GpuPipeline.cpp
@@ -61,7 +61,7 @@ GpuType parseGpuOption(StringRef gpuStr) {
   auto type = llvm::StringSwitch<std::optional<GpuType>>(gpuStr)
                   .CaseLower("cuda", GpuType::Cuda)
                   .CaseLower("intel", GpuType::Intel)
-                  .Default(std::nullopt);
+                  .Default(GpuType::Cuda);
   assert(type && "Unsupported GPU backend");
 
   return *type;
@@ -132,7 +132,7 @@ struct GpuPipeline : public tpp::impl::GpuPipelineBase<GpuPipeline>,
 
 private:
   void constructPipeline() override {
-    GpuType gpuType = parseGpuOption(this->gpuBackend);
+    GpuType gpuType = parseGpuOption(gpuBackend);
     GpuOptions gpuOptions = getGpuOptions(gpuType);
 
     // Input preprocessing.
@@ -187,8 +187,7 @@ private:
     pm.addPass(createCleanup());
 
     // Convert to generic GPU ops.
-    pm.addPass(createGpuConversion(GpuConversionOptions{
-        gpuType == GpuType::Intel, kTile, stages, gpuDpasTile}));
+    pm.addPass(createGpuConversion());
 
     // Lower GPU ops to the chosen GPU backend.
     switch (gpuType) {

--- a/lib/TPP/Options/CMakeLists.txt
+++ b/lib/TPP/Options/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_library(TPPOptions
+  GpuOptions.cpp
   PipelineOptions.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/TPP/Options/CMakeLists.txt
+++ b/lib/TPP/Options/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_library(TPPOptions
+  PipelineOptions.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/TPP
+
+  LINK_LIBS PUBLIC
+    LLVMSupport
+  )

--- a/lib/TPP/Options/GpuOptions.cpp
+++ b/lib/TPP/Options/GpuOptions.cpp
@@ -1,0 +1,61 @@
+//===- GpuOptions.cpp --------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Options/GpuOptions.h"
+
+#include "mlir/Support/LLVM.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+namespace opt {
+
+// Select target GPU backend for the pipeline.
+llvm::cl::opt<std::string>
+    defGpuBackend("gpu", llvm::cl::desc("Target GPU backend for lowering"),
+                  llvm::cl::value_desc("cuda,intel"), llvm::cl::init(""));
+
+// Kernel buffers - arguments and return values - are expected to be allocated
+// on GPU.
+llvm::cl::opt<bool>
+    defGpuArgs("gpu-args",
+               llvm::cl::desc("Kernel buffers are allocated on GPU"),
+               llvm::cl::init(true));
+
+llvm::cl::list<int64_t>
+    gpuBlockTile("gpu-block-tile", llvm::cl::desc("GPU block tile size"),
+                 llvm::cl::list_init<int64_t>(SmallVector<int64_t>{128, 128}),
+                 llvm::cl::CommaSeparated);
+
+llvm::cl::list<int64_t>
+    gpuThreadTile("gpu-thread-tile", llvm::cl::desc("GPU thread tile size"),
+                  llvm::cl::list_init<int64_t>(SmallVector<int64_t>{32, 32}),
+                  llvm::cl::CommaSeparated);
+
+llvm::cl::opt<int64_t> kTile("k-tile", llvm::cl::desc("GEMM K dim tiling size"),
+                             llvm::cl::init(32));
+
+llvm::cl::opt<int64_t> stages("stages",
+                              llvm::cl::desc("GEMM coop prefetch stages"),
+                              llvm::cl::init(1));
+
+// DPAS size defaults to PVC.
+llvm::cl::list<int64_t>
+    gpuDpasTile("dpas-tile", llvm::cl::desc("DPAS register block sizes MxNxK"),
+                llvm::cl::list_init<int64_t>(SmallVector<int64_t>{8, 16, 16}),
+                llvm::cl::CommaSeparated);
+
+// Control GPU vectorization.
+llvm::cl::opt<bool> gpuVector("gpu-vector",
+                              llvm::cl::desc("Vectorize GPU kernel"),
+                              llvm::cl::init(false));
+
+} // namespace opt
+} // namespace tpp
+} // namespace mlir

--- a/lib/TPP/Options/GpuOptions.cpp
+++ b/lib/TPP/Options/GpuOptions.cpp
@@ -18,15 +18,14 @@ namespace opt {
 
 // Select target GPU backend for the pipeline.
 llvm::cl::opt<std::string>
-    defGpuBackend("gpu", llvm::cl::desc("Target GPU backend for lowering"),
-                  llvm::cl::value_desc("cuda,intel"), llvm::cl::init(""));
+    gpuBackend("gpu", llvm::cl::desc("Target GPU backend for lowering"),
+               llvm::cl::value_desc("cuda,intel"), llvm::cl::init(""));
 
 // Kernel buffers - arguments and return values - are expected to be allocated
 // on GPU.
 llvm::cl::opt<bool>
-    defGpuArgs("gpu-args",
-               llvm::cl::desc("Kernel buffers are allocated on GPU"),
-               llvm::cl::init(true));
+    gpuArgs("gpu-args", llvm::cl::desc("Kernel buffers are allocated on GPU"),
+            llvm::cl::init(true));
 
 llvm::cl::list<int64_t>
     gpuBlockTile("gpu-block-tile", llvm::cl::desc("GPU block tile size"),

--- a/lib/TPP/Options/PipelineOptions.cpp
+++ b/lib/TPP/Options/PipelineOptions.cpp
@@ -1,0 +1,66 @@
+//===- PipelineOptions.cpp ---------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Options/PipelineOptions.h"
+
+#include "mlir/Support/LLVM.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+namespace opt {
+
+// Print MLIR before lowering
+llvm::cl::opt<std::string>
+    printMLIR("print-mlir",
+              llvm::cl::desc("Print MLIR to stdout (early, mid, late, llvm)"),
+              llvm::cl::init(""));
+
+// Lower Linalg directly to loops without TPP (for validation purposes)
+llvm::cl::opt<bool> linalgToLoops("linalg-to-loops",
+                                  llvm::cl::desc("Lower linalg to loops"),
+                                  llvm::cl::init(false));
+
+// Control parallelism.
+llvm::cl::opt<bool>
+    defParallel("def-parallel",
+                llvm::cl::desc("Default pipeline - enable parallel execution"),
+                llvm::cl::init(false));
+
+// Control grid parallelism sizes.
+llvm::cl::list<unsigned>
+    parallelTaskGrid("parallel-task-grid",
+                     llvm::cl::desc("Grid-sizes for parallel tasks"),
+                     llvm::cl::list_init<unsigned>(SmallVector<unsigned>{2, 8}),
+                     llvm::cl::CommaSeparated);
+
+llvm::cl::opt<bool> linalgToVector("linalg-to-vector",
+                                   llvm::cl::desc("Lower linalg to vector"),
+                                   llvm::cl::init(false));
+
+llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose(
+    "lower-pack-unpack-without-transpose",
+    llvm::cl::desc("Lower packs and unpacks reverting any dim permutations"),
+    llvm::cl::init(false));
+
+// Lhs tile sizes for linalg-to-vector.
+llvm::cl::list<unsigned>
+    lhsTile("lhsTile", llvm::cl::desc("Lhs tile size for brgemm operation"),
+            llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 8}),
+            llvm::cl::CommaSeparated);
+
+// Rhs tile sizes for linalg-to-vector
+llvm::cl::list<unsigned>
+    rhsTile("rhsTile", llvm::cl::desc("Rhs tile size for brgemm operation"),
+            llvm::cl::list_init<unsigned>(SmallVector<unsigned>{8, 16}),
+            llvm::cl::CommaSeparated);
+
+} // namespace opt
+} // namespace tpp
+} // namespace mlir

--- a/lib/TPP/Options/PipelineOptions.cpp
+++ b/lib/TPP/Options/PipelineOptions.cpp
@@ -44,6 +44,16 @@ llvm::cl::opt<bool> linalgToVector("linalg-to-vector",
                                    llvm::cl::desc("Lower linalg to vector"),
                                    llvm::cl::init(false));
 
+llvm::cl::opt<bool>
+    vectorToXSMM("def-vector-to-xsmm",
+                 llvm::cl::desc("Lower vector patterns to XSMM calls."),
+                 llvm::cl::init(false));
+
+llvm::cl::opt<bool>
+    vectorToKernel("def-vector-to-kernel",
+                   llvm::cl::desc("Lower vector patterns to micro-kernels."),
+                   llvm::cl::init(false));
+
 llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose(
     "lower-pack-unpack-without-transpose",
     llvm::cl::desc("Lower packs and unpacks reverting any dim permutations"),

--- a/lib/TPP/Options/PipelineOptions.cpp
+++ b/lib/TPP/Options/PipelineOptions.cpp
@@ -37,6 +37,7 @@ llvm::cl::opt<bool>
 llvm::cl::list<unsigned>
     parallelTaskGrid("parallel-task-grid",
                      llvm::cl::desc("Grid-sizes for parallel tasks"),
+                     llvm::cl::list_init<unsigned>(SmallVector<unsigned>{2, 8}),
                      llvm::cl::CommaSeparated);
 
 llvm::cl::opt<bool> linalgToVector("linalg-to-vector",

--- a/lib/TPP/Options/PipelineOptions.cpp
+++ b/lib/TPP/Options/PipelineOptions.cpp
@@ -37,7 +37,6 @@ llvm::cl::opt<bool>
 llvm::cl::list<unsigned>
     parallelTaskGrid("parallel-task-grid",
                      llvm::cl::desc("Grid-sizes for parallel tasks"),
-                     llvm::cl::list_init<unsigned>(SmallVector<unsigned>{2, 8}),
                      llvm::cl::CommaSeparated);
 
 llvm::cl::opt<bool> linalgToVector("linalg-to-vector",
@@ -46,13 +45,13 @@ llvm::cl::opt<bool> linalgToVector("linalg-to-vector",
 
 llvm::cl::opt<bool>
     vectorToXSMM("def-vector-to-xsmm",
-                 llvm::cl::desc("Lower vector patterns to XSMM calls."),
+                 llvm::cl::desc("Default pipeline - lower vector to XSMM."),
                  llvm::cl::init(false));
 
-llvm::cl::opt<bool>
-    vectorToKernel("def-vector-to-kernel",
-                   llvm::cl::desc("Lower vector patterns to micro-kernels."),
-                   llvm::cl::init(false));
+llvm::cl::opt<bool> vectorToKernel(
+    "def-vector-to-kernel",
+    llvm::cl::desc("Default pipeline - lower vector to micro-kernels."),
+    llvm::cl::init(false));
 
 llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose(
     "lower-pack-unpack-without-transpose",

--- a/lib/TPP/PassBundles/CMakeLists.txt
+++ b/lib/TPP/PassBundles/CMakeLists.txt
@@ -23,4 +23,5 @@ add_mlir_library(TPPPassBundles
     TPPTransforms
     ${mlir_dialect_libs}
     ${conversion_libs}
+    TPPOptions
   )

--- a/lib/TPP/PassBundles/LowLevelParallelization.cpp
+++ b/lib/TPP/PassBundles/LowLevelParallelization.cpp
@@ -20,10 +20,12 @@
 #include "mlir/Transforms/Passes.h"
 
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/Options/PipelineOptions.h"
 #include "TPP/PassUtils.h"
 
 using namespace mlir;
 using namespace mlir::tpp;
+using namespace mlir::tpp::opt;
 
 namespace mlir {
 namespace tpp {

--- a/lib/TPP/PassBundles/TppMapping.cpp
+++ b/lib/TPP/PassBundles/TppMapping.cpp
@@ -19,10 +19,12 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "TPP/Options/PipelineOptions.h"
 #include "TPP/PassUtils.h"
 
 using namespace mlir;
 using namespace mlir::tpp;
+using namespace mlir::tpp::opt;
 
 namespace mlir {
 namespace tpp {

--- a/test/GPU/CUDA/gpu-pipeline-cuda.mlir
+++ b/test/GPU/CUDA/gpu-pipeline-cuda.mlir
@@ -1,5 +1,5 @@
 // RUN: ASAN_OPTIONS=protect_shadow_gap=0:replace_intrin=0:detect_leaks=0:${ASAN_OPTIONS} \
-// RUN: tpp-opt %s -gpu-pipeline=gpu=cuda -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -gpu-pipeline -gpu=cuda -split-input-file | FileCheck %s
 
 func.func @packed_brgemm(%arg0: memref<4x16x64x64xf32>, %arg1: memref<16x16x64x64xf32>, %arg2: memref<4x16x64x64xf32>) {
   %c0 = arith.constant 0 : index

--- a/test/GPU/Intel/gpu-pipeline-intel.mlir
+++ b/test/GPU/Intel/gpu-pipeline-intel.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -gpu-pipeline=gpu=intel \
+// RUN: tpp-opt %s -gpu-pipeline -gpu=intel \
 // RUN:  -gpu-block-tile=128,128 -gpu-thread-tile=32,32 -k-tile=32 -stages=1 \
 // RUN:  -split-input-file | \
 // RUN: FileCheck %s

--- a/test/Passes/DefaultPipeline/default-tpp-passes-linalg-to-loops.mlir
+++ b/test/Passes/DefaultPipeline/default-tpp-passes-linalg-to-loops.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes="linalg-to-loops" -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -default-tpp-passes -linalg-to-loops -split-input-file | FileCheck %s
 
 // CHECK-NOT: func.func private @xsmm_
 // CHECK: func.func @matmul(

--- a/test/Passes/DefaultPipeline/linalg-matmul-variants.mlir
+++ b/test/Passes/DefaultPipeline/linalg-matmul-variants.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -default-tpp-passes -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -default-tpp-passes -parallel-task-grid=1,1 -split-input-file | FileCheck %s
 
 func.func @matmul(%arg0: tensor<2048x2048xbf16>, %arg1: tensor<2048x2048xbf16>, %arg2: tensor<2048x2048xbf16>)
     -> tensor<2048x2048xbf16> {

--- a/tools/tpp-opt/CMakeLists.txt
+++ b/tools/tpp-opt/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBS
         MLIRToLLVMIRTranslationRegistration
         MLIROptLib
         TPPPipeline
+        TPPOptions
         TPPRunner
         TPPTransforms
         tpp_xsmm_runner_utils

--- a/tools/tpp-run/CMakeLists.txt
+++ b/tools/tpp-run/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBS
         MLIRSupport
         MLIROptLib
         TPPPipeline
+        TPPOptions
         TPPTransforms
         TPPRunner
         tpp_xsmm_runner_utils

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -152,19 +152,18 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   tpp::TppRunnerWrapperOptions wrapperOpts;
   wrapperOpts.kernelName = options.mainFuncName;
   wrapperOpts.kernelType = options.mainFuncType;
-  wrapperOpts.backend = defGpuBackend;
-  wrapperOpts.offloadToDevice = defGpuArgs;
+  wrapperOpts.backend = gpuBackend;
+  wrapperOpts.offloadToDevice = gpuArgs;
   wrapperOpts.numBenchLoops = benchNumLoops;
   // Warmup on GPUs are currently breaking buffer allocation on GPUs
-  wrapperOpts.benchWarmup = defGpuBackend.empty();
+  wrapperOpts.benchWarmup = gpuBackend.empty();
   wrapperOpts.printResult = printKernelResult;
   wrapperOpts.randomSplat = splatRandom;
   wrapperOpts.seed = seed;
   wrapperOpts.initType = initType;
   passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
 
-  tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend};
-  passManager.addPass(tpp::createDefaultPipeline(defPipelineOpts));
+  passManager.addPass(tpp::createDefaultPipeline());
 
   auto result = passManager.run(module);
   if (failed(result)) {

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -55,12 +55,15 @@
 #include "TPP/Dialect/Perf/PerfDialect.h"
 #include "TPP/Dialect/Xsmm/XsmmDialect.h"
 #include "TPP/GPU/Utils.h"
+#include "TPP/Options/GpuOptions.h"
+#include "TPP/Options/PipelineOptions.h"
 #include "TPP/PassBundles.h"
 #include "TPP/Passes.h"
 
 #include <algorithm>
 
 using namespace mlir;
+using namespace mlir::tpp::opt;
 
 // Number of loops for benchmarks
 llvm::cl::opt<unsigned>
@@ -134,18 +137,6 @@ llvm::cl::opt<std::string> initType(
 llvm::cl::opt<bool> printLLVM("print-llvm",
                               llvm::cl::desc("print LLVM IR before lowering"),
                               llvm::cl::init(false));
-
-// Select target GPU backend for the pipeline.
-llvm::cl::opt<std::string>
-    defGpuBackend("gpu", llvm::cl::desc("Target GPU backend for lowering"),
-                  llvm::cl::value_desc("cuda,intel"), llvm::cl::init(""));
-
-// Kernel buffers - arguments and return values - are expected to be allocated
-// on GPU.
-llvm::cl::opt<bool>
-    defGpuArgs("gpu-args",
-               llvm::cl::desc("Kernel buffers are allocated on GPU"),
-               llvm::cl::init(true));
 
 // This function will be called by the pass manager after parsing,
 // so we can modify the IR with the needed wrappers


### PR DESCRIPTION
Moves CLI flags used to control pipelines behavior to a common registry.

This cleanup allows to remove the overhead of piping options through multiple layers of pass bundles. Now, the common CLI flags are globally accessible and can be pulled directly as a dependency by any pass bundle.

Note that individual passes should be self contained and define all necessary options.