### PR TITLE
[nK] Fix broken XSMM generation for nano-kernels

### DIFF
--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -69,13 +69,6 @@ struct DefaultTppPasses
   }
 
 private:
-  // Vectorization is required by the explicit `vector-to-kernel`
-  // and `nano-kernel` paths, which are built on top of it.
-  // Any of these flags enables the vectorization stage.
-  bool shouldVectorize() const {
-    return vectorToKernel || nanoKernel;
-  }
-
   // Lower linalg directly to loops, skipping all TPP transformations.
   void addLinalgToLoopsPasses() {
     // Generalize linalg.pack and linalg.unpack.
@@ -140,7 +133,6 @@ private:
     TppMappingOptions tppMappingOptions{lowerPackUnpackWithoutTranspose,
                                         disableVnniPacking};
     pm.addPass(createTppMapping(tppMappingOptions));
-
     // Generalize linalg.pack and linalg.unpack.
     pm.addPass(createLowerPacksAndUnPacks());
     pm.addPass(createCleanup());
@@ -164,11 +156,12 @@ private:
     // No-op unless the benchmark producer requested replication.
     pm.addPass(createReplicateBenchArgs());
 
-    // Lower Linalg to XSMM.
-    pm.addNestedPass<func::FuncOp>(createLinalgLowering());
-
-    if (shouldVectorize())
+    if (vectorToKernel || nanoKernel)
+      // Lower Linalg to Vector.
       addVectorizationPasses();
+    else
+      // Lower Linalg to XSMM.
+      pm.addNestedPass<func::FuncOp>(createLinalgLowering());
 
     // Final cleanup.
     pm.addPass(createCleanup());

--- a/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16.mlir
+++ b/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void --nano-kernels --registerBlocking=8,32,2 --gemm-unroll=1,16,1 -print  --splat-to-random --init-type normal  -seed 123 %s > %t.2
+// RUN: tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void --vector-to-kernels --registerBlocking=8,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
 memref.global "private" constant @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
@@ -24,7 +24,7 @@ func.func @gemm_bf16_dp_random_AB(%arg0: memref<8x2x32x32xbf16>) -> memref<8x2x3
 
 
 // RUN: tpp-run -e gemm_bf16_args --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e gemm_bf16_args --entry-point-result=void  --nano-kernels --registerBlocking=8,32,2 --gemm-unroll=1,16,1 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: tpp-run -e gemm_bf16_args --entry-point-result=void  --vector-to-kernels --registerBlocking=8,32,2 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 
 func.func @gemm_bf16_args(%arg0: memref<4x2x64x64xbf16>, %arg1: memref<2x2x32x64x2xbf16>, %arg2: memref<4x2x64x64xbf16>) -> memref<4x2x64x64xbf16> {
@@ -47,7 +47,7 @@ func.func @gemm_bf16_args(%arg0: memref<4x2x64x64xbf16>, %arg1: memref<2x2x32x64
 
 
 // RUN: tpp-run -e mlp_bf16 --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e  mlp_bf16 --entry-point-result=void --nano-kernels --registerBlocking=4,32,2 --gemm-unroll=1,16,1 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: tpp-run -e  mlp_bf16 --entry-point-result=void --vector-to-kernels --registerBlocking=4,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 
 memref.global "private" constant @__constant_32xbf16 : memref<32xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
@@ -82,8 +82,8 @@ func.func @mlp_bf16(%arg0: memref<8x2x32x32xbf16>) -> memref<8x2x32x32xbf16> {
 }
 
 // RUN: tpp-run -e optimal_register_blocking --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --nano-kernels --registerBlocking=6,64,2 --gemm-unroll=1,32,1 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
-// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --nano-kernels --registerBlocking=3,32,2 --gemm-unroll=1,16,1 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.3
+// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --vector-to-kernels --registerBlocking=6,64,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --vector-to-kernels --registerBlocking=3,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.3
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.3
 


### PR DESCRIPTION
The XSMM lowering was unguarded and always running, but somehow in the previous pipeline it wasn't generating calls to xsmm on the nano-kernel path. Since this path isn't well tested (especially IR checks), my previous PR allowed XSMM calls to be generated in the nano-kernel path and the Integration tests "passed" because they were not generating nano-kernels at all.

I also had to revert one test that moved on to nano-kernels (actually, xsmm calls) back to `vector-to-kernels`.