### PR TITLE
VNNI gemm vectorization fix

### DIFF
--- a/include/TPP/Dialect/Xsmm/XsmmUtils.h
+++ b/include/TPP/Dialect/Xsmm/XsmmUtils.h
@@ -26,6 +26,10 @@ class MemRefType;
 namespace func {
 class CallOp;
 }
+namespace linalg {
+class GenericOp;
+struct ContractionDimensions;
+} // namespace linalg
 
 namespace xsmm {
 class UnaryKindAttr;
@@ -122,6 +126,19 @@ func::CallOp buildXsmmCall(RewriterBase &rewriter, XsmmCallType callType,
                            SmallVector<XsmmOperand> operands, TypeRange results,
                            FlatSymbolRefAttr fnName, Operation *parentOp,
                            Operation *insertBefore);
+
+std::optional<unsigned>
+getPosInCodomain(unsigned dim, linalg::GenericOp linalgOp, AffineMap map);
+
+LogicalResult checkVNNIGemmStructure(PatternRewriter &rewriter,
+                                     linalg::GenericOp linalgOp);
+
+FailureOr<linalg::ContractionDimensions>
+inferContractionDims(linalg::GenericOp genericOp);
+
+std::optional<unsigned> getAffineBinaryOpExprIndex(AffineMap map, int index,
+                                                   MLIRContext *context);
+
 } // namespace utils
 } // namespace xsmm
 } // namespace mlir

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -677,21 +677,25 @@ LogicalResult checkVNNIGemmStructure(PatternRewriter &rewriter,
   unsigned m = contractionDims->m.back();
   unsigned n = contractionDims->n.back();
 
+  // m and n dimensions must be parallel dimensions
   if (!linalg::isParallelIterator(iteratorTypes[m]) ||
       !linalg::isParallelIterator(iteratorTypes[n])) {
     return failure();
   }
 
+  // innermost dimension must be a reduction dimension for VNNI type operations
   if (!linalg::isReductionIterator(iteratorTypes[iteratorTypes.size() - 1])) {
     return failure();
   }
 
+  // get the index of the iterator corresponding to the floordiv operation
   auto k = contractionDims->k.size() > 0 ? contractionDims->k.back() : 0;
   auto map1 = linalgOp.getIndexingMapsArray()[1];
   auto index = getAffineBinaryOpExprIndex(map1, k, linalgOp.getContext());
   if (!index)
     return failure();
 
+  // Ensure that the body of the generic operation is mul-add chain
   // clang-format off
   using namespace mlir::structured_match;
   auto hasRightOpChain =

--- a/lib/TPP/Transforms/Vectorization.cpp
+++ b/lib/TPP/Transforms/Vectorization.cpp
@@ -42,7 +42,7 @@ struct LinalgGenericToVector : OpRewritePattern<linalg::GenericOp> {
     if (xsmm::utils::getDataType(rewriter, linalgOp.getOperand(0).getType()) ==
             xsmm::DataTypeAttr::get(rewriter.getContext(),
                                     xsmm::DataType::BF16) &&
-        linalgOp.getIteratorTypes().size() >= 5 &&
+        linalgOp.getIteratorTypes().size() >= 4 &&
         linalgOp.getNumOperands() == 3) {
       SmallVector<int64_t> shape;
       SmallVector<ReassociationIndices> indices;
@@ -72,7 +72,8 @@ struct LinalgGenericToVector : OpRewritePattern<linalg::GenericOp> {
       }
       auto map0 = linalgOp.getIndexingMapsArray()[0];
       auto map1 = linalgOp.getIndexingMapsArray()[1];
-      map0 = map0.insertResult(map1.getResult(map1.getNumResults() - 1), 3);
+      map0 = map0.insertResult(map1.getResult(map1.getNumResults() - 1),
+                               map0.getNumResults());
       int map1Index = map1.getNumResults() - 3;
       AffineExpr expr = map1.getResult(map1Index);
       if (isa<AffineBinaryOpExpr>(expr)) {


### PR DESCRIPTION
This PR fixes the VNNI contract lowering for gemms from linalg generics. There was a bug in the older code which did not consider the gemm iterators which would have size 4: 1 for vnni and 3 others corresponding to gemm. Also, the index setting of map was incorrect for VNNI, it was hardcoded to index 3, but should've been a function of the map's size, which I have changed now. I have left the strided VNNI test be, because it covers a positive VNNI example, although it would've worked with the older code as well. The test non_square_vnni_gemm covers both 4 iterator case, as well as setting the index of the map correctly.