### PR TITLE
SFC Creation BugFixes

### DIFF
--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -484,12 +484,13 @@ def SCFForAllLoopFlattenSFC : Pass<"scf-forall-loop-flatten-sfc"> {
   let summary = "Flatten 2D forall loops into 1D with index vectors using space-filling curve";
   let description = [{
     Transform innermost scf.forall operations with exactly 2 induction variables
-    into scf.forall with 1 induction variable. Creates constant dense vectors
+    into scf.forall with 1 induction variable. Creates constant memref globals
     containing the flattened iteration space values using a space-filling curve (SFC) pattern,
-    and uses vector.extract with dynamic position to derive the original induction variables
-    inside the loop body.
+    and uses memref.load with a dynamic index to derive the original induction variables
+    inside the loop body. The integer width of the lookup tables is chosen to fit
+    the linearized tile count (i8, i16, i32 or i64).
   }];
-  let dependentDialects = ["scf::SCFDialect", "arith::ArithDialect", "vector::VectorDialect"];
+  let dependentDialects = ["scf::SCFDialect", "arith::ArithDialect", "memref::MemRefDialect"];
 }
 
 def GpuInlineConstants : Pass<"gpu-inline-constants", "func::FuncOp"> {

--- a/lib/TPP/Transforms/SCFForAllLoopFlattenSFC.cpp
+++ b/lib/TPP/Transforms/SCFForAllLoopFlattenSFC.cpp
@@ -13,12 +13,14 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
@@ -150,17 +152,22 @@ using namespace mlir::scf;
 ///   }
 ///
 /// into:
-///   %iv_i = arith.constant dense<[...]> : vector<NxI16>
-///   %iv_j = arith.constant dense<[...]> : vector<NxI16>
+///   memref.global "private" constant @iv_i : memref<NxiW> = dense<[...]>
+///   memref.global "private" constant @iv_j : memref<NxiW> = dense<[...]>
+///   %tbl_i = memref.get_global @iv_i : memref<NxiW>
+///   %tbl_j = memref.get_global @iv_j : memref<NxiW>
 ///   scf.forall (%idx) in (%cN) {
-///     %i_i16 = vector.extract %iv_i[%idx] : i16 from vector<NxI16>
-///     %j_i16 = vector.extract %iv_j[%idx] : i16 from vector<NxI16>
-///     %i = arith.index_cast %i_i16 : i16 to index
-///     %j = arith.index_cast %j_i16 : i16 to index
+///     %i_iw = memref.load %tbl_i[%idx] : memref<NxiW>
+///     %j_iw = memref.load %tbl_j[%idx] : memref<NxiW>
+///     %i = arith.index_cast %i_iw : iW to index
+///     %j = arith.index_cast %j_iw : iW to index
 ///     // original body using %i and %j
 ///   }
 ///
-/// where N is the total iteration count ub0 * ub1
+/// where N is the total iteration count ub0 * ub1 and iW is the smallest
+/// integer type (i8, i16, i32 or i64) whose range can index all N tiles. The
+/// lookup tables are constant memref globals (rather than vector constants)
+/// so that large tile counts do not overflow the SelectionDAG backend.
 static LogicalResult flattenForallLoop(ForallOp op, OpBuilder &builder) {
   // Only handle 2D forall loops
   if (op.getRank() != 2)
@@ -216,12 +223,29 @@ static LogicalResult flattenForallLoop(ForallOp op, OpBuilder &builder) {
 
   if (totalCount <= 0)
     return failure();
-  if (count0 > std::numeric_limits<int16_t>::max() || count1 > std::numeric_limits<int16_t>::max())
-    return failure();
 
-  // Build the flattened index vectors
-  SmallVector<int16_t> iv0Values;
-  SmallVector<int16_t> iv1Values;
+  // Select the smallest integer type whose value range can index the entire
+  // linearized tile space. The flattened loop walks totalCount tiles, so the
+  // index values stored in the lookup vectors range over [0, totalCount). For
+  // large matrices this can exceed the i16 range that was previously hard-coded
+  // here, so we widen the element type as needed (i8 -> i16 -> i32 -> i64).
+  IntegerType elemType = [&]() -> IntegerType {
+    int64_t maxIndex = totalCount - 1;
+    if (maxIndex <= std::numeric_limits<int8_t>::max())
+      return builder.getI8Type();
+    if (maxIndex <= std::numeric_limits<int16_t>::max())
+      return builder.getI16Type();
+    if (maxIndex <= std::numeric_limits<int32_t>::max())
+      return builder.getI32Type();
+    return builder.getI64Type();
+  }();
+  unsigned elemBitWidth = elemType.getWidth();
+
+  // Build the flattened index vectors using the selected integer width.
+  SmallVector<APInt> iv0Values;
+  SmallVector<APInt> iv1Values;
+  iv0Values.reserve(totalCount);
+  iv1Values.reserve(totalCount);
 
   for (int64_t i = 0; i < count0; ++i) {
     for (int64_t j = 0; j < count1; ++j) {
@@ -233,18 +257,59 @@ static LogicalResult flattenForallLoop(ForallOp op, OpBuilder &builder) {
       // we are using a generalized Hilbert curve to calculate the indices, which can improve locality for certain access patterns
       tpp::sfc::gilbertD2xy(iv0val, iv1val, i * count1 + j, count0, count1);
 
-      iv0Values.push_back(static_cast<int16_t>(iv0val));
-      iv1Values.push_back(static_cast<int16_t>(iv1val));
+      iv0Values.emplace_back(elemBitWidth, static_cast<uint64_t>(iv0val),
+                             /*isSigned=*/true);
+      iv1Values.emplace_back(elemBitWidth, static_cast<uint64_t>(iv1val),
+                             /*isSigned=*/true);
     }
   }
 
-  // Create dense constant vectors
-  auto vectorType = VectorType::get(ArrayRef<int64_t>{totalCount}, builder.getI16Type());
-  auto iv0Attr = DenseElementsAttr::get(vectorType, ArrayRef<int16_t>(iv0Values));
-  auto iv1Attr = DenseElementsAttr::get(vectorType, ArrayRef<int16_t>(iv1Values));
+  // Store the SFC index tables as module-level constant memref globals and look
+  // them up with memref.load inside the loop. A previous implementation
+  // materialized these as `vector<NxiW>` constants and used vector.extract with
+  // a dynamic position; for large tile counts (e.g. a 256x256 block grid =
+  // 65536 tiles) lowering that dynamic extract builds a BUILD_VECTOR SDNode
+  // with one operand per element, which overflows SDNode's operand limit and
+  // crashes the SelectionDAG backend. Constant globals + loads scale to any
+  // table size.
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  if (!moduleOp)
+    return failure();
 
-  Value iv0Vector = arith::ConstantOp::create(builder, loc, vectorType, iv0Attr);
-  Value iv1Vector = arith::ConstantOp::create(builder, loc, vectorType, iv1Attr);
+  auto tableType = MemRefType::get(ArrayRef<int64_t>{totalCount}, elemType);
+  auto tensorType =
+      RankedTensorType::get(ArrayRef<int64_t>{totalCount}, elemType);
+  auto iv0Attr = DenseElementsAttr::get(tensorType, iv0Values);
+  auto iv1Attr = DenseElementsAttr::get(tensorType, iv1Values);
+
+  // Create the constant globals at the top of the module with unique names.
+  OpBuilder globalBuilder(op->getContext());
+  globalBuilder.setInsertionPointToStart(moduleOp.getBody());
+  auto uniqueName = [&](StringRef base) -> std::string {
+    if (!moduleOp.lookupSymbol(base))
+      return base.str();
+    unsigned c = 0;
+    std::string name;
+    do {
+      name = base.str() + "_" + std::to_string(c++);
+    } while (moduleOp.lookupSymbol(name));
+    return name;
+  };
+
+  std::string name0 = uniqueName("__sfc_iv0");
+  auto g0 = memref::GlobalOp::create(
+      globalBuilder, loc, name0, globalBuilder.getStringAttr("private"),
+      tableType, iv0Attr, /*constant=*/true, /*alignment=*/IntegerAttr());
+  std::string name1 = uniqueName("__sfc_iv1");
+  auto g1 = memref::GlobalOp::create(
+      globalBuilder, loc, name1, globalBuilder.getStringAttr("private"),
+      tableType, iv1Attr, /*constant=*/true, /*alignment=*/IntegerAttr());
+
+  // Materialize references to the globals in the function before the loop.
+  Value iv0Table =
+      memref::GetGlobalOp::create(builder, loc, tableType, g0.getSymName());
+  Value iv1Table =
+      memref::GetGlobalOp::create(builder, loc, tableType, g1.getSymName());
 
   // Create the new 1D forall loop
   SmallVector<OpFoldResult> newLowerBound = {builder.getIndexAttr(*lb0)};
@@ -259,11 +324,11 @@ static LogicalResult flattenForallLoop(ForallOp op, OpBuilder &builder) {
 
   Value idx = newLoop.getInductionVars()[0];
 
-  // Extract the original induction variable values using vector.extract with dynamic position
-  Value i = vector::ExtractOp::create(builder, loc, iv0Vector, idx);
-  Value j = vector::ExtractOp::create(builder, loc, iv1Vector, idx);
+  // Look up the original induction variable values from the constant tables.
+  Value i = memref::LoadOp::create(builder, loc, iv0Table, ValueRange{idx});
+  Value j = memref::LoadOp::create(builder, loc, iv1Table, ValueRange{idx});
 
-  // Convert extracted values to index type
+  // Convert loaded values to index type
   Value iIndex = arith::IndexCastOp::create(builder, loc, builder.getIndexType(), i);
   Value jIndex = arith::IndexCastOp::create(builder, loc, builder.getIndexType(), j);
 

--- a/test/Passes/scf-forall-loop-flatten-sfc.mlir
+++ b/test/Passes/scf-forall-loop-flatten-sfc.mlir
@@ -15,17 +15,18 @@ func.func @flatten_2d_forall() {
   return
 }
 
-// CHECK-LABEL: func.func @flatten_2d_forall()
+// CHECK:         memref.global "private" constant @[[IV0:.*]] : memref<32xi8> = dense<[0, 0, 1, 1, 2, 3, 3, 2, 2, 3, 3, 2, 1, 1, 0, 0, 0, 0, 1, 1, 2, 3, 3, 2, 2, 3, 3, 2, 1, 1, 0, 0]>
+// CHECK:         memref.global "private" constant @[[IV1:.*]] : memref<32xi8> = dense<[0, 1, 1, 0, 0, 0, 1, 1, 2, 2, 3, 3, 3, 2, 2, 3, 4, 5, 5, 4, 4, 4, 5, 5, 6, 6, 7, 7, 7, 6, 6, 7]>
+// CHECK:         func.func @flatten_2d_forall()
 // CHECK:         %[[WORK:.*]] = memref.alloca() : memref<4x8xi32>
-// CHECK:         %[[C4:.*]] = arith.constant 4 : index
 // CHECK:         %[[C8:.*]] = arith.constant 8 : index
-// CHECK:         %[[IV_I:.*]] = arith.constant dense<[0, 0, 1, 1, 2, 3, 3, 2, 2, 3, 3, 2, 1, 1, 0, 0, 0, 0, 1, 1, 2, 3, 3, 2, 2, 3, 3, 2, 1, 1, 0, 0]> : vector<32xi16>
-// CHECK:         %[[IV_J:.*]] = arith.constant dense<[0, 1, 1, 0, 0, 0, 1, 1, 2, 2, 3, 3, 3, 2, 2, 3, 4, 5, 5, 4, 4, 4, 5, 5, 6, 6, 7, 7, 7, 6, 6, 7]> : vector<32xi16>
+// CHECK:         %[[TBL_I:.*]] = memref.get_global @[[IV0]] : memref<32xi8>
+// CHECK:         %[[TBL_J:.*]] = memref.get_global @[[IV1]] : memref<32xi8>
 // CHECK:         scf.forall (%[[IDX:.*]]) in (32) {
-// CHECK:           %[[I_I16:.*]] = vector.extract %[[IV_I]][%[[IDX]]] : i16 from vector<32xi16>
-// CHECK:           %[[J_I16:.*]] = vector.extract %[[IV_J]][%[[IDX]]] : i16 from vector<32xi16>
-// CHECK:           %[[I:.*]] = arith.index_cast %[[I_I16]] : i16 to index
-// CHECK:           %[[J:.*]] = arith.index_cast %[[J_I16]] : i16 to index
+// CHECK:           %[[I_I8:.*]] = memref.load %[[TBL_I]][%[[IDX]]] : memref<32xi8>
+// CHECK:           %[[J_I8:.*]] = memref.load %[[TBL_J]][%[[IDX]]] : memref<32xi8>
+// CHECK:           %[[I:.*]] = arith.index_cast %[[I_I8]] : i8 to index
+// CHECK:           %[[J:.*]] = arith.index_cast %[[J_I8]] : i8 to index
 // CHECK:           %[[TEMP:.*]] = arith.muli %[[I]], %[[C8]] : index
 // CHECK:           %[[WORKID:.*]] = arith.addi %[[TEMP]], %[[J]] : index
 // CHECK:           %[[WORKID_I32:.*]] = index.casts %[[WORKID]] : index to i32
@@ -48,19 +49,48 @@ func.func @flatten_different_bounds() {
   return
 }
 
-// CHECK-LABEL: func.func @flatten_different_bounds()
+// CHECK:         memref.global "private" constant @[[IV0:.*]] : memref<6xi8> = dense<[0, 1, 1, 1, 0, 0]>
+// CHECK:         memref.global "private" constant @[[IV1:.*]] : memref<6xi8> = dense<[0, 0, 1, 2, 2, 1]>
+// CHECK:         func.func @flatten_different_bounds()
 // CHECK:         %[[WORK:.*]] = memref.alloca() : memref<2x3xi32>
-// CHECK:         %[[C2:.*]] = arith.constant 2 : index
-// CHECK:         %[[C3:.*]] = arith.constant 3 : index
 // CHECK:         %[[C100:.*]] = arith.constant 100 : i32
-// CHECK:         %[[IV_I:.*]] = arith.constant dense<[0, 1, 1, 1, 0, 0]> : vector<6xi16>
-// CHECK:         %[[IV_J:.*]] = arith.constant dense<[0, 0, 1, 2, 2, 1]> : vector<6xi16>
+// CHECK:         %[[TBL_I:.*]] = memref.get_global @[[IV0]] : memref<6xi8>
+// CHECK:         %[[TBL_J:.*]] = memref.get_global @[[IV1]] : memref<6xi8>
 // CHECK:         scf.forall (%[[IDX:.*]]) in (6) {
-// CHECK:           %[[I_I16:.*]] = vector.extract %[[IV_I]][%[[IDX]]] : i16 from vector<6xi16>
-// CHECK:           %[[J_I16:.*]] = vector.extract %[[IV_J]][%[[IDX]]] : i16 from vector<6xi16>
+// CHECK:           %[[I_I8:.*]] = memref.load %[[TBL_I]][%[[IDX]]] : memref<6xi8>
+// CHECK:           %[[J_I8:.*]] = memref.load %[[TBL_J]][%[[IDX]]] : memref<6xi8>
+// CHECK:           %[[I:.*]] = arith.index_cast %[[I_I8]] : i8 to index
+// CHECK:           %[[J:.*]] = arith.index_cast %[[J_I8]] : i8 to index
+// CHECK:           memref.store %[[C100]], %[[WORK]][%[[I]], %[[J]]] : memref<2x3xi32>
+// CHECK:         }
+// CHECK:         return
+
+// -----
+
+// Test that the index element type widens to i16 once the linearized tile
+// count exceeds the i8 range (16 * 16 = 256 tiles > 127).
+func.func @flatten_widens_to_i16() {
+  %work = memref.alloca() : memref<16x16xi32>
+  %c16 = arith.constant 16 : index
+  %c100 = arith.constant 100 : i32
+
+  scf.forall (%i, %j) in (%c16, %c16) {
+    memref.store %c100, %work[%i, %j] : memref<16x16xi32>
+  }
+
+  return
+}
+
+// CHECK:         memref.global "private" constant @[[IV0:.*]] : memref<256xi16> = dense<{{.*}}>
+// CHECK:         memref.global "private" constant @[[IV1:.*]] : memref<256xi16> = dense<{{.*}}>
+// CHECK:         func.func @flatten_widens_to_i16()
+// CHECK:         %[[TBL_I:.*]] = memref.get_global @[[IV0]] : memref<256xi16>
+// CHECK:         %[[TBL_J:.*]] = memref.get_global @[[IV1]] : memref<256xi16>
+// CHECK:         scf.forall (%[[IDX:.*]]) in (256) {
+// CHECK:           %[[I_I16:.*]] = memref.load %[[TBL_I]][%[[IDX]]] : memref<256xi16>
+// CHECK:           %[[J_I16:.*]] = memref.load %[[TBL_J]][%[[IDX]]] : memref<256xi16>
 // CHECK:           %[[I:.*]] = arith.index_cast %[[I_I16]] : i16 to index
 // CHECK:           %[[J:.*]] = arith.index_cast %[[J_I16]] : i16 to index
-// CHECK:           memref.store %[[C100]], %[[WORK]][%[[I]], %[[J]]] : memref<2x3xi32>
 // CHECK:         }
 // CHECK:         return
 


### PR DESCRIPTION
Lookup tables are now module-level constant memref.globals, referenced via memref.get_global and indexed with memref.load inside the loop body. Constant globals + loads scale to any table size. Globals are created at the top of the module with uniquified symbol names (__sfc_iv0, __sfc_iv1, …) to avoid collisions across multiple flattened loops. Dependent dialect updated: vector::VectorDialect → memref::MemRefDialect; pass description in Passes.td updated accordingly.

The index element type is selected dynamically as the smallest integer type whose range covers the tile count (i8 → i16 → i32 → i64), instead of being hard-coded to i16. This also removes the previous int16_t range check that caused the pass to bail out on larger loops. 