### PR TITLE
[tpp-run]: Support cache nuke using buffer replication.

### DIFF
--- a/include/TPP/PassBundles.td
+++ b/include/TPP/PassBundles.td
@@ -251,4 +251,26 @@ def X86Vectorizer : Pass<"x86-vectorizer", "ModuleOp"> {
   ];
 }
 
+def LowerToLLVMPipeline : Pass<"lower-to-llvm-pipeline", "ModuleOp"> {
+  let summary = "Lower memref-level IR to LLVM dialect";
+  let description = [{
+    A collection of passes after DefaultTppPasses from DefaultPipeline
+    that perform partial lowering (memref expansion, linalg to loops,
+    vector to SCF, etc.) and then convert to LLVM dialect.
+
+    This modularization of pass pipeline is required for cache nuking
+    purpose only to avoid memory allocation and copies inside perf loop.
+
+    This pass is designed to run after bufferization for Cache nuking
+    to support buffer replication pass which expects the kernel function
+    arguments as memrefs allowing TppRunWrapper pass to be inserted
+    between DefaultTppPasses and this lowering pipeline.
+  }];
+  let options = [
+    Option<"enableParallel", "parallel",
+           "bool", /*default=*/"false",
+           "Enable parallel execution via OpenMP.">,
+  ];
+}
+
 #endif // TPP_DIALECT_TPP_PASSBUNDLES

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -602,6 +602,33 @@ def TppRunnerWrapper : Pass<"tpp-runner-wrapper", "ModuleOp">{
   ];
 }
 
