### PR TITLE
[mlir-gen]: Use output argument tensor instead of empty tensor.

### DIFF
--- a/test/Integration/mlir-gen-matmul.mlir
+++ b/test/Integration/mlir-gen-matmul.mlir
@@ -96,10 +96,7 @@
 // MXBF16-CONTRACT-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xbf16>,
 // MXBF16-CONTRACT-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xbf16>,
 // MXBF16-CONTRACT-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32> {
-// MXBF16-CONTRACT:           %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f32
-// MXBF16-CONTRACT:           %[[VAL_1:.*]] = tensor.empty() : tensor<2x16x64x48xf32>
-// MXBF16-CONTRACT:           %[[VAL_2:.*]] = linalg.fill ins(%[[VAL_0]] : f32) outs(%[[VAL_1]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
-// MXBF16-CONTRACT:           %[[VAL_3:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xbf16>, tensor<16x36x64x48xbf16>) outs(%[[VAL_2]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
+// MXBF16-CONTRACT:           %[[VAL_3:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xbf16>, tensor<16x36x64x48xbf16>) outs(%[[ARG2]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
 // MXBF16-CONTRACT:           return %[[VAL_3]] : tensor<2x16x64x48xf32>
 // MXBF16-CONTRACT:         }
 
@@ -142,10 +139,7 @@
 // MXF16-CONTRACT-SAME:                     %[[ARG0:.*]]: tensor<2x36x64x64xf16>,
 // MXF16-CONTRACT-SAME:                     %[[ARG1:.*]]: tensor<16x36x64x48xf16>,
 // MXF16-CONTRACT-SAME:                     %[[ARG2:.*]]: tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32> {
-// MXF16-CONTRACT:           %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f32
-// MXF16-CONTRACT:           %[[VAL_1:.*]] = tensor.empty() : tensor<2x16x64x48xf32>
-// MXF16-CONTRACT:           %[[VAL_2:.*]] = linalg.fill ins(%[[VAL_0]] : f32) outs(%[[VAL_1]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
-// MXF16-CONTRACT:           %[[VAL_3:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xf16>, tensor<16x36x64x48xf16>) outs(%[[VAL_2]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
+// MXF16-CONTRACT:           %[[VAL_3:.*]] = linalg.contract indexing_maps = [#[[$ATTR_0]], #[[$ATTR_1]], #[[$ATTR_2]]] ins(%[[ARG0]], %[[ARG1]] : tensor<2x36x64x64xf16>, tensor<16x36x64x48xf16>) outs(%[[ARG2]] : tensor<2x16x64x48xf32>) -> tensor<2x16x64x48xf32>
 // MXF16-CONTRACT:           return %[[VAL_3]] : tensor<2x16x64x48xf32>
 // MXF16-CONTRACT:         }
 

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -605,10 +605,6 @@ Value MLIRGenerator::lowerMatmul(LayerArgs &args, bool hasMixedType = false) {
       TensorType intAccumulatorType =
           RankedTensorType::get(shape, builder.getIntegerType(32));
       output = getZeroInitTensor(intAccumulatorType);
-    } else if (elementType.isBF16() || elementType.isF16()) {
-      output = getZeroInitTensor(cast<TensorType>(outputType));
-    } else {
-      llvm_unreachable("Unsupported dequantization data type");
     }
   }
 


### PR DESCRIPTION
For 16-bit float, we don't need temporary empty tensor accumulator, instead we have to use the output tensor argument. This patch removes the generation of empty tensor and utilize output tensor argument.