### PR TITLE
[nK] Separating more the XSMM/Loops pipeline from nano-kernel

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -43,14 +43,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--nano-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--nano-kernels --gemm-unroll=1,16,1 --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlir_gemm_fp32_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--nano-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--nano-kernels --gemm-unroll=1,16,1 --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2"]
     },
     "mlir_gemm_fp32_vector_sve": {
@@ -74,14 +74,14 @@
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --nano-kernels --registerBlocking=8,32,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --nano-kernels --gemm-unroll=1,16,1 --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlir_mlp_fp32_vector_avx2": {
       "type": "IR-GEN",
       "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": {},
-      "flags": [ "-n", "100",  "-run-args='--def-parallel --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
+      "flags": [ "-n", "100",  "-run-args='--def-parallel --nano-kernels --gemm-unroll=1,16,1 --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2" ]
     },
     "mlir_mlp_fp32_vector_sve": {

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -214,7 +214,6 @@ private:
   // Partially lower the IR towards LLVM.
   void addPartialLoweringPasses() {
     pm.addPass(memref::createExpandStridedMetadataPass());
-    pm.addPass(createConvertTensorToLinalgPass());
     pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
     if (defParallel)
       pm.addPass(createConvertSCFToOpenMPPass());

--- a/lib/TPP/DefaultTppPasses.cpp
+++ b/lib/TPP/DefaultTppPasses.cpp
@@ -8,6 +8,7 @@
 
 #include "TPP/PassBundles.h"
 
+#include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -75,6 +76,7 @@ private:
     pm.addPass(createLowerPacksAndUnPacks());
     pm.addNestedPass<func::FuncOp>(createDecomposeAggregatedOps());
     pm.addPass(createBufferize());
+    pm.addPass(createConvertTensorToLinalgPass());
     pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
     pm.addPass(createCleanup());
   }
@@ -185,16 +187,17 @@ private:
       pm.addPass(createLowLevelParallelization(LowLevelParallelization));
 
     // TODO: These passes have been moved out of low level parallelization
-    // pass since these apply on xsmm dialect. They'll be moved back in
-    // subsequent commits.
-    pm.addNestedPass<func::FuncOp>(createIntelAMXTileConfigInsertionPass());
-    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
-    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(createIntelAMXTileConfigHoistingPass());
-    // TODO: This pass has been moved out of LocalDialectsLowering since it is
-    // applicable to xsmm only. It'll be moved back in subsequent commits.
-    pm.addPass(createConvertXsmmToFunc());
+    // pass since these apply on xsmm dialect.
+    if (!(vectorToKernel || nanoKernel)) {
+      pm.addNestedPass<func::FuncOp>(createIntelAMXTileConfigInsertionPass());
+      pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+      pm.addNestedPass<func::FuncOp>(createLoopInvariantCodeMotionPass());
+      pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+      pm.addNestedPass<func::FuncOp>(createIntelAMXTileConfigHoistingPass());
+      // TODO: This pass has been moved out of LocalDialectsLowering since it is
+      // applicable to xsmm only.
+      pm.addPass(createConvertXsmmToFunc());
+    }
   }
 
   void constructPipeline() override {


### PR DESCRIPTION
Also, moving some benchmarks that already worked with nano-kernels.