### PR TITLE
Support simple elemntwise tiling on linalg.generic.

### DIFF
--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -61,6 +61,9 @@ def DefaultTppPasses : Pass<"default-tpp-passes", "ModuleOp"> {
     Option<"disableVnniPacking", "disable-vnni-packing",
            "bool", /*default=*/"false",
            "Disables VNNI packing for packed types.">,
+    Option<"disableTileElementwiseOps", "disable-tile-elementwise-ops",
+           "bool", /*default=*/"false",
+           "Disables tiling of elementwise operations.">,
     ListOption<"registerBlocking", "registerBlocking",
            "unsigned", "Register blocking tile sizes for brgemm operation.">,
     ListOption<"gemmUnroll", "gemm-unroll", "int64_t",
@@ -85,7 +88,10 @@ def TppMapping : Pass<"tpp-mapping", "ModuleOp"> {
            "Lower non-constant packs and unpacks reverting any dim permutations.">,
     Option<"disableVnniPacking", "disable-vnni-packing",
            "bool", /*default=*/"false",
-           "Disables VNNI packing for packed types.">
+           "Disables VNNI packing for packed types.">,
+    Option<"disableTileElementwiseOps", "disable-tile-elementwise-ops",
+           "bool", /*default=*/"false",
+           "Disables tiling of elementwise operations.">,
   ];
 }
 

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -363,6 +363,17 @@ def ElementWiseFusion : Pass<"element-wise-fusion", "func::FuncOp"> {
   let summary = "Run linalg element-wise fusion";
 }
 