+def ReplicateBuffersForBenchmark : Pass<"replicate-buffers-benchmark", "ModuleOp"> {
+  let summary = "Replicate buffers for cold-cache benchmarking";
+  let description = [{
+    Creates multiple copies of input/output buffers to exceed L3 cache,
+    then iterates through all copies. This ensures cold-cache conditions
+    for accurate GEMM benchmarking.
+
+    The pass finds global memrefs created by TppRunnerWrapper and:
+    1. Allocates separate buffers.
+    2. Replicates the kernel calls using the separate buffers.
+
+    When numLayers=-1 (default), automatically calculates the number of
+    layers needed to reach ~5GB working set size.
+  }];
+  let dependentDialects = ["func::FuncDialect",
+                           "memref::MemRefDialect",
+                           "arith::ArithDialect"];
+  let options = [
+    Option<"numLayers", "num-layers", "int64_t",
+            /*default=*/"-1",
+           "Number of buffer copies. -1 = auto-calculate for ~5GB working set.">,
+    Option<"targetWorkingSetGB", "target-gb", "double",
+            /*default=*/"5.0",
+           "Target working set size in GB for auto-calculation.">
+  ];
+}
+
 def LinalgToXeGPU : Pass<"linalg-to-xegpu", "func::FuncOp"> {
   let summary = "Convert linalg dialect to XeGPU dialect.";
   let description = [{

--- a/include/TPP/Transforms/Utils/TensorInit.h
+++ b/include/TPP/Transforms/Utils/TensorInit.h
@@ -51,9 +51,17 @@ template <typename T> struct TensorInit : public ITensorInit {
 
     // For some reason, memref global op needs dense tensor type
     // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
-    auto tensorType =
-        mlir::RankedTensorType::get(shape.getShape(), shape.getElementType());
-    return mlir::DenseElementsAttr::get(tensorType, buffer);
+    mlir::ShapedType attrType;
+    if (mlir::isa<mlir::MemRefType, mlir::TensorType>(shape)) {
+      attrType =
+          mlir::RankedTensorType::get(shape.getShape(), shape.getElementType());
+    } else {
+      // Fixes this error "'arith.constant' op failed to verify that all of
+      // {value, result} have same type" as there is no need to convert it to
+      // ranked TensorType.
+      attrType = shape;
+    }
+    return mlir::DenseElementsAttr::get(attrType, buffer);
   }
 
 protected:

--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_library(TPPPipeline
   DefaultPipeline.cpp
   DefaultTppPasses.cpp
   LoadTppDialects.cpp
+  LowerToLLVMPipeline.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/TPP

--- a/lib/TPP/LowerToLLVMPipeline.cpp
+++ b/lib/TPP/LowerToLLVMPipeline.cpp
@@ -1,0 +1,126 @@
+//===- LowerToLLVMPipeline.cpp -----------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the LowerToLLVMPipeline pass bundle, which performs
+// partial lowering and LLVM dialect conversion. This pass is designed to run
+// after bufferization (e.g., after DefaultTppPasses), allowing wrapper passes
+// to be inserted between tensor-to-memref conversion and final LLVM lowering.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/PassBundles.h"
+#include "TPP/PassUtils.h"
+#include "TPP/Passes.h"
+
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Async/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::tpp;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_LOWERTOLLVMPIPELINE
+#include "TPP/PassBundles.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+// The lowering pipeline from memref-level IR to LLVM dialect.
+struct LowerToLLVMPipeline
+    : public tpp::impl::LowerToLLVMPipelineBase<LowerToLLVMPipeline>,
+      PassBundle<ModuleOp> {
+  using LowerToLLVMPipelineBase::LowerToLLVMPipelineBase;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    // Add all core MLIR dialects as this pipeline may touch many.
+    registerAllDialects(registry);
+  }
+
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    // Initialize the pipeline if needed.
+    // Otherwise, just run the cached one.
+    if (pm.empty())
+      constructPipeline();
+
+    if (failed(runPipeline(pm, module)))
+      return signalPassFailure();
+  }
+
+private:
+  void constructPipeline() override {
+    // Lower TPP-specific dialects (perf, check, xsmm) before partial lowering.
+    // This is needed when wrapper passes (e.g., TppRunnerWrapper) are run
+    // after DefaultTppPasses but create perf ops that need lowering.
+    pm.addPass(createLocalDialectsLowering());
+
+    // Partial Lowering
+    pm.addPass(memref::createExpandStridedMetadataPass());
+    pm.addPass(createConvertTensorToLinalgPass());
+    pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+    if (enableParallel)
+      pm.addPass(createConvertSCFToOpenMPPass());
+    pm.addPass(createConvertVectorToSCFPass());
+    mlir::arith::ArithExpandOpsPassOptions arithExpandOpsOptions;
+    arithExpandOpsOptions.includeF8E8M0 = true;
+    pm.addPass(arith::createArithExpandOpsPass(arithExpandOpsOptions));
+    pm.addPass(createLowerAffinePass());
+
+    // Lower to LLVM
+    ConvertVectorToLLVMPassOptions options;
+#if defined(__x86_64__)
+    options.x86 = true;
+#endif
+    pm.addPass(createConvertVectorToLLVMPass(options));
+    pm.addPass(createFinalizeMemRefToLLVMConversionPass());
+    pm.addPass(createSCFToControlFlowPass());
+
+    pm.addNestedPass<func::FuncOp>(createGpuAsyncRegionPass());
+    pm.addPass(createGpuToLLVMConversionPass());
+    GpuModuleToBinaryPassOptions gpuModuleToBinaryPassOptions;
+    gpuModuleToBinaryPassOptions.compilationTarget = "fatbin";
+    pm.addPass(createGpuModuleToBinaryPass(gpuModuleToBinaryPassOptions));
+    pm.addPass(createConvertMathToLLVMPass());
+    pm.addPass(createAsyncToAsyncRuntimePass());
+    pm.addPass(createAsyncRuntimeRefCountingPass());
+    pm.addPass(createConvertAsyncToLLVMPass());
+    pm.addPass(createConvertIndexToLLVMPass());
+
+    pm.addPass(createConvertFuncToLLVMPass());
+
+    pm.addPass(createArithToLLVMConversionPass());
+    pm.addPass(createConvertControlFlowToLLVMPass());
+    if (enableParallel)
+      pm.addPass(createConvertOpenMPToLLVMPass());
+    pm.addPass(createUBToLLVMConversionPass());
+    pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
+    pm.addPass(createReconcileUnrealizedCastsPass());
+
+    // Anything useful has been lowered by now.
+    // Cleanup IR by removing any dead symbols.
+    // This step aims to avoid errors caused by frontend leftovers.
+    // See issue: #704
+    pm.addPass(createSymbolDCEPass());
+  }
+};
+
+} // namespace

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -243,7 +243,8 @@ LogicalResult MLIRBench::createKernelArgs() {
 
     // For quantized kernels output arguments, make the init type normal.
     auto funcType = kernel.getFunctionType();
-    auto numOutputs = funcType.getNumResults();
+    // For memref arguments in cache-nuke path, set numOutputs to 1.
+    auto numOutputs = isa<MemRefType>(argTy) ? 1 : funcType.getNumResults();
     if (kernel.getArgumentTypes().size() - numOutputs ==
             static_cast<size_t>(argNum) &&
         argInitType == TensorInitType::Quant) {

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_library(TPPTransforms
   LinalgDeGeneralize.cpp
   LowerPacksAndUnpacks.cpp
   LowerPacksAndUnpacksWithoutTranspose.cpp
+  ReplicateBuffersForBenchmark.cpp
   RewriteBatchMatmulToMatmul.cpp
   RewriteToBatchReduceGemm.cpp
   TileConsumerAndFuseProducers.cpp

--- a/lib/TPP/Transforms/ReplicateBuffersForBenchmark.cpp
+++ b/lib/TPP/Transforms/ReplicateBuffersForBenchmark.cpp
@@ -1,0 +1,306 @@
+//===------------ ReplicateBuffersForBenchmark.cpp ---------------*- C++-*-===//
+//
+// This pass replicates buffers for cold-cache benchmarking.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Dialect/Perf/PerfOps.h"
+#include "TPP/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_REPLICATEBUFFERSFORBENCHMARK
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+/// Calculate the total size in bytes of a memref type.
+static int64_t getMemRefSizeBytes(MemRefType memrefType) {
+  if (!memrefType.hasStaticShape())
+    return -1;
+
+  int64_t numElements = 1;
+  for (int64_t dim : memrefType.getShape())
+    numElements *= dim;
+
+  unsigned elementBits = memrefType.getElementTypeBitWidth();
+  return numElements * (elementBits / 8);
+}
+
+// MemRef-based replication using SEPARATE ALLOCATIONS per layer.
+struct ReplicateBuffersForBenchmark
+    : public tpp::impl::ReplicateBuffersForBenchmarkBase<
+          ReplicateBuffersForBenchmark> {
+  using ReplicateBuffersForBenchmarkBase::ReplicateBuffersForBenchmarkBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    // Find the wrapper function created by TppRunnerWrapper.
+    // It uses __wrapper_* global memrefs and calls a renamed kernel (_name).
+    func::FuncOp mainFunc = nullptr;
+    for (auto func : module.getOps<func::FuncOp>()) {
+      // The wrapper function uses global memrefs with __wrapper_ prefix.
+      bool hasWrapperGlobals = false;
+      func.walk([&](memref::GetGlobalOp getGlobal) {
+        if (getGlobal.getName().starts_with("__wrapper_")) {
+          hasWrapperGlobals = true;
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      
+      if (hasWrapperGlobals) {
+        mainFunc = func;
+        break;
+      }
+    }
+
+    if (!mainFunc) {
+      // No wrapper function found - pass is a no-op.
+      emitError(module.getLoc(),
+                "No wrapper function with __wrapper_ globals found");
+      return signalPassFailure();
+    }
+
+    // Collect global memrefs used in main (TppRunnerWrapper creates these).
+    SmallVector<memref::GetGlobalOp> globalGetOps;
+    SmallVector<memref::GlobalOp> globalOps;
+    DenseMap<StringRef, memref::GlobalOp> globalMap;
+
+    // Build map of global memrefs.
+    for (auto globalOp : module.getOps<memref::GlobalOp>()) {
+      globalMap[globalOp.getName()] = globalOp;
+    }
+
+    // Find all memref.get_global ops in main.
+    mainFunc.walk([&](memref::GetGlobalOp getGlobal) {
+      auto it = globalMap.find(getGlobal.getName());
+      if (it != globalMap.end()) {
+        globalGetOps.push_back(getGlobal);
+        globalOps.push_back(it->second);
+      }
+    });
+
+    if (globalGetOps.empty()) {
+      // No global memrefs to replicate.
+      emitError(module.getLoc(), "No global memrefs found in wrapper function");
+      return signalPassFailure();
+    }
+
+    // Calculate total buffer size.
+    int64_t totalBytesPerLayer = 0;
+    int64_t totalBytes = 0;
+    for (auto globalOp : globalOps) {
+      auto memrefType = cast<MemRefType>(globalOp.getType());
+      int64_t size = getMemRefSizeBytes(memrefType);
+      if (size < 0) {
+        emitError(globalOp.getLoc(),
+                  "Cannot compute size for dynamic memref, skipping");
+        return signalPassFailure();
+      }
+      totalBytesPerLayer += size;
+    }
+
+    if (totalBytesPerLayer == 0) {
+      emitError(module.getLoc(),
+                "Total buffer size is zero, nothing to replicate");
+      return signalPassFailure();
+    }
+
+    // Calculate effective number of layers.
+    int64_t effectiveNumLayers = numLayers;
+    if (numLayers == -1) {
+      int64_t targetBytes =
+          static_cast<int64_t>(targetWorkingSetGB * 1024 * 1024 * 1024);
+      while (totalBytes < targetBytes) {
+        effectiveNumLayers++;
+        totalBytes = totalBytesPerLayer * effectiveNumLayers;
+      }
+    }
+
+    if (effectiveNumLayers <= 1) {
+      emitError(
+          module.getLoc(),
+          "Effective number of layers is 1 or less, no replication needed");
+      return signalPassFailure();
+    }
+
+    // Find the benchmark perf.bench operation (the one with most iterations).
+    // TppRunnerWrapper creates warmup (small iter count) and benchmark (large iter count).
+    perf::BenchOp benchmarkOp = nullptr;
+    int64_t maxIters = 0;
+    mainFunc.walk([&](perf::BenchOp benchOp) {
+      // Try to get the iteration count as a constant.
+      if (auto numIters = benchOp.getNumIters()) {
+        if (auto constOp = numIters.getDefiningOp<arith::ConstantOp>()) {
+          if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue())) {
+            int64_t iters = intAttr.getInt();
+            if (iters > maxIters) {
+              maxIters = iters;
+              benchmarkOp = benchOp;
+            }
+          }
+        }
+      }
+    });
+
+    // Find the kernel call - either inside benchmark perf.bench or standalone.
+    func::CallOp kernelCall = nullptr;
+    Operation *searchRegion = benchmarkOp ? benchmarkOp.getOperation() : mainFunc.getOperation();
+    searchRegion->walk([&](func::CallOp call) {
+      // The kernel call is typically not "main"/"entry" and not a built-in.
+      StringRef callee = call.getCallee();
+      if (callee != "main" && callee != "_mlir_ciface_main" &&
+          callee != "entry" && callee.starts_with("_")) {
+        // Renamed kernel functions start with "_" (e.g., "_entry").
+        if (!kernelCall) {
+          kernelCall = call;
+        }
+      }
+    });
+
+    if (!kernelCall) {
+      emitWarning(mainFunc.getLoc(), "No kernel call found in main");
+      return signalPassFailure();
+    }
+
+    // Map from original GetGlobalOp results to their GlobalOp.
+    DenseMap<Value, memref::GlobalOp> valueToGlobal;
+    for (size_t i = 0; i < globalGetOps.size(); ++i) {
+      Value getGlobalResult = globalGetOps[i].getResult();
+      valueToGlobal[getGlobalResult] = globalOps[i];
+    }
+
+    // Find which kernel arguments come from global memrefs.
+    SmallVector<std::pair<unsigned, memref::GlobalOp>> argsFromGlobals;
+    for (unsigned i = 0; i < kernelCall.getNumOperands(); ++i) {
+      Value arg = kernelCall.getOperand(i);
+      auto it = valueToGlobal.find(arg);
+      if (it != valueToGlobal.end()) {
+        argsFromGlobals.push_back({i, it->second});
+      }
+    }
+
+    if (argsFromGlobals.empty()) {
+      emitWarning(kernelCall.getLoc(),
+                  "No kernel arguments sourced from global memrefs");
+      return signalPassFailure();
+    }
+
+    // Now transform the IR.
+    OpBuilder builder(module.getContext());
+    Location loc = kernelCall.getLoc();
+
+    // Insert allocations at the beginning.
+    builder.setInsertionPointToStart(&mainFunc.getBody().front());
+
+    // Track allocations for cleanup.
+    SmallVector<Value> allocsToDealloc;
+
+    // Map from globalOp to vector of allocated memrefs (one per layer).
+    DenseMap<memref::GlobalOp, SmallVector<Value>> globalToLayerMemRefs;
+
+    // First pass: create separate allocations for each layer (unrolled).
+    Operation *insertBeforeBench =
+        benchmarkOp ? benchmarkOp.getOperation() : kernelCall.getOperation();
+    builder.setInsertionPoint(insertBeforeBench);
+
+    for (auto &[argIdx, globalOp] : argsFromGlobals) {
+      if (globalToLayerMemRefs.count(globalOp))
+        continue;
+
+      auto origMemRefType = cast<MemRefType>(globalOp.getType());
+
+      // Allocate each layer separately.
+      SmallVector<Value> layerMemRefs;
+      for (int64_t layer = 0; layer < effectiveNumLayers; ++layer) {
+        auto layerAlloc = memref::AllocOp::create(builder, loc, origMemRefType);
+        layerMemRefs.push_back(layerAlloc);
+        allocsToDealloc.push_back(layerAlloc);
+      }
+      globalToLayerMemRefs[globalOp] = std::move(layerMemRefs);
+    }
+
+    // Insert unrolled kernel calls INSIDE the benchmark region.
+    builder.setInsertionPoint(kernelCall);
+
+    // Unrolled layer calls.
+    for (int64_t layer = 0; layer < effectiveNumLayers; ++layer) {
+      // Build new operands using the layer's memrefs.
+      SmallVector<Value> newOperands;
+      for (unsigned i = 0; i < kernelCall.getNumOperands(); ++i) {
+        Value origArg = kernelCall.getOperand(i);
+
+        auto globalIt = valueToGlobal.find(origArg);
+        if (globalIt == valueToGlobal.end()) {
+          newOperands.push_back(origArg);
+          continue;
+        }
+        auto layerMemRefsIt = globalToLayerMemRefs.find(globalIt->second);
+        if (layerMemRefsIt == globalToLayerMemRefs.end()) {
+          newOperands.push_back(origArg);
+          continue;
+        }
+
+        // Use this layer's memref directly.
+        newOperands.push_back(layerMemRefsIt->second[layer]);
+      }
+
+      // Kernel call for this layer.
+      func::CallOp::create(builder, loc, kernelCall.getCallee(),
+                           kernelCall.getResultTypes(), newOperands);
+    }
+
+    // Erase the original kernel call.
+    kernelCall.erase();
+
+    // Adjust timing computation: divide by (iterations * numLayers) instead
+    // of just iterations.We need to multiply the divisor by numLayers.
+    if (benchmarkOp && effectiveNumLayers > 1) {
+      Value benchResult = benchmarkOp.getResult(0);
+
+      // Find the divf that uses the bench result.
+      for (Operation *user : benchResult.getUsers()) {
+        if (auto divOp = dyn_cast<arith::DivFOp>(user)) {
+          // Get the divisor (iterations converted to f64).
+          Value divisor = divOp.getRhs();
+
+          // Insert multiplication: divisor * numLayers
+          builder.setInsertionPoint(divOp);
+          auto f64Type = builder.getF64Type();
+          auto numLayersF64 = arith::ConstantFloatOp::create(
+              builder, loc, f64Type,
+              APFloat(static_cast<double>(effectiveNumLayers)));
+          auto newDivisor =
+              arith::MulFOp::create(builder, loc, divisor, numLayersF64);
+
+          // Update the divf to use the new divisor.
+          divOp.setOperand(1, newDivisor);
+          break;
+        }
+      }
+    }
+
+    // Add deallocations for memref-based allocations before the return.
+    if (!allocsToDealloc.empty()) {
+      func::ReturnOp returnOp = nullptr;
+      mainFunc.walk([&](func::ReturnOp op) { returnOp = op; });
+      if (returnOp) {
+        builder.setInsertionPoint(returnOp);
+        for (Value alloc : allocsToDealloc) {
+          memref::DeallocOp::create(builder, loc, alloc);
+        }
+      }
+    }
+  }
+};
+
+} // namespace

--- a/test/Passes/replicate-buffers-benchmark.mlir
+++ b/test/Passes/replicate-buffers-benchmark.mlir
@@ -1,0 +1,136 @@
+// RUN: tpp-opt %s -replicate-buffers-benchmark="num-layers=2" --split-input-file | FileCheck %s
+// RUN: tpp-opt %s -replicate-buffers-benchmark="num-layers=2" --split-input-file | FileCheck %s --check-prefix=BF16
+
+module {
+  memref.global "private" @__wrapper_4 : memref<2x2x32x32xf32> = dense<0.0> {alignment = 128 : i64}
+  memref.global "private" @__wrapper_3 : memref<64xf32> = dense<1.0> {alignment = 128 : i64}
+  memref.global "private" @__wrapper_2 : memref<2x2x16x32x4xi8> = dense<1> {alignment = 128 : i64}
+  memref.global "private" @__wrapper_1 : memref<64xf32> = dense<1.0> {alignment = 128 : i64}
+  memref.global "private" @__wrapper_0 : memref<2x2x32x64xi8> = dense<1> {alignment = 128 : i64}
+
+  func.func @_entry(%arg0: memref<2x2x32x64xi8>, %arg1: memref<64xf32>,
+                    %arg2: memref<2x2x16x32x4xi8>, %arg3: memref<64xf32>,
+                    %arg4: memref<2x2x32x32xf32>) {
+    return
+  }
+
+  func.func @entry() {
+    %0 = memref.get_global @__wrapper_0 : memref<2x2x32x64xi8>
+    %2 = memref.get_global @__wrapper_1 : memref<64xf32>
+    %4 = memref.get_global @__wrapper_2 : memref<2x2x16x32x4xi8>
+    %6 = memref.get_global @__wrapper_3 : memref<64xf32>
+    %8 = memref.get_global @__wrapper_4 : memref<2x2x32x32xf32>
+
+    // Warmup
+    %c1_i64 = arith.constant 1 : i64
+    %warmup = perf.bench(%c1_i64 : i64) -> f64 {
+      func.call @_entry(%0, %2, %4, %6, %8) : (memref<2x2x32x64xi8>, memref<64xf32>, memref<2x2x16x32x4xi8>, memref<64xf32>, memref<2x2x32x32xf32>) -> ()
+    }
+
+    // Benchmark
+    %c10_i64 = arith.constant 10 : i64
+    %bench = perf.bench(%c10_i64 : i64) -> f64 {
+      func.call @_entry(%0, %2, %4, %6, %8) : (memref<2x2x32x64xi8>, memref<64xf32>, memref<2x2x16x32x4xi8>, memref<64xf32>, memref<2x2x32x32xf32>) -> ()
+    }
+
+    %iters_f64 = arith.uitofp %c10_i64 : i64 to f64
+    %avg_time = arith.divf %bench, %iters_f64 : f64
+    vector.print %avg_time : f64
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @entry()
+
+// Warmup
+// CHECK: perf.bench({{.*}} : i64) -> f64 {
+// CHECK: func.call @_entry
+
+// Unrolled allocations: 2 separate allocs per buffer (numLayers=2)
+// i8 activation buffers (2 layers)
+// CHECK-DAG: memref.alloc() : memref<2x2x32x64xi8>
+// CHECK-DAG: memref.alloc() : memref<2x2x32x64xi8>
+// f32 scale buffers (2 layers)
+// CHECK-DAG: memref.alloc() : memref<64xf32>
+// CHECK-DAG: memref.alloc() : memref<64xf32>
+// i8 weight buffers (2 layers)
+// CHECK-DAG: memref.alloc() : memref<2x2x16x32x4xi8>
+// CHECK-DAG: memref.alloc() : memref<2x2x16x32x4xi8>
+// f32 scale buffers (2 layers)
+// CHECK-DAG: memref.alloc() : memref<64xf32>
+// CHECK-DAG: memref.alloc() : memref<64xf32>
+// f32 output buffers (2 layers)
+// CHECK-DAG: memref.alloc() : memref<2x2x32x32xf32>
+// CHECK-DAG: memref.alloc() : memref<2x2x32x32xf32>
+
+// Benchmark with unrolled kernel calls
+// CHECK: perf.bench({{.*}} : i64) -> f64 {
+// CHECK: func.call @_entry
+// CHECK: func.call @_entry
+
+// Timing adjusted for 2 layers
+// CHECK: %[[NLAYERS:.*]] = arith.constant 2.000000e+00 : f64
+// CHECK: arith.mulf {{.*}}, %[[NLAYERS]] : f64
+
+// -----
+
+// Test cache-nuke buffer replication.
+module {
+  memref.global "private" @__wrapper_2 : memref<2x2x32x32xf32> = dense<0.0> {alignment = 128 : i64}
+  memref.global "private" @__wrapper_1 : memref<2x2x16x32x2xbf16> = dense<1.0> {alignment = 128 : i64}
+  memref.global "private" @__wrapper_0 : memref<2x2x32x32xbf16> = dense<1.0> {alignment = 128 : i64}
+
+  func.func @_entry(%arg0: memref<2x2x32x32xbf16>, %arg1: memref<2x2x16x32x2xbf16>,
+                    %arg2: memref<2x2x32x32xf32>) {
+    return
+  }
+
+  func.func @entry() {
+    %0 = memref.get_global @__wrapper_0 : memref<2x2x32x32xbf16>
+    %1 = memref.get_global @__wrapper_1 : memref<2x2x16x32x2xbf16>
+    %2 = memref.get_global @__wrapper_2 : memref<2x2x32x32xf32>
+
+    // Warmup
+    %c1_i64 = arith.constant 1 : i64
+    %warmup = perf.bench(%c1_i64 : i64) -> f64 {
+      func.call @_entry(%0, %1, %2) : (memref<2x2x32x32xbf16>, memref<2x2x16x32x2xbf16>, memref<2x2x32x32xf32>) -> ()
+    }
+
+    // Benchmark
+    %c10_i64 = arith.constant 10 : i64
+    %bench = perf.bench(%c10_i64 : i64) -> f64 {
+      func.call @_entry(%0, %1, %2) : (memref<2x2x32x32xbf16>, memref<2x2x16x32x2xbf16>, memref<2x2x32x32xf32>) -> ()
+    }
+
+    %iters_f64 = arith.uitofp %c10_i64 : i64 to f64
+    %avg_time = arith.divf %bench, %iters_f64 : f64
+    vector.print %avg_time : f64
+    return
+  }
+}
+
+// BF16-LABEL: func.func @entry()
+
+// Warmup
+// BF16: perf.bench({{.*}} : i64) -> f64 {
+// BF16: func.call @_entry
+
+// Unrolled allocations: 2 separate allocs per buffer (numLayers=2)
+// bf16 activation buffers (2 layers)
+// BF16-DAG: memref.alloc() : memref<2x2x32x32xbf16>
+// BF16-DAG: memref.alloc() : memref<2x2x32x32xbf16>
+// bf16 weight buffers in VNNI format (2 layers)
+// BF16-DAG: memref.alloc() : memref<2x2x16x32x2xbf16>
+// BF16-DAG: memref.alloc() : memref<2x2x16x32x2xbf16>
+// f32 output buffers (2 layers)
+// BF16-DAG: memref.alloc() : memref<2x2x32x32xf32>
+// BF16-DAG: memref.alloc() : memref<2x2x32x32xf32>
+
+// Benchmark with unrolled kernel calls
+// BF16: perf.bench({{.*}} : i64) -> f64 {
+// BF16: func.call @_entry
+// BF16: func.call @_entry
+
+// Timing adjusted for 2 layers
+// BF16: %[[NLAYERS:.*]] = arith.constant 2.000000e+00 : f64
+// BF16: arith.mulf {{.*}}, %[[NLAYERS]] : f64

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -136,6 +136,39 @@ llvm::cl::opt<bool>
                llvm::cl::desc("Kernel buffers are allocated on GPU"),
                llvm::cl::init(true));
 
+// Extern declarations for DefaultTppPasses options defined in
+// DefaultPipeline.cpp. These are needed for the cache-nuke split pipeline to
+// pass options correctly.
+extern llvm::cl::opt<bool> linalgToLoops;
+extern llvm::cl::opt<bool> sfcOrder;
+extern llvm::cl::list<unsigned> parallelTaskGrid;
+extern llvm::cl::opt<bool> linalgToVector;
+extern llvm::cl::opt<bool> vectorToXSMM;
+extern llvm::cl::opt<bool> lowerPackUnpackWithoutTranspose;
+extern llvm::cl::opt<bool> disableVnniPacking;
+extern llvm::cl::opt<bool> disableTileElementwiseOps;
+extern llvm::cl::list<unsigned> registerBlocking;
+extern llvm::cl::opt<bool> vectorToKernel;
+extern llvm::cl::opt<bool> nanoKernel;
+extern llvm::cl::opt<bool> defParallel;
+
+// Cache-nuking benchmark options for cold-cache measurements.
+llvm::cl::opt<bool> enableCacheNuking(
+    "cache-nuke",
+    llvm::cl::desc("Enable buffer replication for cold-cache benchmarking"),
+    llvm::cl::init(false));
+
+llvm::cl::opt<int64_t> cacheNukeLayers(
+    "cache-nuke-layers",
+    llvm::cl::desc(
+        "Number of buffer layers for cache-nuking (-1=auto for ~5GB)"),
+    llvm::cl::init(-1));
+
+llvm::cl::opt<double> cacheNukeTargetGB(
+    "cache-nuke-target-gb",
+    llvm::cl::desc("Target working set size in GB for auto-calculation"),
+    llvm::cl::init(5.0));
+
 struct TargetMachineOptions {
   std::string triple;
   std::string cpu;
@@ -205,11 +238,51 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   wrapperOpts.seed = seed;
   wrapperOpts.initType = initType;
   wrapperOpts.identity = identity;
-  passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
 
-  tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend,
-                                              runnerCpuTargetFeature};
-  passManager.addPass(tpp::createDefaultPipeline(defPipelineOpts));
+  // Benchmarking with cache-nuking requires wrapper passes to run after
+  // bufferization to avoid memref.copy being inserted inside the timed region.
+  // Use split pipeline.
+  if (enableCacheNuking && benchNumLoops > 1) {
+    // Step 1: DefaultTppPasses - tensor to memref (includes bufferization)
+    // Pass all CLI options that DefaultPipeline would normally pass.
+    tpp::DefaultTppPassesOptions tppPassesOpts;
+    tppPassesOpts.linalgToLoops = linalgToLoops;
+    tppPassesOpts.sfcOrder = sfcOrder;
+    tppPassesOpts.parallelTaskGrid =
+        SmallVector<unsigned>{parallelTaskGrid.begin(), parallelTaskGrid.end()};
+    tppPassesOpts.linalgToVector = linalgToVector;
+    tppPassesOpts.vectorToXSMM = vectorToXSMM;
+    tppPassesOpts.lowerPackUnpackWithoutTranspose =
+        lowerPackUnpackWithoutTranspose;
+    tppPassesOpts.disableVnniPacking = disableVnniPacking;
+    tppPassesOpts.disableTileElementwiseOps = disableTileElementwiseOps;
+    tppPassesOpts.registerBlocking =
+        SmallVector<unsigned>{registerBlocking.begin(), registerBlocking.end()};
+    tppPassesOpts.vectorToKernel = vectorToKernel;
+    tppPassesOpts.nanoKernel = nanoKernel;
+    tppPassesOpts.defBundleCpuTargetFeature = runnerCpuTargetFeature;
+    passManager.addPass(tpp::createDefaultTppPasses(tppPassesOpts));
+
+    // Step 2: Wrapper passes - now operate on memrefs (after bufferization)
+    passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
+
+    tpp::ReplicateBuffersForBenchmarkOptions replicateOpts;
+    replicateOpts.numLayers = cacheNukeLayers;
+    replicateOpts.targetWorkingSetGB = cacheNukeTargetGB;
+    passManager.addPass(tpp::createReplicateBuffersForBenchmark(replicateOpts));
+
+    // Step 3: LowerToLLVMPipeline - memref to LLVM
+    tpp::LowerToLLVMPipelineOptions lowerOpts;
+    lowerOpts.enableParallel = defParallel;
+    passManager.addPass(tpp::createLowerToLLVMPipeline(lowerOpts));
+  } else {
+    // Original pipeline order when cache-nuking is not needed.
+    passManager.addPass(tpp::createTppRunnerWrapper(wrapperOpts));
+
+    tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend,
+                                                runnerCpuTargetFeature};
+    passManager.addPass(tpp::createDefaultPipeline(defPipelineOpts));
+  }
 
   auto result = passManager.run(module);
   if (failed(result)) {


### PR DESCRIPTION
For consistent and accurate benchmarking cold cache is desired. This patch implements the cache nuking by replicating the actual kernel calls into layers such that complete cache is invalidated. Layers are unrolled and each layer uses separate memory allocation for all of its arguments.

This patch also integrates this cache nuking in the middle of the pass pipeline by bifurcating the actual one into two and scheduling this pass after DefaultTppPasses to ensure bufferization is done to avoid allocation and copies inside benchmark loop. This is disabled by default and can be enabled with "--cache-nuke" flag.