### PR TITLE
Cold-cache Buffer Replication & Benchmark scripts for tracking sfc_ca_gemm

### DIFF
--- a/benchmarks/mlir/sfc_ca_gemm/postprocess.py
+++ b/benchmarks/mlir/sfc_ca_gemm/postprocess.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Post-process raw sfc_ca_gemm timings.
+
+Reads a raw CSV with columns ``M,N,K,runtime_s`` produced by
+``run_sfc_ca_gemm.sh`` and writes a CSV that:
+
+  * computes the arithmetic complexity (FLOPs = 2 * M * N * K) of each GEMM,
+  * computes the achieved performance in TFLOP/s next to the runtime,
+  * is sorted by ascending arithmetic complexity.
+
+Usage:
+    postprocess.py <raw_csv> <out_csv>
+"""
+
+import csv
+import sys
+
+
+def main(argv):
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <raw_csv> <out_csv>", file=sys.stderr)
+        return 1
+
+    raw_path, out_path = argv[1], argv[2]
+
+    rows = []
+    with open(raw_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for rec in reader:
+            M = int(rec["M"])
+            N = int(rec["N"])
+            K = int(rec["K"])
+            try:
+                runtime_s = float(rec["runtime_s"])
+            except (ValueError, KeyError):
+                runtime_s = float("nan")
+
+            # Arithmetic complexity of a single M x N x K GEMM.
+            flops = 2.0 * M * N * K
+
+            if runtime_s > 0.0:
+                tflops = flops / runtime_s / 1.0e12
+            else:
+                tflops = float("nan")
+
+            rows.append(
+                {
+                    "M": M,
+                    "N": N,
+                    "K": K,
+                    "flops": int(flops),
+                    "runtime_s": runtime_s,
+                    "tflops": tflops,
+                }
+            )
+
+    # Sort by arithmetic complexity (ascending), then by dimensions for ties.
+    rows.sort(key=lambda r: (r["flops"], r["M"], r["N"], r["K"]))
+
+    with open(out_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["M", "N", "K", "flops", "runtime_s", "tflops"])
+        for r in rows:
+            writer.writerow(
+                [
+                    r["M"],
+                    r["N"],
+                    r["K"],
+                    r["flops"],
+                    f"{r['runtime_s']:.9g}",
+                    f"{r['tflops']:.6g}",
+                ]
+            )
+
+    print(f"Wrote {len(rows)} rows to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm.sh
+++ b/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm.sh
@@ -61,7 +61,7 @@ if [[ "${RANDOM_INIT}" != "0" ]]; then
 fi
 
 # GEMM dimensions to sweep (full cross-product), matching benchmark_sample.sh.
-SIZES=(512 1024 2048 4096)
+SIZES=(512 1024 2048 4096 8192)
 
 MLIR_GEN="${BIN_DIR}/mlir-gen"
 TPP_RUN="${BIN_DIR}/tpp-run"

--- a/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm.sh
+++ b/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Cold-cache GEMM sweep for tpp-run, modeled after libxsmm's sfc_ca_gemm
+# benchmark_sample.sh. For every (M, N, K) configuration it:
+#   1. generates an mx-bf16 GEMM kernel with mlir-gen,
+#   2. runs tpp-run with -bench-replication-gb=5.0 so the kernel arguments are
+#      replicated to a 5 GiB footprint and iterated inside the timing loop
+#      (cold-cache measurement),
+#   3. records the reported mean per-call runtime (seconds).
+#
+# The raw timings are written to a CSV (M,N,K,runtime_s) which is then handed to
+# postprocess.py to compute TFLOP/s and sort by arithmetic complexity.
+#
+# Run this from the build directory (so that ./bin/mlir-gen and ./bin/tpp-run
+# resolve), or set BIN_DIR to point at the directory holding those tools.
+
+set -euo pipefail
+
+#==============================================================================
+# Environment settings (adopted from libxsmm sfc_ca_gemm/benchmark_sample.sh)
+#==============================================================================
+export KMP_AFFINITY=granularity=fine,compact,1,0
+export OMP_NUM_THREADS=64
+export LIBXSMM_X86_AMX_GEMM_STREAMING_A=1
+export LIBXSMM_X86_AMX_GEMM_STREAMING_B=1
+
+#==============================================================================
+# Configuration
+#==============================================================================
+# Directory containing the mlir-gen / tpp-run binaries (default: ./bin).
+BIN_DIR="${BIN_DIR:-./bin}"
+# Directory for this script (used to locate postprocess.py).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Output directory for generated MLIR and result CSVs.
+OUT_DIR="${OUT_DIR:-$(pwd)/sfc_ca_gemm_results}"
+# GEMM block tiles (bm, bn, bk). K-blocking and K-layers are fixed to 1 since
+# the generated MLIR does not model them.
+TILES="${TILES:-32,32,32}"
+# Number of timed loops handed to tpp-run.
+N_ITERS="${N_ITERS:-100}"
+# Target replication footprint in GiB for cold-cache benchmarking.
+REPL_GIB="${REPL_GIB:-5.0}"
+# Enable parallel (multi-threaded / OpenMP) execution in tpp-run. Set to 0 for
+# a serial run. Parallelism is driven by OMP_NUM_THREADS (set above).
+PARALLEL="${PARALLEL:-1}"
+# Initialize the replicated cold-cache buffers with random FP values (matching
+# the element precision) instead of zeros. All-zero inputs let the FMA units
+# run at an unrealistically high clock. Set to 0 to keep zero initialization.
+RANDOM_INIT="${RANDOM_INIT:-1}"
+
+# Assemble the parallel-execution flags for tpp-run.
+PARALLEL_FLAGS=()
+if [[ "${PARALLEL}" != "0" ]]; then
+  PARALLEL_FLAGS=(--def-parallel)
+fi
+
+# Assemble the random-initialization flag for tpp-run.
+RANDOM_FLAGS=()
+if [[ "${RANDOM_INIT}" != "0" ]]; then
+  RANDOM_FLAGS=(--splat-to-random --seed=555)
+fi
+
+# GEMM dimensions to sweep (full cross-product), matching benchmark_sample.sh.
+SIZES=(512 1024 2048 4096)
+
+MLIR_GEN="${BIN_DIR}/mlir-gen"
+TPP_RUN="${BIN_DIR}/tpp-run"
+
+#==============================================================================
+# Sanity checks
+#==============================================================================
+for tool in "${MLIR_GEN}" "${TPP_RUN}"; do
+  if [[ ! -x "${tool}" ]]; then
+    echo "error: cannot find executable '${tool}'." >&2
+    echo "       Run from the build directory or set BIN_DIR." >&2
+    exit 1
+  fi
+done
+
+mkdir -p "${OUT_DIR}"
+RAW_CSV="${OUT_DIR}/sfc_ca_gemm_raw.csv"
+echo "M,N,K,runtime_s" > "${RAW_CSV}"
+
+#==============================================================================
+# Sweep
+#==============================================================================
+for M in "${SIZES[@]}"; do
+  for N in "${SIZES[@]}"; do
+    for K in "${SIZES[@]}"; do
+      mlir_file="${OUT_DIR}/gemm_sfc_${M}_${N}_${K}_mx-bf16.mlir"
+
+      echo "=== Generating M=${M} N=${N} K=${K} ==="
+      "${MLIR_GEN}" --kernel=args --float-type=bf16 \
+        --batch="${N}" --layers="${K},${M}" --tiles="${TILES}" --vnni=2 \
+        > "${mlir_file}"
+
+      echo "=== Running   M=${M} N=${N} K=${K} ==="
+      run_out="$("${TPP_RUN}" "${mlir_file}" \
+        -e entry -entry-point-result=void \
+        -n "${N_ITERS}" --bench-replication-gb="${REPL_GIB}" \
+        "${RANDOM_FLAGS[@]}" \
+        "${PARALLEL_FLAGS[@]}")"
+
+      # tpp-run prints the mean per-call time (seconds) as a single float.
+      runtime="$(printf '%s\n' "${run_out}" \
+        | grep -oE '[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?' \
+        | tail -n 1)"
+
+      if [[ -z "${runtime}" ]]; then
+        echo "warning: could not parse runtime for M=${M} N=${N} K=${K}" >&2
+        runtime="nan"
+      fi
+
+      echo "${M},${N},${K},${runtime}" >> "${RAW_CSV}"
+      echo "    runtime = ${runtime} s"
+    done
+  done
+done
+
+echo
+echo "Raw timings written to ${RAW_CSV}"
+
+#==============================================================================
+# Post-process: compute TFLOP/s and sort by arithmetic complexity
+#==============================================================================
+SORTED_CSV="${OUT_DIR}/sfc_ca_gemm_results.csv"
+python3 "${SCRIPT_DIR}/postprocess.py" "${RAW_CSV}" "${SORTED_CSV}"
+
+echo "Sorted results with TFLOP/s written to ${SORTED_CSV}"

--- a/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm_gold.sh
+++ b/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm_gold.sh
@@ -36,10 +36,10 @@ export LIBXSMM_X86_AMX_GEMM_STREAMING_B=1
 #==============================================================================
 # Configuration
 #==============================================================================
-# Path to the libxsmm sfc_ca_gemm reference binary (default: ./sfc_ca_gemm).
-SFC_BIN="${SFC_BIN:-./sfc_ca_gemm}"
 # Directory for this script (used to locate postprocess.py).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Path to the libxsmm sfc_ca_gemm reference binary (default: ./sfc_ca_gemm).
+SFC_BIN="${SFC_BIN:-${SCRIPT_DIR}/sfc_ca_gemm-main/sfc_ca_gemm}"
 # Output directory for the result CSVs.
 OUT_DIR="${OUT_DIR:-$(pwd)/sfc_ca_gemm_gold_results}"
 # GEMM block tiles (bm, bn, bk). K-blocking and K-layers are fixed to 1 since
@@ -73,13 +73,52 @@ if [[ -n "${NUMACTL}" ]]; then
 fi
 
 # GEMM dimensions to sweep (full cross-product), matching run_sfc_ca_gemm.sh.
-SIZES=(512 1024 2048 4096)
+SIZES=(512 1024 2048 4096 8192)
 
 #==============================================================================
-# Sanity checks
+# Sanity checks / auto-build
 #==============================================================================
+# If the sfc_ca_gemm binary is missing, fetch the upstream sources into this
+# script's directory, build LIBXSMM and the benchmark with icx, and point
+# SFC_BIN at the freshly built binary.
 if [[ ! -x "${SFC_BIN}" ]]; then
-  echo "error: cannot find executable '${SFC_BIN}'." >&2
+  echo "sfc_ca_gemm binary not found at '${SFC_BIN}'; building from source." >&2
+
+  SFC_SRC_URL="https://github.com/libxsmm/sfc_ca_gemm/archive/refs/heads/main.zip"
+  SFC_SRC_DIR="${SCRIPT_DIR}/sfc_ca_gemm-main"
+  SFC_ZIP="${SCRIPT_DIR}/sfc_ca_gemm-main.zip"
+
+  if [[ ! -d "${SFC_SRC_DIR}" ]]; then
+    echo "  Downloading ${SFC_SRC_URL}" >&2
+    if command -v curl >/dev/null 2>&1; then
+      curl -fsSL "${SFC_SRC_URL}" -o "${SFC_ZIP}"
+    elif command -v wget >/dev/null 2>&1; then
+      wget -q "${SFC_SRC_URL}" -O "${SFC_ZIP}"
+    else
+      echo "error: need 'curl' or 'wget' to download the sfc_ca_gemm sources." >&2
+      exit 1
+    fi
+
+    echo "  Unpacking $(basename "${SFC_ZIP}")" >&2
+    unzip -q -o "${SFC_ZIP}" -d "${SCRIPT_DIR}"
+    rm -f "${SFC_ZIP}"
+  fi
+
+  echo "  Preparing LIBXSMM (SFC_CA_GEMM_COMPILER=clang)" >&2
+  ( cd "${SFC_SRC_DIR}" && SFC_CA_GEMM_COMPILER=clang ./prepare_libxsmm.sh )
+
+  echo "  Building sfc_ca_gemm (SFC_CA_GEMM_COMPILER=clang make)" >&2
+  ( cd "${SFC_SRC_DIR}" && SFC_CA_GEMM_COMPILER=clang make )
+
+  SFC_BIN="${SFC_SRC_DIR}/sfc_ca_gemm"
+
+  # Make the freshly built LIBXSMM shared library visible for this run only.
+  SFC_LIBXSMM_LIB="${SFC_SRC_DIR}/libxsmm/lib"
+  export LD_LIBRARY_PATH="${SFC_LIBXSMM_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
+
+if [[ ! -x "${SFC_BIN}" ]]; then
+  echo "error: cannot find executable '${SFC_BIN}' after build attempt." >&2
   echo "       Build it from https://github.com/libxsmm/sfc_ca_gemm and set" >&2
   echo "       SFC_BIN to its path." >&2
   exit 1

--- a/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm_gold.sh
+++ b/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm_gold.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Cold-cache GEMM sweep for libxsmm's reference sfc_ca_gemm binary (the "gold"
+# reference for the tpp-run sweep in run_sfc_ca_gemm.sh). For every (M, N, K)
+# configuration it:
+#   1. runs the sfc_ca_gemm binary with cold-cache replication (n_layers=-1
+#      auto-sizes the replicated footprint to ~5 GiB, matching the original
+#      benchmark_sample.sh),
+#   2. parses the reported GFLOP/s from the binary's MEASURE line,
+#   3. derives the effective per-GEMM runtime so the result is directly
+#      comparable to the tpp-run sweep (runtime_s = 2*M*N*K / (GFLOPS * 1e9)).
+#
+# The raw timings are written to a CSV (M,N,K,runtime_s) which is then handed to
+# the shared postprocess.py to compute TFLOP/s and sort by arithmetic
+# complexity -- the exact same post-processing used by run_sfc_ca_gemm.sh, so
+# the two result CSVs line up row-for-row.
+#
+# The sfc_ca_gemm binary is built from https://github.com/libxsmm/sfc_ca_gemm.
+# Point SFC_BIN at it (default: ./sfc_ca_gemm).
+#
+# CLI of the reference binary:
+#   sfc_ca_gemm M N K bm bn bk kbf K_layers n_layers n_iters check [DTYPE]
+# K-blocking (kbf) and K-layers are fixed to 1 to match the MLIR sweep, which
+# does not model them.
+
+set -euo pipefail
+
+#==============================================================================
+# Environment settings (adopted from libxsmm sfc_ca_gemm/benchmark_sample.sh)
+#==============================================================================
+export KMP_AFFINITY=granularity=fine,compact,1,0
+export OMP_NUM_THREADS=64
+export LIBXSMM_X86_AMX_GEMM_STREAMING_A=1
+export LIBXSMM_X86_AMX_GEMM_STREAMING_B=1
+
+#==============================================================================
+# Configuration
+#==============================================================================
+# Path to the libxsmm sfc_ca_gemm reference binary (default: ./sfc_ca_gemm).
+SFC_BIN="${SFC_BIN:-./sfc_ca_gemm}"
+# Directory for this script (used to locate postprocess.py).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Output directory for the result CSVs.
+OUT_DIR="${OUT_DIR:-$(pwd)/sfc_ca_gemm_gold_results}"
+# GEMM block tiles (bm, bn, bk). K-blocking and K-layers are fixed to 1 since
+# the MLIR sweep does not model them.
+TILES="${TILES:-32,32,32}"
+# Number of timed iterations handed to the binary.
+N_ITERS="${N_ITERS:-100}"
+# Replication layer count. -1 lets the binary auto-size the cold-cache footprint
+# to ~5 GiB (matching benchmark_sample.sh). Set a positive value to override.
+N_LAYERS="${N_LAYERS:--1}"
+# K-blocking factor and K-layers, fixed to 1 to match the MLIR sweep.
+KBF="${KBF:-1}"
+K_LAYERS="${K_LAYERS:-1}"
+# Run the binary's built-in correctness check (0=no, 1=yes). Off by default for
+# faster timing-only runs.
+CHECK="${CHECK:-0}"
+# Element data type: BF16, BF8 or FP32 (matches the MLIR sweep's bf16 default).
+DTYPE="${DTYPE:-BF16}"
+# numactl prefix for NUMA/affinity pinning (as in benchmark_sample.sh). Set to
+# an empty string to run without numactl.
+NUMACTL="${NUMACTL:-numactl -m 0 -C 0-63}"
+
+# Split TILES (bm,bn,bk) into the positional block-size arguments.
+IFS=',' read -r BM BN BK <<< "${TILES}"
+
+# Assemble the optional numactl prefix as an argv array.
+NUMACTL_PREFIX=()
+if [[ -n "${NUMACTL}" ]]; then
+  # shellcheck disable=SC2206
+  NUMACTL_PREFIX=(${NUMACTL})
+fi
+
+# GEMM dimensions to sweep (full cross-product), matching run_sfc_ca_gemm.sh.
+SIZES=(512 1024 2048 4096)
+
+#==============================================================================
+# Sanity checks
+#==============================================================================
+if [[ ! -x "${SFC_BIN}" ]]; then
+  echo "error: cannot find executable '${SFC_BIN}'." >&2
+  echo "       Build it from https://github.com/libxsmm/sfc_ca_gemm and set" >&2
+  echo "       SFC_BIN to its path." >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+RAW_CSV="${OUT_DIR}/sfc_ca_gemm_gold_raw.csv"
+echo "M,N,K,runtime_s" > "${RAW_CSV}"
+
+#==============================================================================
+# Sweep
+#==============================================================================
+for M in "${SIZES[@]}"; do
+  for N in "${SIZES[@]}"; do
+    for K in "${SIZES[@]}"; do
+      echo "=== Running   M=${M} N=${N} K=${K} ==="
+      run_out="$("${NUMACTL_PREFIX[@]}" "${SFC_BIN}" \
+        "${M}" "${N}" "${K}" "${BM}" "${BN}" "${BK}" \
+        "${KBF}" "${K_LAYERS}" "${N_LAYERS}" "${N_ITERS}" "${CHECK}" "${DTYPE}")"
+
+      # The binary prints "MEASURE <gflops> SFC_CA_GEMM_...". Pull the GFLOP/s.
+      gflops="$(printf '%s\n' "${run_out}" \
+        | awk '/^MEASURE/ {print $2; exit}')"
+
+      if [[ -z "${gflops}" ]]; then
+        echo "warning: could not parse GFLOP/s for M=${M} N=${N} K=${K}" >&2
+        runtime="nan"
+      else
+        # Effective per-GEMM time, comparable to the tpp-run per-call time:
+        #   runtime_s = (2 * M * N * K) / (GFLOPS * 1e9)
+        runtime="$(awk -v m="${M}" -v n="${N}" -v k="${K}" -v g="${gflops}" \
+          'BEGIN { printf "%.10g", (2.0 * m * n * k) / (g * 1.0e9) }')"
+      fi
+
+      echo "${M},${N},${K},${runtime}" >> "${RAW_CSV}"
+      echo "    GFLOP/s = ${gflops:-nan}, runtime = ${runtime} s"
+    done
+  done
+done
+
+echo
+echo "Raw timings written to ${RAW_CSV}"
+
+#==============================================================================
+# Post-process: compute TFLOP/s and sort by arithmetic complexity
+#==============================================================================
+SORTED_CSV="${OUT_DIR}/sfc_ca_gemm_gold_results.csv"
+python3 "${SCRIPT_DIR}/postprocess.py" "${RAW_CSV}" "${SORTED_CSV}"
+
+echo "Sorted results with TFLOP/s written to ${SORTED_CSV}"

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -397,22 +397,35 @@ def ReplicateBenchArgs : Pass<"replicate-bench-args", "ModuleOp"> {
   let description = [{
     Operates after bufferization on the benchmark wrapper produced by tpp-run.
     For each `perf.bench` region, the (single) kernel call is wrapped in an
-    `scf.for` loop that iterates over a new outer "replica" dimension. Each
-    kernel argument is backed by a freshly allocated, value-initialized global
-    memref whose leading dimension is the replication factor; every iteration
-    feeds the kernel a distinct `memref.subview` (pure pointer arithmetic, no
-    allocation or copy). This mirrors the "n_layers" replication used by
-    libxsmm's cold-cache GEMM benchmark: the same problem is run on different
-    memory so the caches stay cold.
+    `scf.for` loop that iterates over a new "replica" dimension. Each kernel
+    argument is backed by a flat, zero-initialized `i8` global holding
+    `replication-factor` contiguous copies of the argument; every iteration
+    feeds the kernel a distinct `memref.view` into that buffer (pure pointer
+    arithmetic, no allocation or copy). `memref.view` is used instead of
+    `memref.subview` so that each replica keeps the original identity layout and
+    zero offset, which avoids breaking layout-sensitive ops in the kernel (such
+    as the `memref.expand_shape` introduced by bf16 VNNI packing). This mirrors
+    the "n_layers" replication used by libxsmm's cold-cache GEMM benchmark: the
+    same problem is run on different memory so the caches stay cold.
 
     The replication factor is taken from the `replication-factor` option when
     positive, otherwise from the `tpp.bench_replication_factor` module attribute
     set by the benchmark producer. A factor <= 1 disables the pass.
+
+    By default the buffers are zero initialized. When the `random-init` option
+    or the `tpp.bench_replication_random_init` module attribute is set, each
+    float buffer is filled once (before any timed region) with PRNG-generated
+    values in [1, 2); this avoids the unrealistically high clock that the FMA
+    units reach when fed all-zero inputs.
   }];
   let options = [
     Option<"replicationFactor", "replication-factor", "int64_t",
            /*default=*/"0",
            "Number of replicas (0 = read from module attribute).">,
+    Option<"randomInit", "random-init", "bool",
+           /*default=*/"false",
+           "Initialize the replicated buffers at runtime with random "
+           "floating-point values instead of zeros.">,
   ];
   let dependentDialects = ["memref::MemRefDialect",
                            "scf::SCFDialect",

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -412,11 +412,12 @@ def ReplicateBenchArgs : Pass<"replicate-bench-args", "ModuleOp"> {
     positive, otherwise from the `tpp.bench_replication_factor` module attribute
     set by the benchmark producer. A factor <= 1 disables the pass.
 
-    By default the buffers are zero initialized. When the `random-init` option
-    or the `tpp.bench_replication_random_init` module attribute is set, each
-    float buffer is filled once (before any timed region) with PRNG-generated
-    values in [1, 2); this avoids the unrealistically high clock that the FMA
-    units reach when fed all-zero inputs.
+    Each float buffer is filled once, before any timed region. By default it is
+    filled with the constant 1.0; when the `random-init` option or the
+    `tpp.bench_replication_random_init` module attribute is set, it is instead
+    filled with PRNG-generated values in [1, 2). Neither default is zero, which
+    avoids the unrealistically high clock that the FMA units reach when fed
+    all-zero inputs.
   }];
   let options = [
     Option<"replicationFactor", "replication-factor", "int64_t",
@@ -424,8 +425,8 @@ def ReplicateBenchArgs : Pass<"replicate-bench-args", "ModuleOp"> {
            "Number of replicas (0 = read from module attribute).">,
     Option<"randomInit", "random-init", "bool",
            /*default=*/"false",
-           "Initialize the replicated buffers at runtime with random "
-           "floating-point values instead of zeros.">,
+           "Initialize the replicated float buffers at runtime with random "
+           "floating-point values in [1, 2) instead of the constant 1.0.">,
   ];
   let dependentDialects = ["memref::MemRefDialect",
                            "scf::SCFDialect",

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -392,6 +392,33 @@ def Bufferize : Pass<"bufferize", "ModuleOp"> {
   ];
 }
 
+def ReplicateBenchArgs : Pass<"replicate-bench-args", "ModuleOp"> {
+  let summary = "Replicate benchmark kernel arguments for cold-cache timing";
+  let description = [{
+    Operates after bufferization on the benchmark wrapper produced by tpp-run.
+    For each `perf.bench` region, the (single) kernel call is wrapped in an
+    `scf.for` loop that iterates over a new outer "replica" dimension. Each
+    kernel argument is backed by a freshly allocated, value-initialized global
+    memref whose leading dimension is the replication factor; every iteration
+    feeds the kernel a distinct `memref.subview` (pure pointer arithmetic, no
+    allocation or copy). This mirrors the "n_layers" replication used by
+    libxsmm's cold-cache GEMM benchmark: the same problem is run on different
+    memory so the caches stay cold.
+
+    The replication factor is taken from the `replication-factor` option when
+    positive, otherwise from the `tpp.bench_replication_factor` module attribute
+    set by the benchmark producer. A factor <= 1 disables the pass.
+  }];
+  let options = [
+    Option<"replicationFactor", "replication-factor", "int64_t",
+           /*default=*/"0",
+           "Number of replicas (0 = read from module attribute).">,
+  ];
+  let dependentDialects = ["memref::MemRefDialect",
+                           "scf::SCFDialect",
+                           "func::FuncDialect"];
+}
+
 def DuplicateFill : Pass<"duplicate-fill", "func::FuncOp"> {
   let summary = "Duplicate fill operations";
   let description = [{
@@ -599,6 +626,12 @@ def TppRunnerWrapper : Pass<"tpp-runner-wrapper", "ModuleOp">{
     Option<"identity", "identity", "int64_t",
             /*default=*/"-1",
            "Identity square argument (-1=none, 0=a, 1=b, ...).">,
+    Option<"benchReplicationGiB", "bench-replication-gb", "double",
+            /*default=*/"0.0",
+           "Replicate kernel tensor arguments along a new outer dimension so "
+           "that their overall memory footprint reaches the given size in GiB, "
+           "and iterate over the replicas inside the timing loop to benchmark "
+           "out of cold caches (0 = disabled).">,
   ];
 }
 

--- a/include/TPP/Runner/MLIRBench.h
+++ b/include/TPP/Runner/MLIRBench.h
@@ -41,15 +41,17 @@ class FuncOp;
 struct MLIRBenchConfig {
   MLIRBenchConfig() = default;
   MLIRBenchConfig(int seed, TensorInitType initType, int identity, std::string backend,
-                  bool offloadToDevice)
+                  bool offloadToDevice, double replicationTargetGiB = 0.0)
       : seed(seed), initType(initType), identity(identity), backend(backend),
-        offloadToDevice(offloadToDevice) {}
+        offloadToDevice(offloadToDevice),
+        replicationTargetGiB(replicationTargetGiB) {}
 
   int seed = 0;
   TensorInitType initType = TensorInitType::Auto;
   int identity = -1;
   std::string backend = "cpu";
   bool offloadToDevice = true;
+  double replicationTargetGiB = 0.0;
 };
 
 /// MLIRBench - Creates wrapper for calling kernel methods.
@@ -102,6 +104,14 @@ class MLIRBench {
 
   /// Allocate arguments on target device
   bool offloadToDevice;
+
+  /// Target footprint (in GiB) used to replicate kernel tensor arguments along
+  /// a new outer dimension for cold-cache benchmarking (0 = disabled).
+  double replicationTargetGiB;
+
+  /// Number of replicas added as a new outer dimension to each tensor argument.
+  /// 1 means replication is disabled.
+  int64_t replicationFactor = 1;
 
   /// Gets module's main block
   Block &getModuleBlock();

--- a/include/TPP/Runner/MLIRBench.h
+++ b/include/TPP/Runner/MLIRBench.h
@@ -41,10 +41,12 @@ class FuncOp;
 struct MLIRBenchConfig {
   MLIRBenchConfig() = default;
   MLIRBenchConfig(int seed, TensorInitType initType, int identity, std::string backend,
-                  bool offloadToDevice, double replicationTargetGiB = 0.0)
+                  bool offloadToDevice, double replicationTargetGiB = 0.0,
+                  bool replicationRandomInit = false)
       : seed(seed), initType(initType), identity(identity), backend(backend),
         offloadToDevice(offloadToDevice),
-        replicationTargetGiB(replicationTargetGiB) {}
+        replicationTargetGiB(replicationTargetGiB),
+        replicationRandomInit(replicationRandomInit) {}
 
   int seed = 0;
   TensorInitType initType = TensorInitType::Auto;
@@ -52,6 +54,7 @@ struct MLIRBenchConfig {
   std::string backend = "cpu";
   bool offloadToDevice = true;
   double replicationTargetGiB = 0.0;
+  bool replicationRandomInit = false;
 };
 
 /// MLIRBench - Creates wrapper for calling kernel methods.
@@ -108,6 +111,10 @@ class MLIRBench {
   /// Target footprint (in GiB) used to replicate kernel tensor arguments along
   /// a new outer dimension for cold-cache benchmarking (0 = disabled).
   double replicationTargetGiB;
+
+  /// When true, the replicated cold-cache buffers are initialized at runtime
+  /// with random floating-point values instead of zeros.
+  bool replicationRandomInit = false;
 
   /// Number of replicas added as a new outer dimension to each tensor argument.
   /// 1 means replication is disabled.

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -140,6 +140,11 @@ private:
         pm.addPass(createBufferize());
       }
 
+      // Replicate benchmark kernel arguments for cold-cache timing. Runs on
+      // bufferized memrefs so replicas are plain subviews (no allocs/copies).
+      // No-op unless the benchmark producer requested replication.
+      pm.addPass(createReplicateBenchArgs());
+
       // Lower Linalg to XSMM.
       pm.addNestedPass<func::FuncOp>(
           createLinalgLowering(LinalgLoweringOptions{skipOperations}));

--- a/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
+++ b/lib/TPP/Dialect/Perf/BufferizableOpInterfaceImpl.cpp
@@ -44,8 +44,8 @@ struct SinkLayoutInterface
     return true;
   }
 
-  SmallVector<OpResult> getAliasingOpResult(Operation *op, OpOperand &opOperand,
-                                            const AnalysisState &state) const {
+  AliasingValueList getAliasingValues(Operation *op, OpOperand &opOperand,
+                                      const AnalysisState &state) const {
     return {};
   }
 

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -29,6 +29,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/InitAllDialects.h"
@@ -51,6 +52,7 @@
 #include "mlir/Transforms/Passes.h"
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 
 using namespace mlir;
@@ -62,6 +64,7 @@ MLIRBench::MLIRBench(mlir::Operation *op, const MLIRBenchConfig &config)
   backend = config.backend;
   initType = config.initType;
   offloadToDevice = config.offloadToDevice;
+  replicationTargetGiB = config.replicationTargetGiB;
 
   module = dyn_cast<ModuleOp>(op);
   assert(module && "expected a 'builtin.Module' op");
@@ -226,6 +229,49 @@ LogicalResult MLIRBench::createKernelArgs() {
   auto funcType = kernel.getFunctionType();
   std::vector<Type> argTypes(funcType.getInputs().begin(),
                              funcType.getInputs().end());
+
+  // When replication is requested, compute how many copies of the kernel
+  // arguments are needed so that their combined footprint reaches the target
+  // size. The actual replication (extra outer dimension + inner loop over the
+  // replicas) is performed later, after bufferization, by the
+  // `replicate-bench-args` pass operating on memrefs (so the replicas become
+  // plain subviews without per-iteration allocations or copies). Here we only
+  // compute the factor, record it for that pass, and keep it for the timing
+  // normalization in getTimerStats(). This mirrors the "n_layers" replication
+  // used by libxsmm's sfc_ca_gemm benchmark to defeat large L3 caches and
+  // measure cold-cache GEMM performance.
+  replicationFactor = 1;
+  if (replicationTargetGiB > 0.0) {
+    double footprintBytes = 0.0;
+    for (auto argTy : argTypes) {
+      auto shaped = dyn_cast<ShapedType>(argTy);
+      if (!shaped)
+        continue;
+      if (!isa<TensorType>(argTy))
+        return module.emitError(
+            "Replication benchmarking only supports tensor kernel arguments");
+      if (!shaped.hasStaticShape())
+        return module.emitError(
+            "Replication benchmarking requires statically shaped arguments");
+      int64_t numElements = 1;
+      for (auto d : shaped.getShape())
+        numElements *= d;
+      int64_t eltBytes =
+          (shaped.getElementType().getIntOrFloatBitWidth() + 7) / 8;
+      footprintBytes += static_cast<double>(numElements) *
+                        static_cast<double>(eltBytes);
+    }
+    if (footprintBytes > 0.0) {
+      double targetBytes = replicationTargetGiB * 1024.0 * 1024.0 * 1024.0;
+      replicationFactor = std::max<int64_t>(
+          1, static_cast<int64_t>(std::ceil(targetBytes / footprintBytes)));
+    }
+    // Record the factor for the post-bufferization replication pass.
+    if (replicationFactor > 1)
+      module->setAttr("tpp.bench_replication_factor",
+                      builder.getI64IntegerAttr(replicationFactor));
+  }
+
   for (unsigned i = 0; i < argTypes.size(); i++) {
     auto argTy = argTypes[i];
     auto nextArgTy = (i + 1 < argTypes.size()) ? argTypes[i + 1] : nullptr;
@@ -274,7 +320,7 @@ LogicalResult MLIRBench::createKernelArgs() {
               // Create a memref global and cast it to a tensor
               // to ensure that the buffer is writable and
               // bufferization does not insert extra
-              // allocations + copies
+              // allocations + copies.
               auto memrefType = MemRefType::get(tensorTy.getShape(),
                                                 tensorTy.getElementType());
               auto nextShapedType =
@@ -331,7 +377,10 @@ Value MLIRBench::createTimerLoop(unsigned iters) {
   auto bench = perf::BenchOp::create(builder, unkLoc, count, ValueRange{});
   builder.setInsertionPointToStart(bench.getBody());
 
-  // Call the kernel, ignore output
+  // Call the kernel, ignore output. When replication benchmarking is active
+  // (replicationFactor > 1), the post-bufferization `replicate-bench-args` pass
+  // wraps this call in a loop over the replicated argument buffers; here we just
+  // emit the single call.
   [[maybe_unused]] auto *call = callKernel();
   assert(call && "Failed to generate a kernel call");
 
@@ -349,8 +398,21 @@ Value MLIRBench::getTimerStats(Value deltas) {
   auto iters = cast<perf::BenchOp>(bench)->getOperand(0);
 
   // Mean is deltas / iters
-  auto fIters =
+  Value fIters =
       arith::UIToFPOp::create(builder, unkLoc, builder.getF64Type(), iters);
+
+  // Each timed iteration runs `replicationFactor` kernel calls (one per
+  // replica), so normalize by that factor to report the per-call time. This
+  // keeps the reported throughput correct for the per-call BENCH_TOTAL_FLOPS,
+  // matching the C benchmark where the flop count is scaled by the number of
+  // replicas.
+  if (replicationFactor > 1) {
+    auto factor = arith::ConstantOp::create(
+        builder, unkLoc,
+        builder.getF64FloatAttr(static_cast<double>(replicationFactor)));
+    fIters = arith::MulFOp::create(builder, unkLoc, fIters, factor);
+  }
+
   auto div = arith::DivFOp::create(builder, unkLoc, deltas, fIters);
   return div.getResult();
 }

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -65,6 +65,7 @@ MLIRBench::MLIRBench(mlir::Operation *op, const MLIRBenchConfig &config)
   initType = config.initType;
   offloadToDevice = config.offloadToDevice;
   replicationTargetGiB = config.replicationTargetGiB;
+  replicationRandomInit = config.replicationRandomInit;
 
   module = dyn_cast<ModuleOp>(op);
   assert(module && "expected a 'builtin.Module' op");
@@ -267,9 +268,16 @@ LogicalResult MLIRBench::createKernelArgs() {
           1, static_cast<int64_t>(std::ceil(targetBytes / footprintBytes)));
     }
     // Record the factor for the post-bufferization replication pass.
-    if (replicationFactor > 1)
+    if (replicationFactor > 1) {
       module->setAttr("tpp.bench_replication_factor",
                       builder.getI64IntegerAttr(replicationFactor));
+      // Request runtime random initialization of the replicated buffers so the
+      // FMA units operate on non-trivial data (all-zero inputs run at an
+      // unrealistically high frequency).
+      if (replicationRandomInit)
+        module->setAttr("tpp.bench_replication_random_init",
+                        builder.getUnitAttr());
+    }
   }
 
   for (unsigned i = 0; i < argTypes.size(); i++) {

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -248,10 +248,7 @@ LogicalResult MLIRBench::createKernelArgs() {
       auto shaped = dyn_cast<ShapedType>(argTy);
       if (!shaped)
         continue;
-      if (!isa<TensorType>(argTy))
-        return module.emitError(
-            "Replication benchmarking only supports tensor kernel arguments");
-      if (!shaped.hasStaticShape())
+      if (!isa<TensorType>(argTy) || !shaped.hasStaticShape())
         return module.emitError(
             "Replication benchmarking requires statically shaped arguments");
       int64_t numElements = 1;

--- a/lib/TPP/Runner/TppRunnerWrapper.cpp
+++ b/lib/TPP/Runner/TppRunnerWrapper.cpp
@@ -62,7 +62,8 @@ struct TppRunnerWrapper
     double replicationTargetGiB =
         (numBenchLoops > 1) ? benchReplicationGiB : 0.0;
     MLIRBenchConfig config(seed, tensorInitType, identity, backend,
-                           offloadToDevice, replicationTargetGiB);
+                           offloadToDevice, replicationTargetGiB,
+                           /*replicationRandomInit=*/randomSplat);
     MLIRBench bench(module, config);
 
     // Can only either print or run benchmarks, make this clear before we try to

--- a/lib/TPP/Runner/TppRunnerWrapper.cpp
+++ b/lib/TPP/Runner/TppRunnerWrapper.cpp
@@ -56,7 +56,13 @@ struct TppRunnerWrapper
     }
 
     // Benchmark object.
-    MLIRBenchConfig config(seed, tensorInitType, identity, backend, offloadToDevice);
+    // Replication only makes sense in the benchmarking path, where the kernel
+    // is invoked from inside the timing loop. Disable it for single runs so the
+    // kernel arguments keep their original shapes.
+    double replicationTargetGiB =
+        (numBenchLoops > 1) ? benchReplicationGiB : 0.0;
+    MLIRBenchConfig config(seed, tensorInitType, identity, backend,
+                           offloadToDevice, replicationTargetGiB);
     MLIRBench bench(module, config);
 
     // Can only either print or run benchmarks, make this clear before we try to

--- a/lib/TPP/Transforms/CMakeLists.txt
+++ b/lib/TPP/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_library(TPPTransforms
   ConstantFoldPack.cpp
   ConvertForAllToParallelOp.cpp
   DecomposeAggregatedOps.cpp
+  ReplicateBenchArgs.cpp
   LinalgDeGeneralize.cpp
   LowerPacksAndUnpacks.cpp
   LowerPacksAndUnpacksWithoutTranspose.cpp

--- a/lib/TPP/Transforms/ReplicateBenchArgs.cpp
+++ b/lib/TPP/Transforms/ReplicateBenchArgs.cpp
@@ -1,0 +1,217 @@
+//===- ReplicateBenchArgs.cpp -----------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Replicate benchmark kernel arguments for cold-cache timing.
+//
+// Runs after bufferization on the benchmark wrapper produced by tpp-run. The
+// single kernel call inside every `perf.bench` region is wrapped in an
+// `scf.for` loop over a new outer "replica" dimension. Each kernel argument is
+// backed by a freshly allocated, value-initialized global memref whose leading
+// dimension is the replication factor; every iteration feeds the kernel a
+// distinct `memref.subview` (pure pointer arithmetic, no allocation or copy).
+// This mirrors the "n_layers" replication used by libxsmm's cold-cache GEMM
+// benchmark: the same problem is run on different memory so caches stay cold.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TPP/Passes.h"
+
+#include "TPP/Dialect/Perf/PerfOps.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace tpp {
+#define GEN_PASS_DEF_REPLICATEBENCHARGS
+#include "TPP/Passes.h.inc"
+} // namespace tpp
+} // namespace mlir
+
+namespace {
+
+constexpr StringLiteral kReplicationFactorAttr = "tpp.bench_replication_factor";
+
+// Build a splat initializer (value 1) for the replicated global. Using a
+// constant non-zero value keeps the buffers free of denormals/garbage that
+// would otherwise distort floating-point timing.
+static TypedAttr getOneScalar(OpBuilder &builder, Type elemTy) {
+  if (isa<FloatType>(elemTy))
+    return builder.getFloatAttr(elemTy, 1.0);
+  if (auto intTy = dyn_cast<IntegerType>(elemTy))
+    return builder.getIntegerAttr(elemTy, 1);
+  return nullptr;
+}
+
+struct ReplicateBenchArgs
+    : public tpp::impl::ReplicateBenchArgsBase<ReplicateBenchArgs> {
+  using ReplicateBenchArgsBase::ReplicateBenchArgsBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    // Resolve the replication factor: command-line option wins, otherwise read
+    // the attribute stamped by the benchmark producer.
+    int64_t factor = replicationFactor;
+    if (factor <= 0) {
+      if (auto attr =
+              module->getAttrOfType<IntegerAttr>(kReplicationFactorAttr))
+        factor = attr.getInt();
+    }
+    module->removeAttr(kReplicationFactorAttr);
+    if (factor <= 1)
+      return;
+
+    // Collect the benchmark timing regions.
+    SmallVector<perf::BenchOp> benches;
+    module.walk([&](perf::BenchOp bench) { benches.push_back(bench); });
+    if (benches.empty())
+      return;
+
+    // Identify the benchmarked kernel from the first call inside any bench.
+    func::FuncOp kernel;
+    for (auto bench : benches) {
+      bench.getBodyRegion().walk([&](func::CallOp call) {
+        if (!kernel)
+          kernel = module.lookupSymbol<func::FuncOp>(call.getCalleeAttr());
+      });
+      if (kernel)
+        break;
+    }
+    if (!kernel) {
+      module.emitError("replicate-bench-args: no kernel call found in perf.bench");
+      return signalPassFailure();
+    }
+
+    MLIRContext *ctx = module.getContext();
+    Location loc = kernel.getLoc();
+    auto origInputs = kernel.getFunctionType().getInputs();
+
+    // For each kernel argument, create a replicated, initialized global memref
+    // and pre-compute the rank-reduced strided type of a single replica slice.
+    OpBuilder globalBuilder(ctx);
+    globalBuilder.setInsertionPointToStart(module.getBody());
+    SmallVector<StringRef> globalNames(origInputs.size());
+    SmallVector<MemRefType> sliceTypes(origInputs.size());
+    auto alignment = globalBuilder.getI64IntegerAttr(128);
+    for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
+      auto memrefTy = dyn_cast<MemRefType>(inTy);
+      if (!memrefTy || !memrefTy.hasStaticShape()) {
+        module.emitError("replicate-bench-args: kernel arguments must be "
+                         "statically shaped memrefs");
+        return signalPassFailure();
+      }
+
+      // Replicated global shape: [factor, origShape...].
+      SmallVector<int64_t> replShape;
+      replShape.push_back(factor);
+      replShape.append(memrefTy.getShape().begin(), memrefTy.getShape().end());
+      auto replTy = MemRefType::get(replShape, memrefTy.getElementType());
+
+      TypedAttr one = getOneScalar(globalBuilder, memrefTy.getElementType());
+      if (!one) {
+        module.emitError("replicate-bench-args: unsupported element type");
+        return signalPassFailure();
+      }
+      auto tensorTy =
+          RankedTensorType::get(replShape, memrefTy.getElementType());
+      auto initAttr = DenseElementsAttr::get(tensorTy, one);
+
+      std::string name = "__bench_replica_" + std::to_string(idx);
+      auto global = memref::GlobalOp::create(
+          globalBuilder, loc, name, globalBuilder.getStringAttr("private"),
+          replTy, initAttr, /*constant=*/false, alignment);
+      globalNames[idx] = global.getName();
+
+      // Type of a single replica slice: drop the leading replica dimension,
+      // keeping a (statically strided, dynamically offset) view into the
+      // contiguous replicated buffer.
+      SmallVector<int64_t> staticOffsets, staticSizes, staticStrides;
+      staticOffsets.push_back(ShapedType::kDynamic);
+      staticSizes.push_back(1);
+      staticStrides.push_back(1);
+      for (int64_t d : memrefTy.getShape()) {
+        staticOffsets.push_back(0);
+        staticSizes.push_back(d);
+        staticStrides.push_back(1);
+      }
+      sliceTypes[idx] = memref::SubViewOp::inferRankReducedResultType(
+          memrefTy.getShape(), replTy, staticOffsets, staticSizes,
+          staticStrides);
+    }
+
+    // Relax the kernel signature so it accepts the strided replica slices.
+    SmallVector<Type> newInputs(sliceTypes.begin(), sliceTypes.end());
+    kernel.setType(FunctionType::get(ctx, newInputs,
+                                     kernel.getFunctionType().getResults()));
+    for (auto [blockArg, sliceTy] :
+         llvm::zip_equal(kernel.getBody().getArguments(), sliceTypes))
+      blockArg.setType(sliceTy);
+
+    // Wrap every kernel call inside a perf.bench in a replication loop.
+    for (auto bench : benches) {
+      SmallVector<func::CallOp> calls;
+      bench.getBodyRegion().walk([&](func::CallOp call) {
+        if (call.getCallee() == kernel.getSymName())
+          calls.push_back(call);
+      });
+
+      for (func::CallOp call : calls) {
+        OpBuilder builder(call);
+
+        // Hoist the global handles out of the loop; they are loop invariant.
+        SmallVector<Value> globals(origInputs.size());
+        for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
+          auto replTy = cast<MemRefType>(
+              cast<memref::GlobalOp>(module.lookupSymbol(globalNames[idx]))
+                  .getType());
+          globals[idx] = memref::GetGlobalOp::create(builder, loc, replTy,
+                                                      globalNames[idx]);
+        }
+
+        Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+        Value one = arith::ConstantIndexOp::create(builder, loc, 1);
+        Value ub = arith::ConstantIndexOp::create(builder, loc, factor);
+        auto loop = scf::ForOp::create(builder, loc, zero, ub, one);
+
+        OpBuilder bodyBuilder(loop.getBody(), loop.getBody()->begin());
+        Value iv = loop.getInductionVar();
+
+        SmallVector<Value> sliceArgs(origInputs.size());
+        for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
+          auto memrefTy = cast<MemRefType>(inTy);
+          SmallVector<OpFoldResult> offsets, sizes, strides;
+          offsets.push_back(iv);
+          sizes.push_back(bodyBuilder.getIndexAttr(1));
+          strides.push_back(bodyBuilder.getIndexAttr(1));
+          for (int64_t d : memrefTy.getShape()) {
+            offsets.push_back(bodyBuilder.getIndexAttr(0));
+            sizes.push_back(bodyBuilder.getIndexAttr(d));
+            strides.push_back(bodyBuilder.getIndexAttr(1));
+          }
+          sliceArgs[idx] = memref::SubViewOp::create(
+              bodyBuilder, loc, sliceTypes[idx], globals[idx], offsets, sizes,
+              strides);
+        }
+
+        func::CallOp::create(bodyBuilder, loc, kernel, sliceArgs);
+        call.erase();
+      }
+    }
+  }
+};
+
+} // namespace

--- a/lib/TPP/Transforms/ReplicateBenchArgs.cpp
+++ b/lib/TPP/Transforms/ReplicateBenchArgs.cpp
@@ -10,12 +10,25 @@
 //
 // Runs after bufferization on the benchmark wrapper produced by tpp-run. The
 // single kernel call inside every `perf.bench` region is wrapped in an
-// `scf.for` loop over a new outer "replica" dimension. Each kernel argument is
-// backed by a freshly allocated, value-initialized global memref whose leading
-// dimension is the replication factor; every iteration feeds the kernel a
-// distinct `memref.subview` (pure pointer arithmetic, no allocation or copy).
+// `scf.for` loop over a new "replica" dimension. For each kernel argument a
+// flat `i8` global of `factor * sizeof(arg)` bytes is allocated once; every
+// iteration feeds the kernel a distinct `memref.view` into that buffer (pure
+// pointer arithmetic, no allocation or copy). `memref.view` is used instead of
+// `memref.subview` on purpose: it always yields an identity-layout, offset-0
+// result that exactly matches the original (contiguous) argument type, so any
+// layout-sensitive ops inside the kernel (e.g. the `memref.expand_shape`
+// introduced by bf16 VNNI packing) keep verifying. A strided subview with a
+// dynamic offset would instead change the argument layout and break them.
+//
 // This mirrors the "n_layers" replication used by libxsmm's cold-cache GEMM
 // benchmark: the same problem is run on different memory so caches stay cold.
+//
+// The buffers are zero initialized by default. With random initialization
+// enabled (the `random-init` option or the `tpp.bench_replication_random_init`
+// module attribute) each float buffer is instead filled once, before any timed
+// region, with PRNG-generated values in [1, 2). All-zero inputs let the FMA
+// units run at an unrealistically high clock, so random data yields more
+// representative timings.
 //
 //===----------------------------------------------------------------------===//
 
@@ -44,16 +57,50 @@ namespace tpp {
 namespace {
 
 constexpr StringLiteral kReplicationFactorAttr = "tpp.bench_replication_factor";
+constexpr StringLiteral kReplicationRandomInitAttr =
+    "tpp.bench_replication_random_init";
 
-// Build a splat initializer (value 1) for the replicated global. Using a
-// constant non-zero value keeps the buffers free of denormals/garbage that
-// would otherwise distort floating-point timing.
-static TypedAttr getOneScalar(OpBuilder &builder, Type elemTy) {
-  if (isa<FloatType>(elemTy))
-    return builder.getFloatAttr(elemTy, 1.0);
-  if (auto intTy = dyn_cast<IntegerType>(elemTy))
-    return builder.getIntegerAttr(elemTy, 1);
-  return nullptr;
+// Emit a cheap counter-based PRNG that maps a linear element index to a
+// floating-point value in [1, 2). The [1, 2) range guarantees normal (non-zero,
+// non-denormal, finite) values, so the FMA units are exercised realistically
+// without the risk of NaN/Inf slowdowns. f32 and bf16 are handled explicitly;
+// for any other float type it falls back to a constant 1.0.
+static Value emitRandomFloat(OpBuilder &b, Location loc, Value linearIdx,
+                             Type elemTy) {
+  Type i32Ty = b.getI32Type();
+  auto c32 = [&](uint32_t v) -> Value {
+    return arith::ConstantOp::create(
+        b, loc, b.getIntegerAttr(i32Ty, static_cast<int32_t>(v)));
+  };
+
+  // MurmurHash3-style finalizer using modulo-2^32 arithmetic.
+  Value h = arith::IndexCastOp::create(b, loc, i32Ty, linearIdx);
+  h = arith::MulIOp::create(b, loc, h, c32(0x9E3779B1u));
+  h = arith::XOrIOp::create(b, loc, h,
+                            arith::ShRUIOp::create(b, loc, h, c32(16)));
+  h = arith::MulIOp::create(b, loc, h, c32(0x85EBCA77u));
+  h = arith::XOrIOp::create(b, loc, h,
+                            arith::ShRUIOp::create(b, loc, h, c32(13)));
+
+  if (elemTy.isF32()) {
+    // mantissa = h & 0x7FFFFF; bits = 0x3F800000 | mantissa -> [1, 2).
+    Value mant = arith::AndIOp::create(b, loc, h, c32(0x7FFFFFu));
+    Value bits = arith::OrIOp::create(b, loc, mant, c32(0x3F800000u));
+    return arith::BitcastOp::create(b, loc, elemTy, bits);
+  }
+  if (elemTy.isBF16()) {
+    // bf16 is the top 16 bits of an f32; build the [1, 2) pattern directly.
+    Type i16Ty = b.getIntegerType(16);
+    Value h16 = arith::TruncIOp::create(b, loc, i16Ty, h);
+    auto c16 = [&](uint16_t v) -> Value {
+      return arith::ConstantOp::create(
+          b, loc, b.getIntegerAttr(i16Ty, static_cast<int16_t>(v)));
+    };
+    Value mant = arith::AndIOp::create(b, loc, h16, c16(0x7Fu));
+    Value bits = arith::OrIOp::create(b, loc, mant, c16(0x3F80u));
+    return arith::BitcastOp::create(b, loc, elemTy, bits);
+  }
+  return arith::ConstantOp::create(b, loc, b.getFloatAttr(elemTy, 1.0));
 }
 
 struct ReplicateBenchArgs
@@ -72,6 +119,11 @@ struct ReplicateBenchArgs
         factor = attr.getInt();
     }
     module->removeAttr(kReplicationFactorAttr);
+
+    // Resolve random initialization: command-line option OR module attribute.
+    bool doRandomInit = randomInit || module->hasAttr(kReplicationRandomInitAttr);
+    module->removeAttr(kReplicationRandomInitAttr);
+
     if (factor <= 1)
       return;
 
@@ -100,12 +152,20 @@ struct ReplicateBenchArgs
     Location loc = kernel.getLoc();
     auto origInputs = kernel.getFunctionType().getInputs();
 
-    // For each kernel argument, create a replicated, initialized global memref
-    // and pre-compute the rank-reduced strided type of a single replica slice.
+    // For each kernel argument, allocate a flat i8 global large enough to hold
+    // `factor` contiguous copies of the argument. The buffer is zero
+    // initialized: the all-zero byte pattern reinterprets to +0.0 for floats
+    // and 0 for integers, both of which are normal values that avoid the
+    // denormal/NaN penalties that uninitialized memory could introduce. When
+    // `doRandomInit` is set, the buffers are instead filled with random values
+    // at runtime (see below); the zero global init still serves as a safe
+    // default for any element type the random fill does not cover.
     OpBuilder globalBuilder(ctx);
     globalBuilder.setInsertionPointToStart(module.getBody());
+    Type i8Ty = globalBuilder.getI8Type();
     SmallVector<StringRef> globalNames(origInputs.size());
-    SmallVector<MemRefType> sliceTypes(origInputs.size());
+    SmallVector<int64_t> replicaByteSizes(origInputs.size());
+    SmallVector<int64_t> totalElemCounts(origInputs.size());
     auto alignment = globalBuilder.getI64IntegerAttr(128);
     for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
       auto memrefTy = dyn_cast<MemRefType>(inTy);
@@ -114,52 +174,72 @@ struct ReplicateBenchArgs
                          "statically shaped memrefs");
         return signalPassFailure();
       }
-
-      // Replicated global shape: [factor, origShape...].
-      SmallVector<int64_t> replShape;
-      replShape.push_back(factor);
-      replShape.append(memrefTy.getShape().begin(), memrefTy.getShape().end());
-      auto replTy = MemRefType::get(replShape, memrefTy.getElementType());
-
-      TypedAttr one = getOneScalar(globalBuilder, memrefTy.getElementType());
-      if (!one) {
+      if (!memrefTy.getLayout().isIdentity()) {
+        module.emitError("replicate-bench-args: kernel arguments must have "
+                         "identity layout");
+        return signalPassFailure();
+      }
+      Type elemTy = memrefTy.getElementType();
+      if (!elemTy.isIntOrFloat()) {
         module.emitError("replicate-bench-args: unsupported element type");
         return signalPassFailure();
       }
-      auto tensorTy =
-          RankedTensorType::get(replShape, memrefTy.getElementType());
-      auto initAttr = DenseElementsAttr::get(tensorTy, one);
+
+      int64_t numElements = 1;
+      for (int64_t d : memrefTy.getShape())
+        numElements *= d;
+      int64_t eltBytes = (elemTy.getIntOrFloatBitWidth() + 7) / 8;
+      int64_t replicaBytes = numElements * eltBytes;
+      replicaByteSizes[idx] = replicaBytes;
+      totalElemCounts[idx] = numElements * factor;
+      int64_t totalBytes = replicaBytes * factor;
+
+      auto flatTy = MemRefType::get({totalBytes}, i8Ty);
+      auto tensorTy = RankedTensorType::get({totalBytes}, i8Ty);
+      auto initAttr = DenseElementsAttr::get(
+          tensorTy, globalBuilder.getIntegerAttr(i8Ty, 0));
 
       std::string name = "__bench_replica_" + std::to_string(idx);
       auto global = memref::GlobalOp::create(
           globalBuilder, loc, name, globalBuilder.getStringAttr("private"),
-          replTy, initAttr, /*constant=*/false, alignment);
+          flatTy, initAttr, /*constant=*/false, alignment);
       globalNames[idx] = global.getName();
-
-      // Type of a single replica slice: drop the leading replica dimension,
-      // keeping a (statically strided, dynamically offset) view into the
-      // contiguous replicated buffer.
-      SmallVector<int64_t> staticOffsets, staticSizes, staticStrides;
-      staticOffsets.push_back(ShapedType::kDynamic);
-      staticSizes.push_back(1);
-      staticStrides.push_back(1);
-      for (int64_t d : memrefTy.getShape()) {
-        staticOffsets.push_back(0);
-        staticSizes.push_back(d);
-        staticStrides.push_back(1);
-      }
-      sliceTypes[idx] = memref::SubViewOp::inferRankReducedResultType(
-          memrefTy.getShape(), replTy, staticOffsets, staticSizes,
-          staticStrides);
     }
 
-    // Relax the kernel signature so it accepts the strided replica slices.
-    SmallVector<Type> newInputs(sliceTypes.begin(), sliceTypes.end());
-    kernel.setType(FunctionType::get(ctx, newInputs,
-                                     kernel.getFunctionType().getResults()));
-    for (auto [blockArg, sliceTy] :
-         llvm::zip_equal(kernel.getBody().getArguments(), sliceTypes))
-      blockArg.setType(sliceTy);
+    // Optionally fill each replicated buffer with random floating-point values
+    // once, before any timed region. All-zero inputs let the FMA units run at
+    // an unrealistically high clock; random data exercises them realistically.
+    // The fill loop sits before the first perf.bench so it is never timed.
+    if (doRandomInit) {
+      OpBuilder initBuilder(benches.front());
+      Value c0 = arith::ConstantIndexOp::create(initBuilder, loc, 0);
+      Value c1 = arith::ConstantIndexOp::create(initBuilder, loc, 1);
+      for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
+        auto memrefTy = cast<MemRefType>(inTy);
+        Type elemTy = memrefTy.getElementType();
+        // Only float buffers get randomized; integer/other buffers keep the
+        // safe zero initialization.
+        if (!isa<FloatType>(elemTy))
+          continue;
+
+        auto flatTy = cast<MemRefType>(
+            cast<memref::GlobalOp>(module.lookupSymbol(globalNames[idx]))
+                .getType());
+        Value flat = memref::GetGlobalOp::create(initBuilder, loc, flatTy,
+                                                 globalNames[idx]);
+        // Typed view over the whole buffer: memref<totalElems x elemTy>.
+        auto viewTy = MemRefType::get({totalElemCounts[idx]}, elemTy);
+        Value typedView = memref::ViewOp::create(initBuilder, loc, viewTy, flat,
+                                                 c0, /*sizes=*/ValueRange{});
+        Value ub = arith::ConstantIndexOp::create(initBuilder, loc,
+                                                  totalElemCounts[idx]);
+        auto fill = scf::ForOp::create(initBuilder, loc, c0, ub, c1);
+        OpBuilder fb(fill.getBody(), fill.getBody()->begin());
+        Value iv = fill.getInductionVar();
+        Value v = emitRandomFloat(fb, loc, iv, elemTy);
+        memref::StoreOp::create(fb, loc, v, typedView, ValueRange{iv});
+      }
+    }
 
     // Wrap every kernel call inside a perf.bench in a replication loop.
     for (auto bench : benches) {
@@ -172,13 +252,13 @@ struct ReplicateBenchArgs
       for (func::CallOp call : calls) {
         OpBuilder builder(call);
 
-        // Hoist the global handles out of the loop; they are loop invariant.
+        // Hoist the flat global handles out of the loop; they are invariant.
         SmallVector<Value> globals(origInputs.size());
         for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
-          auto replTy = cast<MemRefType>(
+          auto flatTy = cast<MemRefType>(
               cast<memref::GlobalOp>(module.lookupSymbol(globalNames[idx]))
                   .getType());
-          globals[idx] = memref::GetGlobalOp::create(builder, loc, replTy,
+          globals[idx] = memref::GetGlobalOp::create(builder, loc, flatTy,
                                                       globalNames[idx]);
         }
 
@@ -190,24 +270,22 @@ struct ReplicateBenchArgs
         OpBuilder bodyBuilder(loop.getBody(), loop.getBody()->begin());
         Value iv = loop.getInductionVar();
 
-        SmallVector<Value> sliceArgs(origInputs.size());
+        SmallVector<Value> viewArgs(origInputs.size());
         for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
           auto memrefTy = cast<MemRefType>(inTy);
-          SmallVector<OpFoldResult> offsets, sizes, strides;
-          offsets.push_back(iv);
-          sizes.push_back(bodyBuilder.getIndexAttr(1));
-          strides.push_back(bodyBuilder.getIndexAttr(1));
-          for (int64_t d : memrefTy.getShape()) {
-            offsets.push_back(bodyBuilder.getIndexAttr(0));
-            sizes.push_back(bodyBuilder.getIndexAttr(d));
-            strides.push_back(bodyBuilder.getIndexAttr(1));
-          }
-          sliceArgs[idx] = memref::SubViewOp::create(
-              bodyBuilder, loc, sliceTypes[idx], globals[idx], offsets, sizes,
-              strides);
+          // Byte offset of replica `iv`: iv * sizeof(arg).
+          Value replicaBytes = arith::ConstantIndexOp::create(
+              bodyBuilder, loc, replicaByteSizes[idx]);
+          Value byteShift =
+              arith::MulIOp::create(bodyBuilder, loc, iv, replicaBytes);
+          // memref.view yields an identity-layout, offset-0 memref that matches
+          // the original argument type exactly.
+          viewArgs[idx] = memref::ViewOp::create(
+              bodyBuilder, loc, memrefTy, globals[idx], byteShift,
+              /*sizes=*/ValueRange{});
         }
 
-        func::CallOp::create(bodyBuilder, loc, kernel, sliceArgs);
+        func::CallOp::create(bodyBuilder, loc, kernel, viewArgs);
         call.erase();
       }
     }

--- a/lib/TPP/Transforms/ReplicateBenchArgs.cpp
+++ b/lib/TPP/Transforms/ReplicateBenchArgs.cpp
@@ -23,12 +23,12 @@
 // This mirrors the "n_layers" replication used by libxsmm's cold-cache GEMM
 // benchmark: the same problem is run on different memory so caches stay cold.
 //
-// The buffers are zero initialized by default. With random initialization
-// enabled (the `random-init` option or the `tpp.bench_replication_random_init`
-// module attribute) each float buffer is instead filled once, before any timed
-// region, with PRNG-generated values in [1, 2). All-zero inputs let the FMA
-// units run at an unrealistically high clock, so random data yields more
-// representative timings.
+// Each float buffer is filled once, before any timed region. By default it is
+// filled with the constant 1.0; with random initialization enabled (the
+// `random-init` option or the `tpp.bench_replication_random_init` module
+// attribute) it is instead filled with PRNG-generated values in [1, 2).
+// All-zero inputs let the FMA units run at an unrealistically high clock, so
+// neither default value is zero.
 //
 //===----------------------------------------------------------------------===//
 
@@ -156,10 +156,11 @@ struct ReplicateBenchArgs
     // `factor` contiguous copies of the argument. The buffer is zero
     // initialized: the all-zero byte pattern reinterprets to +0.0 for floats
     // and 0 for integers, both of which are normal values that avoid the
-    // denormal/NaN penalties that uninitialized memory could introduce. When
-    // `doRandomInit` is set, the buffers are instead filled with random values
-    // at runtime (see below); the zero global init still serves as a safe
-    // default for any element type the random fill does not cover.
+    // denormal/NaN penalties that uninitialized memory could introduce. The
+    // float buffers are then overwritten at runtime (see below) with 1.0 by
+    // default, or random values when `doRandomInit` is set; the zero global
+    // init still serves as a safe default for any element type the runtime
+    // fill does not cover (e.g. integers).
     OpBuilder globalBuilder(ctx);
     globalBuilder.setInsertionPointToStart(module.getBody());
     Type i8Ty = globalBuilder.getI8Type();
@@ -206,19 +207,22 @@ struct ReplicateBenchArgs
       globalNames[idx] = global.getName();
     }
 
-    // Optionally fill each replicated buffer with random floating-point values
-    // once, before any timed region. All-zero inputs let the FMA units run at
-    // an unrealistically high clock; random data exercises them realistically.
-    // The fill loop sits before the first perf.bench so it is never timed.
-    if (doRandomInit) {
+    // Fill each replicated float buffer once, before any timed region. All-zero
+    // inputs let the FMA units run at an unrealistically high clock, so by
+    // default every float buffer is filled with the constant 1.0; with random
+    // initialization enabled it is instead filled with random values in
+    // [1, 2), which exercises the units more realistically. The fill loop sits
+    // before the first perf.bench so it is never timed. Integer/other buffers
+    // keep the safe zero initialization.
+    {
       OpBuilder initBuilder(benches.front());
       Value c0 = arith::ConstantIndexOp::create(initBuilder, loc, 0);
       Value c1 = arith::ConstantIndexOp::create(initBuilder, loc, 1);
       for (auto [idx, inTy] : llvm::enumerate(origInputs)) {
         auto memrefTy = cast<MemRefType>(inTy);
         Type elemTy = memrefTy.getElementType();
-        // Only float buffers get randomized; integer/other buffers keep the
-        // safe zero initialization.
+        // Only float buffers are filled; integer/other buffers keep the safe
+        // zero initialization.
         if (!isa<FloatType>(elemTy))
           continue;
 
@@ -236,7 +240,10 @@ struct ReplicateBenchArgs
         auto fill = scf::ForOp::create(initBuilder, loc, c0, ub, c1);
         OpBuilder fb(fill.getBody(), fill.getBody()->begin());
         Value iv = fill.getInductionVar();
-        Value v = emitRandomFloat(fb, loc, iv, elemTy);
+        Value v = doRandomInit
+                      ? emitRandomFloat(fb, loc, iv, elemTy)
+                      : arith::ConstantOp::create(
+                            fb, loc, fb.getFloatAttr(elemTy, 1.0));
         memref::StoreOp::create(fb, loc, v, typedView, ValueRange{iv});
       }
     }

--- a/test/Passes/replicate-bench-args.mlir
+++ b/test/Passes/replicate-bench-args.mlir
@@ -20,7 +20,13 @@ func.func @_entry(%a: memref<4x4xf32>, %b: memref<4x4xf32>, %c: memref<4x4xf32>)
   return
 }
 
+// By default the float buffers are filled once, before perf.bench, with the
+// constant 1.0 through a whole-buffer memref.view + scf.for.
 // CHECK-LABEL: func.func @entry
+// CHECK: memref.view %{{.*}}[%{{.*}}][] : memref<128xi8> to memref<32xf32>
+// CHECK: scf.for
+// CHECK: arith.constant 1.000000e+00 : f32
+// CHECK: memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<32xf32>
 // CHECK: perf.bench
 // CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
 // CHECK: memref.view %{{.*}}[%{{.*}}][] : memref<128xi8> to memref<4x4xf32>

--- a/test/Passes/replicate-bench-args.mlir
+++ b/test/Passes/replicate-bench-args.mlir
@@ -1,0 +1,39 @@
+// RUN: tpp-opt %s -replicate-bench-args="replication-factor=2" | FileCheck %s
+
+// Replicate the kernel arguments of a (bufferized) benchmark wrapper so that
+// the timed kernel call iterates over distinct, value-initialized buffers.
+
+// CHECK: memref.global "private" @__bench_replica_0 : memref<2x4x4xf32> = dense<1.000000e+00>
+// CHECK: memref.global "private" @__bench_replica_1 : memref<2x4x4xf32> = dense<1.000000e+00>
+// CHECK: memref.global "private" @__bench_replica_2 : memref<2x4x4xf32> = dense<1.000000e+00>
+
+// The kernel signature is relaxed to accept strided replica slices.
+// CHECK-LABEL: func.func @_entry
+// CHECK-SAME: memref<4x4xf32, strided<[4, 1], offset: ?>>
+func.func @_entry(%a: memref<4x4xf32>, %b: memref<4x4xf32>, %c: memref<4x4xf32>) {
+  linalg.matmul ins(%a, %b : memref<4x4xf32>, memref<4x4xf32>)
+                outs(%c : memref<4x4xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @entry
+// CHECK: perf.bench
+// CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK: memref.subview
+// CHECK: func.call @_entry
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: memref.copy
+func.func @entry() {
+  %c10 = arith.constant 10 : i64
+  %0 = memref.get_global @g0 : memref<4x4xf32>
+  %1 = memref.get_global @g1 : memref<4x4xf32>
+  %2 = memref.get_global @g2 : memref<4x4xf32>
+  %t = perf.bench(%c10 : i64) -> f64 {
+    func.call @_entry(%0, %1, %2)
+        : (memref<4x4xf32>, memref<4x4xf32>, memref<4x4xf32>) -> ()
+  }
+  return
+}
+memref.global "private" @g0 : memref<4x4xf32> = dense<1.000000e+00>
+memref.global "private" @g1 : memref<4x4xf32> = dense<1.000000e+00>
+memref.global "private" @g2 : memref<4x4xf32> = dense<1.000000e+00>

--- a/test/Passes/replicate-bench-args.mlir
+++ b/test/Passes/replicate-bench-args.mlir
@@ -1,15 +1,19 @@
 // RUN: tpp-opt %s -replicate-bench-args="replication-factor=2" | FileCheck %s
+// RUN: tpp-opt %s -replicate-bench-args="replication-factor=2 random-init=true" | FileCheck %s --check-prefix=RANDOM
 
 // Replicate the kernel arguments of a (bufferized) benchmark wrapper so that
-// the timed kernel call iterates over distinct, value-initialized buffers.
+// the timed kernel call iterates over distinct buffers. Each argument is backed
+// by a flat, zero-initialized i8 global holding `factor` contiguous copies
+// (2 * 4 * 4 * 4 bytes = 128 bytes), and every iteration feeds the kernel a
+// `memref.view` into that buffer.
 
-// CHECK: memref.global "private" @__bench_replica_0 : memref<2x4x4xf32> = dense<1.000000e+00>
-// CHECK: memref.global "private" @__bench_replica_1 : memref<2x4x4xf32> = dense<1.000000e+00>
-// CHECK: memref.global "private" @__bench_replica_2 : memref<2x4x4xf32> = dense<1.000000e+00>
+// CHECK: memref.global "private" @__bench_replica_0 : memref<128xi8> = dense<0>
+// CHECK: memref.global "private" @__bench_replica_1 : memref<128xi8> = dense<0>
+// CHECK: memref.global "private" @__bench_replica_2 : memref<128xi8> = dense<0>
 
-// The kernel signature is relaxed to accept strided replica slices.
+// The kernel signature is preserved (identity-layout contiguous memrefs).
 // CHECK-LABEL: func.func @_entry
-// CHECK-SAME: memref<4x4xf32, strided<[4, 1], offset: ?>>
+// CHECK-SAME: memref<4x4xf32>, %{{.*}}: memref<4x4xf32>, %{{.*}}: memref<4x4xf32>
 func.func @_entry(%a: memref<4x4xf32>, %b: memref<4x4xf32>, %c: memref<4x4xf32>) {
   linalg.matmul ins(%a, %b : memref<4x4xf32>, memref<4x4xf32>)
                 outs(%c : memref<4x4xf32>)
@@ -19,10 +23,19 @@ func.func @_entry(%a: memref<4x4xf32>, %b: memref<4x4xf32>, %c: memref<4x4xf32>)
 // CHECK-LABEL: func.func @entry
 // CHECK: perf.bench
 // CHECK: scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK: memref.subview
+// CHECK: memref.view %{{.*}}[%{{.*}}][] : memref<128xi8> to memref<4x4xf32>
 // CHECK: func.call @_entry
 // CHECK-NOT: memref.alloc
 // CHECK-NOT: memref.copy
+
+// With random-init the float buffers are filled once, before perf.bench, with
+// a PRNG value in [1, 2) through a whole-buffer memref.view + scf.for.
+// RANDOM-LABEL: func.func @entry
+// RANDOM: memref.view %{{.*}}[%{{.*}}][] : memref<128xi8> to memref<32xf32>
+// RANDOM: scf.for
+// RANDOM: arith.bitcast %{{.*}} : i32 to f32
+// RANDOM: memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<32xf32>
+// RANDOM: perf.bench
 func.func @entry() {
   %c10 = arith.constant 10 : i64
   %0 = memref.get_global @g0 : memref<4x4xf32>

--- a/tools/tpp-run/tpp-run.cpp
+++ b/tools/tpp-run/tpp-run.cpp
@@ -70,6 +70,17 @@ llvm::cl::opt<unsigned>
     benchNumLoops("n", llvm::cl::desc("Number of loops for benchmarks"),
                   llvm::cl::value_desc("int"), llvm::cl::init(1));
 
+// Replicate kernel tensor arguments to reach the given footprint (in GiB) and
+// iterate over the replicas inside the timing loop to measure cold-cache
+// performance. Zero disables replication.
+llvm::cl::opt<double> benchReplicationGiB(
+    "bench-replication-gb",
+    llvm::cl::desc("Replicate kernel tensor arguments along a new outer "
+                   "dimension until their footprint reaches the given size in "
+                   "GiB and loop over the replicas inside the timing loop "
+                   "(0 = disabled)"),
+    llvm::cl::value_desc("GiB"), llvm::cl::init(0.0));
+
 // Print result
 llvm::cl::opt<bool> printKernelResult("print",
                                       llvm::cl::desc("Print kernel result"),
@@ -197,6 +208,7 @@ static LogicalResult prepareMLIRKernel(Operation *op,
   wrapperOpts.wrapperCpuTargetFeature = runnerCpuTargetFeature;
   wrapperOpts.offloadToDevice = defGpuArgs;
   wrapperOpts.numBenchLoops = benchNumLoops;
+  wrapperOpts.benchReplicationGiB = benchReplicationGiB;
   // Warmup on GPUs are currently breaking buffer allocation on GPUs
   wrapperOpts.benchWarmup = defGpuBackend.empty();
   wrapperOpts.printResult = printKernelResult;


### PR DESCRIPTION
### Summary
Adds the ability to benchmark kernels out of cold caches in tpp-run. Instead of timing the same buffers repeatedly (which keeps everything hot in L2/L3 and inflates throughput), the kernel's tensor arguments are replicated so their combined footprint exceeds the cache size, and each timed iteration runs on a distinct copy. This mirrors the "n_layers" replication used by libxsmm's sfc_ca_gemm cold-cache GEMM benchmark.

### Motivation
For memory-bound or large-GEMM workloads, repeatedly hitting the same hot buffers reports unrealistically high performance. Cold-cache replication produces timings representative of real workloads where weights/activations are not already resident in cache.

### How it works
- New -bench-replication-gb=<GiB> flag on tpp-run (0 = disabled). Only active on the benchmarking path (-n > 1); single runs keep original argument shapes.
- MLIRBench computes a replicationFactor so that factor × argument_footprint ≈ target GiB, stamps it onto the module as tpp.bench_replication_factor, and normalizes the reported per-call time by the factor in getTimerStats() (so throughput stays correct).
-  New replicate-bench-args pass (runs after bufferization, on memrefs) rewrites each perf.bench region:
-- Each kernel argument is backed by a flat, zero-initialized i8 global holding factor contiguous copies.
-- The kernel call is wrapped in an scf.for over the replica dimension; each iteration feeds the kernel a distinct memref.view into the buffer (pure pointer arithmetic, no per-iteration allocation or copy).
-- memref.view (identity layout, offset 0) is used instead of memref.subview so layout-sensitive ops in the kernel (e.g. the memref.expand_shape from bf16 VNNI packing) keep verifying.

### Random initialization
All-zero inputs let FMA units run at an unrealistically high clock. With random-init (auto-enabled via randomSplat), each float buffer is filled once before any timed region using a cheap counter-based MurmurHash3-style PRNG producing values in [1, 2) (guaranteed normal/finite). f32 and bf16 are handled explicitly; integer buffers keep the safe zero init.

### CAUTION
This PR should be merged after #1129 as otherwise the following plot cannot be created as the compiler crashes.  

<img width="2634" height="665" alt="image" src="https://github.com/user-attachments/assets/ca33b867-6a7f-4c44-b2ad-bb3c4198cb79" />