+def TileElementWiseOps : Pass<"tile-elementwise-ops", "func::FuncOp"> {
+  let summary = "Tile elementwise linalg.generic operations";
+  let description = [{
+    Tile elementwise linalg.generic operations to enable better vectorization.
+  }];
+  let dependentDialects = ["linalg::LinalgDialect", "scf::SCFDialect"];
+  let options = [
+    ListOption<"tileSizes", "tile-sizes", "int64_t", "Tile sizes">,
+  ];
+}
+
 def Bufferize : Pass<"bufferize", "ModuleOp"> {
   let summary = "Bufferize tensor to memref for the entire module";
   let options = [

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -93,6 +93,11 @@ llvm::cl::opt<bool>
                        llvm::cl::desc("Disables VNNI packing for packed types"),
                        llvm::cl::init(false));
 
+llvm::cl::opt<bool> disableTileElementwiseOps(
+    "disable-tile-elementwise-ops",
+    llvm::cl::desc("Disables tiling of elementwise operations"),
+    llvm::cl::init(false));
+
 llvm::cl::list<unsigned> registerBlocking(
     "registerBlocking",
     llvm::cl::desc("Register blocking tile sizes for brgemm operation"),
@@ -184,6 +189,7 @@ private:
       tppDefaultOptions.lowerPackUnpackWithoutTranspose =
           lowerPackUnpackWithoutTranspose;
       tppDefaultOptions.disableVnniPacking = disableVnniPacking;
+      tppDefaultOptions.disableTileElementwiseOps = disableTileElementwiseOps;
       tppDefaultOptions.registerBlocking = SmallVector<unsigned>{
           registerBlocking.begin(), registerBlocking.end()};
       tppDefaultOptions.vectorToKernel = vectorToKernel;

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -155,7 +155,9 @@ private:
         pm.addNestedPass<func::FuncOp>(createBrgemmLinalgTiling(
             BrgemmLinalgTilingOptions{SmallVector<unsigned>{*registerBlocking}}));
         pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
-        pm.addNestedPass<func::FuncOp>(createTileDequantElementwiseOps());
+        // pm.addNestedPass<func::FuncOp>(createTileDequantElementwiseOps());
+        if (!disableTileElementwiseOps)
+          pm.addNestedPass<func::FuncOp>(createTileElementWiseOps());
         pm.addNestedPass<func::FuncOp>(createVectorizationPass());
 
         if (nanoKernel) {

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -155,7 +155,6 @@ private:
         pm.addNestedPass<func::FuncOp>(createBrgemmLinalgTiling(
             BrgemmLinalgTilingOptions{SmallVector<unsigned>{*registerBlocking}}));
         pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
-        // pm.addNestedPass<func::FuncOp>(createTileDequantElementwiseOps());
         if (!disableTileElementwiseOps)
           pm.addNestedPass<func::FuncOp>(createTileElementWiseOps());
         pm.addNestedPass<func::FuncOp>(createVectorizationPass());

--- a/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
@@ -33,6 +33,8 @@ namespace tpp {
 #include "TPP/Passes.h.inc"
 #define GEN_PASS_DEF_ELEMENTWISEFUSION
 #include "TPP/Passes.h.inc"
+#define GEN_PASS_DEF_TILEELEMENTWISEOPS
+#include "TPP/Passes.h.inc"
 } // namespace tpp
 } // namespace mlir
 
@@ -793,6 +795,91 @@ struct ElementWiseFusion : tpp::impl::ElementWiseFusionBase<ElementWiseFusion> {
     linalg::populateElementwiseOpsFusionPatterns(patterns,
                                                  fuseElementwiseOpsControlFn);
     (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+// Define an element-wise tiling pass on a linalg.generic op with parallel
+// iterators.
+struct TileElementWiseOps
+    : tpp::impl::TileElementWiseOpsBase<TileElementWiseOps> {
+  using TileElementWiseOpsBase::TileElementWiseOpsBase;
+
+  void runOnOperation() override {
+    auto &ctx = getContext();
+    RewritePatternSet patterns(&ctx);
+
+    // Define a pattern of linalg.generic op with parallel iterators on which we
+    // want to apply tiling.
+    struct TileElementwiseGenericPattern
+        : public OpRewritePattern<linalg::GenericOp> {
+      TileElementWiseOps *pass;
+      TileElementwiseGenericPattern(MLIRContext *context,
+                                    TileElementWiseOps *pass)
+          : OpRewritePattern<linalg::GenericOp>(context), pass(pass) {
+        this->setHasBoundedRewriteRecursion(true);
+      }
+      LogicalResult matchAndRewrite(linalg::GenericOp op,
+                                    PatternRewriter &rewriter) const override {
+        if (!llvm::all_of(op.getIteratorTypesArray(), [](auto it) {
+              return linalg::isParallelIterator(it);
+            }))
+          return rewriter.notifyMatchFailure(
+              op, "Only tiles linalg.generic with parallel iterators");
+
+        // Exit if no non-terminating operations in the body (e.g., just a
+        // yield)
+        Block &body = op.getRegion().front();
+        if (body.without_terminator().empty())
+          return rewriter.notifyMatchFailure(
+              op, "No non-terminating operations in the body");
+
+        auto bodyOps = body.without_terminator();
+        if (llvm::hasSingleElement(bodyOps) &&
+            isa<arith::AddFOp>(*bodyOps.begin()))
+          return rewriter.notifyMatchFailure(
+              op, "Dont tile linalg.generic with single addf in the body, as "
+                  "it is likely a reduction");
+
+        // Exit for Op without inputs.
+        if (op.getDpsInputs().empty())
+          return rewriter.notifyMatchFailure(op,
+                                             "May be a reduction, no inputs");
+
+        // Derive the tile sizes for the elementwise op using the output shape.
+        // Tile the outer dimension with 1 and inner dimension with the inner
+        // dimension size of the output shape.
+        auto outputType = cast<ShapedType>(op.getDpsInits()[0].getType());
+        auto outputShape = outputType.getShape();
+        if (outputType.getRank() != 2)
+          return rewriter.notifyMatchFailure(
+              op,
+              "Only tiles linalg.generic with parallel iterators of rank 2");
+
+        SmallVector<int64_t> tileSizes{1, outputShape[1]};
+        linalg::LinalgTilingOptions options;
+        options.setLoopType(linalg::LinalgTilingLoopType::Loops);
+        if (pass->tileSizes.size() == 0)
+          pass->tileSizes = tileSizes;
+        options.setTileSizes(pass->tileSizes);
+        FailureOr<linalg::TiledLinalgOp> tiled =
+            linalg::tileLinalgOp(rewriter, op, options);
+
+        if (failed(tiled))
+          return rewriter.notifyMatchFailure(
+              op, "Failed to tile linalg.generic with parallel iterators");
+
+        rewriter.replaceOp(op, tiled->tensorResults);
+        return success();
+      }
+    };
+
+    mlir::GreedyRewriteConfig config;
+    // Limit to exactly 1 successful matchAndRewrite
+    config.setMaxNumRewrites(1);
+    config.setStrictness(GreedyRewriteStrictness::ExistingOps);
+
+    patterns.add<TileElementwiseGenericPattern>(&ctx, this);
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
   }
 };
 

--- a/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
+++ b/lib/TPP/Transforms/TileConsumerAndFuseProducers.cpp
@@ -820,11 +820,9 @@ struct TileElementWiseOps
       }
       LogicalResult matchAndRewrite(linalg::GenericOp op,
                                     PatternRewriter &rewriter) const override {
-        if (!llvm::all_of(op.getIteratorTypesArray(), [](auto it) {
-              return linalg::isParallelIterator(it);
-            }))
+        if (!isElementwise(op))
           return rewriter.notifyMatchFailure(
-              op, "Only tiles linalg.generic with parallel iterators");
+              op, "Only tiles linalg.generic with elementwise semantics");
 
         // Exit if no non-terminating operations in the body (e.g., just a
         // yield)
@@ -834,11 +832,9 @@ struct TileElementWiseOps
               op, "No non-terminating operations in the body");
 
         auto bodyOps = body.without_terminator();
-        if (llvm::hasSingleElement(bodyOps) &&
-            isa<arith::AddFOp>(*bodyOps.begin()))
+        if (llvm::hasSingleElement(bodyOps))
           return rewriter.notifyMatchFailure(
-              op, "Dont tile linalg.generic with single addf in the body, as "
-                  "it is likely a reduction");
+              op, "Dont tile linalg.generic with single op in the body.");
 
         // Exit for Op without inputs.
         if (op.getDpsInputs().empty())

--- a/test/I8/Integration/amx/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
+++ b/test/I8/Integration/amx/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
@@ -5,12 +5,12 @@
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
 // IR-COUNT-4: amx.tile_muli
+
 // IR: scf.for
-// IR:   memref.load
-// IR:   vector.broadcast
-// IR:   arith.extf
-// IR:   scf.for
 // IR-COUNT-2:     vector.transfer_read
+// IR: vector.broadcast
+// IR-COUNT-1:     vector.transfer_read
+// IR: vector.shape_cast
 // IR:     arith.extf
 // IR:     arith.mulf
 // IR:     arith.sitofp

--- a/test/I8/Integration/amx/tpp-run-gemm-dequantize-correctness-i8-f32.mlir
+++ b/test/I8/Integration/amx/tpp-run-gemm-dequantize-correctness-i8-f32.mlir
@@ -36,11 +36,12 @@
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
 // IR-COUNT-4: amx.tile_muli
+
 // IR: scf.for
-// IR:   memref.load
-// IR:   vector.broadcast
-// IR:   scf.for
-// IR:     vector.transfer_read
+// IR-COUNT-2:     vector.transfer_read
+// IR: vector.broadcast
+// IR-COUNT-1:     vector.transfer_read
+// IR: vector.shape_cast
 // IR:     arith.mulf
 // IR:     arith.sitofp
 // IR:     arith.mulf

--- a/test/Passes/tile-elementwise-ops.mlir
+++ b/test/Passes/tile-elementwise-ops.mlir
@@ -1,0 +1,181 @@
+// RUN: tpp-opt %s -tile-elementwise-ops -split-input-file | FileCheck %s
+// RUN: tpp-opt %s -tile-elementwise-ops="tile-sizes=4,8" -split-input-file | FileCheck %s --check-prefix=CUSTOM
+
+// -----
+// Test 1: Basic 2D elementwise op gets tiled with default sizes [1, N]
+// where N is the inner dimension of the output shape.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @tile_basic_elementwise(%arg0: tensor<32x64xf32>,
+                                   %arg1: tensor<32x64xf32>,
+                                   %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0, %arg1 : tensor<32x64xf32>, tensor<32x64xf32>)
+    outs(%arg2 : tensor<32x64xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %m = arith.mulf %a, %b : f32
+    %r = arith.addf %m, %c : f32
+    linalg.yield %r : f32
+  } -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @tile_basic_elementwise
+// CHECK:         scf.for %{{.*}} = %c0 to %c32 step %c1
+// CHECK:           tensor.extract_slice {{.*}} [1, 64]
+// CHECK:           linalg.generic
+// CHECK-SAME:        ins({{.*}} : tensor<1x64xf32>, tensor<1x64xf32>)
+// CHECK-SAME:        outs({{.*}} : tensor<1x64xf32>)
+// CHECK:             arith.mulf
+// CHECK:             arith.addf
+// CHECK:           tensor.insert_slice
+
+// CUSTOM-LABEL: func.func @tile_basic_elementwise
+// CUSTOM:         scf.for %{{.*}} step %c4
+// CUSTOM:           scf.for %{{.*}} step %c8
+// CUSTOM:             linalg.generic
+// CUSTOM-SAME:          ins({{.*}} : tensor<4x8xf32>, tensor<4x8xf32>)
+
+// -----
+
+// Test 2: Single-op body (e.g., just yield of an arg) should NOT be tiled.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @no_tile_single_op_body(%arg0: tensor<32x64xf32>,
+                                   %arg1: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%arg0 : tensor<32x64xf32>)
+    outs(%arg1 : tensor<32x64xf32>) {
+  ^bb0(%a: f32, %c: f32):
+    linalg.yield %a : f32
+  } -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_single_op_body
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic
+// CHECK-SAME:      ins({{.*}} : tensor<32x64xf32>) outs({{.*}} : tensor<32x64xf32>)
+
+// -----
+
+// Test 3: Op with reduction iterator should NOT be tiled (not elementwise).
+
+#mapA = affine_map<(d0, d1, d2) -> (d0, d2)>
+#mapB = affine_map<(d0, d1, d2) -> (d2, d1)>
+#mapC = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @no_tile_reduction(%arg0: tensor<32x64xf32>,
+                              %arg1: tensor<64x16xf32>,
+                              %arg2: tensor<32x16xf32>) -> tensor<32x16xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#mapA, #mapB, #mapC],
+    iterator_types = ["parallel", "parallel", "reduction"]
+  } ins(%arg0, %arg1 : tensor<32x64xf32>, tensor<64x16xf32>)
+    outs(%arg2 : tensor<32x16xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %m = arith.mulf %a, %b : f32
+    %r = arith.addf %m, %c : f32
+    linalg.yield %r : f32
+  } -> tensor<32x16xf32>
+  return %0 : tensor<32x16xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_reduction
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "reduction"]
+
+// -----
+
+// Test 4: Op without inputs should NOT be tiled.
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @no_tile_no_inputs(%arg0: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  %cst = arith.constant 1.0 : f32
+  %0 = linalg.generic {
+    indexing_maps = [#map],
+    iterator_types = ["parallel", "parallel"]
+  } outs(%arg0 : tensor<32x64xf32>) {
+  ^bb0(%c: f32):
+    linalg.yield %cst : f32
+  } -> tensor<32x64xf32>
+  return %0 : tensor<32x64xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_no_inputs
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic
+
+// -----
+
+// Test 5: 3D elementwise op should NOT be tiled (rank != 2).
+
+#map3d = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+func.func @no_tile_3d(%arg0: tensor<4x32x64xf32>,
+                       %arg1: tensor<4x32x64xf32>) -> tensor<4x32x64xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map3d, #map3d],
+    iterator_types = ["parallel", "parallel", "parallel"]
+  } ins(%arg0 : tensor<4x32x64xf32>)
+    outs(%arg1 : tensor<4x32x64xf32>) {
+  ^bb0(%a: f32, %c: f32):
+    %r = math.exp %a : f32
+    linalg.yield %r : f32
+  } -> tensor<4x32x64xf32>
+  return %0 : tensor<4x32x64xf32>
+}
+
+// CHECK-LABEL: func.func @no_tile_3d
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.generic {{.*}}iterator_types = ["parallel", "parallel", "parallel"]
+
+// -----
+
+// Test 6: Dequantization-like elementwise pattern (multi-op body) should be tiled.
+// Mimics the i8 dequant pattern: combined_scale * sitofp(dot)
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#mapR = affine_map<(d0, d1) -> (d0)>
+#mapC = affine_map<(d0, d1) -> (d1)>
+
+func.func @tile_dequant_eltwise(%dot: tensor<128x768xi32>,
+                                 %iScale: tensor<128xf32>,
+                                 %wScale: tensor<768xf32>,
+                                 %out: tensor<128x768xf32>) -> tensor<128x768xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [#map, #mapR, #mapC, #map],
+    iterator_types = ["parallel", "parallel"]
+  } ins(%dot, %iScale, %wScale
+        : tensor<128x768xi32>, tensor<128xf32>, tensor<768xf32>)
+    outs(%out : tensor<128x768xf32>) {
+  ^bb0(%d: i32, %is: f32, %ws: f32, %o: f32):
+    %c = arith.mulf %is, %ws : f32
+    %f = arith.sitofp %d : i32 to f32
+    %r = arith.mulf %f, %c : f32
+    linalg.yield %r : f32
+  } -> tensor<128x768xf32>
+  return %0 : tensor<128x768xf32>
+}
+
+// CHECK-LABEL: func.func @tile_dequant_eltwise
+// CHECK:         scf.for %{{.*}} = %c0 to %c128 step %c1
+// CHECK:           linalg.generic
+// CHECK-SAME:        outs({{.*}} : tensor<1x768xf32>)
+// CHECK:             arith.mulf
+// CHECK:             arith.sitofp
+// CHECK:             arith.mulf
+
+// CUSTOM-LABEL: func.func @tile_dequant_eltwise
+// CUSTOM:         scf.for %{{.*}} step %c4
+// CUSTOM:           scf.for %{{.*}} step %c8
+// CUSTOM:             linalg.generic
+// CUSTOM-SAME:          outs({{.*}} : tensor<4x8xf32>)
+


### PR DESCRIPTION
Element wise operations on bigger tensor shapes results in bad code generation with inserts/extracts and spill. This pass tries to tile such operation so that backend could produce nice compact code without spills.