### PR TITLE
[Cleanup] Renaming, copy-pasta, cleanups

### DIFF
--- a/benchmarks/config/base/base.json
+++ b/benchmarks/config/base/base.json
@@ -34,28 +34,28 @@
   "mlir_gemm_fp32": {
     "mlir_gemm_fp32_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": []
     },
     "mlir_gemm_fp32_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--nano-kernels --gemm-unroll=1,16,1 --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlir_gemm_fp32_vector_avx2": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--nano-kernels --gemm-unroll=1,16,1 --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2"]
     },
     "mlir_gemm_fp32_vector_sve": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": ["asimd"]
@@ -65,28 +65,28 @@
   "mlir_mlp_fp32": {
     "mlir_mlp_fp32_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": []
     },
     "mlir_mlp_fp32_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --nano-kernels --gemm-unroll=1,16,1 --registerBlocking=8,32,1'" ],
       "extensions": ["avx512.*"]
     },
     "mlir_mlp_fp32_vector_avx2": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --nano-kernels --gemm-unroll=1,16,1 --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": ["avx2" ]
     },
     "mlir_mlp_fp32_vector_sve": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100",  "-run-args='--def-parallel --vector-to-kernels --registerBlocking=4,32,1 -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": ["asimd"]
@@ -96,49 +96,49 @@
   "mlir_gemm_bf16": {
     "mlir_gemm_bf16_vnni_dp2_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "mlir_gemm_bf16_vnni_dp2_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512.*" ]
     },
     "mlir_gemm_bf16_vnni_dp2_vector_avx2": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "avx2" ]
     },
     "mlir_gemm_bf16_splat_dp2_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing'" ],
       "extensions": [ "avx2" ]
     },
     "mlir_gemm_bf16_splat_dp2_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "mlir_gemm_bf16_splat_dp2_vector_avx2_arl": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "mlir_gemm_bf16_dp4_sve": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
@@ -148,49 +148,49 @@
   "mlir_mlp_bf16": {
     "mlir_mlp_bf16_vnni_dp2_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "avx2" ]
     },
     "mlir_mlp_bf16_vnni_dp2_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512.*" ]
     },
     "mlir_mlp_bf16_vnni_dp2_vector_avx2": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "avx2" ]
     },
     "mlir_mlp_bf16_splat_dp2_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing'" ],
       "extensions": [ "avx2" ]
     },
     "mlir_mlp_bf16_splat_dp2_vector_avx2_arl": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "mlir_mlp_bf16_splat_dp2_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "mlir_mlp_bf16_dp4_sve": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "svebf16" ]
@@ -200,28 +200,28 @@
   "argument_types_fp32": {
     "fp32_const_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_const_vector": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_args_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
      "fp32_args_vector": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,1'" ],
       "extensions": [ "avx512.*" ]
@@ -231,42 +231,42 @@
   "argument_types_bf16": {
     "bf16_const_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_const_vector_avx2": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'"],
       "extensions": [ "avx2" ]
     },
     "bf16_const_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
       "extensions": [ "avx512.*" ]
     },
     "bf16_args_xsmm": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_args_vector_avx2": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'"],
       "extensions": [ "avx2" ]
     },
     "bf16_args_vector_avx512": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": {},
       "flags": [ "-n", "100", "-run-args='--vector-to-kernels --registerBlocking=8,32,2'"],
       "extensions": [ "avx512.*" ]

--- a/benchmarks/config/base/named-ops.json
+++ b/benchmarks/config/base/named-ops.json
@@ -3,28 +3,28 @@
   "mlp_named_ops": {
     "fp32_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--output=named --kernel=const --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--output=named --kernel=const --bias --relu --data-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--output=named --kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--output=named --kernel=args --bias --relu --data-type=f32 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_const_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--output=named --kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--output=named --kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]
     },
     "bf16_3x1024_args_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--output=named --kernel=args --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
+      "benchmark": [ "mlir-gen", "--output=named --kernel=args --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024" ],
       "environment": {},
       "flags": [ "-n", "100"],
       "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/config/fc/1024x1024x512.json
+++ b/benchmarks/config/fc/1024x1024x512.json
@@ -37,14 +37,14 @@
   "fc_1024x1024x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x1024x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x1024x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x2560x1024.json
+++ b/benchmarks/config/fc/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "fc_1024x2560x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x2560x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x2560x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x352x512.json
+++ b/benchmarks/config/fc/1024x352x512.json
@@ -37,14 +37,14 @@
   "fc_1024x352x512_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x352x512_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x352x512_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/1024x512x256.json
+++ b/benchmarks/config/fc/1024x512x256.json
@@ -37,14 +37,14 @@
   "fc_1024x512x256_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_1024x512x256_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_1024x512x256_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x1024.json
+++ b/benchmarks/config/fc/128x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_128x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x1024x4096.json
+++ b/benchmarks/config/fc/128x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_128x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x3072x768.json
+++ b/benchmarks/config/fc/128x3072x768.json
@@ -37,14 +37,14 @@
   "fc_128x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x4096x1024.json
+++ b/benchmarks/config/fc/128x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_128x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x2304.json
+++ b/benchmarks/config/fc/128x768x2304.json
@@ -37,14 +37,14 @@
   "fc_128x768x2304_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x2304_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x2304_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x3072.json
+++ b/benchmarks/config/fc/128x768x3072.json
@@ -37,14 +37,14 @@
   "fc_128x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/128x768x768.json
+++ b/benchmarks/config/fc/128x768x768.json
@@ -37,14 +37,14 @@
   "fc_128x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_128x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_128x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x1024.json
+++ b/benchmarks/config/fc/256x1024x1024.json
@@ -37,14 +37,14 @@
   "fc_256x1024x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x1024x4096.json
+++ b/benchmarks/config/fc/256x1024x4096.json
@@ -37,14 +37,14 @@
   "fc_256x1024x4096_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x1024x4096_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x1024x4096_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x3072x768.json
+++ b/benchmarks/config/fc/256x3072x768.json
@@ -37,14 +37,14 @@
   "fc_256x3072x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x3072x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x3072x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x4096x1024.json
+++ b/benchmarks/config/fc/256x4096x1024.json
@@ -37,14 +37,14 @@
   "fc_256x4096x1024_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x4096x1024_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x4096x1024_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x3072.json
+++ b/benchmarks/config/fc/256x768x3072.json
@@ -37,14 +37,14 @@
   "fc_256x768x3072_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x3072_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x3072_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/fc/256x768x768.json
+++ b/benchmarks/config/fc/256x768x768.json
@@ -37,14 +37,14 @@
   "fc_256x768x768_fp32_mlir": {
     "fc_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "fc_256x768x768_bf16_dp2_mlir": {
     "fc_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fc_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "fc_256x768x768_bf16_dp4_mlir": {
     "fc_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "fc_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --bias --relu --data-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x1024x512.json
+++ b/benchmarks/config/matmul/1024x1024x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x1024x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x1024x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x1024x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=512,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x2560x1024.json
+++ b/benchmarks/config/matmul/1024x2560x1024.json
@@ -37,14 +37,14 @@
   "matmul_1024x2560x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x2560x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x2560x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=1024,2560 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x352x512.json
+++ b/benchmarks/config/matmul/1024x352x512.json
@@ -37,14 +37,14 @@
   "matmul_1024x352x512_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x352x512_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x352x512_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=512,352 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/1024x512x256.json
+++ b/benchmarks/config/matmul/1024x512x256.json
@@ -37,14 +37,14 @@
   "matmul_1024x512x256_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_1024x512x256_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_1024x512x256_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=1024 --layers=256,512 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x1024.json
+++ b/benchmarks/config/matmul/128x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x1024x4096.json
+++ b/benchmarks/config/matmul/128x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_128x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x3072x768.json
+++ b/benchmarks/config/matmul/128x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_128x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x4096x1024.json
+++ b/benchmarks/config/matmul/128x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_128x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x2304.json
+++ b/benchmarks/config/matmul/128x768x2304.json
@@ -37,14 +37,14 @@
   "matmul_128x768x2304_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x2304_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x2304_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=2304,768 --tiles=64,48,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x3072.json
+++ b/benchmarks/config/matmul/128x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_128x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=3072,768 --tiles=32,48,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/128x768x768.json
+++ b/benchmarks/config/matmul/128x768x768.json
@@ -37,14 +37,14 @@
   "matmul_128x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_128x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_128x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=128 --layers=768,768 --tiles=32,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x1024.json
+++ b/benchmarks/config/matmul/256x1024x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=1024,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x1024x4096.json
+++ b/benchmarks/config/matmul/256x1024x4096.json
@@ -37,14 +37,14 @@
   "matmul_256x1024x4096_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x1024x4096_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x1024x4096_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=4096,1024 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x3072x768.json
+++ b/benchmarks/config/matmul/256x3072x768.json
@@ -37,14 +37,14 @@
   "matmul_256x3072x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x3072x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x3072x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=768,3072 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x4096x1024.json
+++ b/benchmarks/config/matmul/256x4096x1024.json
@@ -37,14 +37,14 @@
   "matmul_256x4096x1024_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x4096x1024_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x4096x1024_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=1024,4096 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x3072.json
+++ b/benchmarks/config/matmul/256x768x3072.json
@@ -37,14 +37,14 @@
   "matmul_256x768x3072_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x3072_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x3072_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=3072,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/matmul/256x768x768.json
+++ b/benchmarks/config/matmul/256x768x768.json
@@ -37,14 +37,14 @@
   "matmul_256x768x768_fp32_mlir": {
     "matmul_fp32_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "1" },
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_fp32_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=f32 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -54,14 +54,14 @@
   "matmul_256x768x768_bf16_dp2_mlir": {
     "matmul_bf16_dp2_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "matmul_bf16_dp2_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=2 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -71,14 +71,14 @@
   "matmul_256x768x768_bf16_dp4_mlir": {
     "matmul_bf16_dp4_single_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": {},
       "flags": [ "-n", "100" ],
       "extensions": [ "(svebf16)" ]
     },
     "matmul_bf16_dp4_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=bf16 --vnni=4 --batch=256 --layers=768,768 --tiles=64,64,64" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='-def-parallel'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/omp/mlir-vector-amx.json
+++ b/benchmarks/config/omp/mlir-vector-amx.json
@@ -3,28 +3,28 @@
   "gemm_i8_f32_dequant_mlir_vector_large_amx": {
     "i8_f32_dequant_4096x4096_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,64 --init-type=quant --splat-to-random --seed=123'" ],
       "extensions": [ "amx_int8" ]
     },
     "i8_f32_dequant_4096x4096_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,64 --init-type=quant --splat-to-random --seed=123'" ],
       "extensions": [ "amx_int8" ]
     },
     "i8_f32_dequant_4096x4096_omp_32_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
       "environment": { "OMP_NUM_THREADS": "32", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,64 --init-type=quant --splat-to-random --seed=123'" ],
       "extensions": [ "amx_int8" ]
     },
     "i8_f32_dequant_4096x4096_omp_64_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --tiles=32,32,64 --vnni=4 --quant-type=dequantize" ],
       "environment": { "OMP_NUM_THREADS": "64", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,64 --init-type=quant --splat-to-random --seed=123'" ],
       "extensions": [ "amx_int8" ]
@@ -34,28 +34,28 @@
   "gemm_bf16_f32_mlir_vector_large_amx": {
     "bf16_f32_4096x4096_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,32 --init-type=normal --splat-to-random --seed=123'" ],
       "extensions": [ "amx_bf16" ]
     },
     "bf16_f32_4096x4096_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,32 --init-type=normal --splat-to-random --seed=123'" ],
       "extensions": [ "amx_bf16" ]
     },
     "bf16_f32_4096x4096_omp_32_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "32", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,32 --init-type=normal --splat-to-random --seed=123'" ],
       "extensions": [ "amx_bf16" ]
     },
     "bf16_f32_4096x4096_omp_64_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=args --float-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=args --data-type=mx-bf16 --batch=4096 --layers=8192,4096 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "64", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --vector-to-kernels --registerBlocking=32,32,32 --init-type=normal --splat-to-random --seed=123'" ],
       "extensions": [ "amx_bf16" ]

--- a/benchmarks/config/omp/mlir-vector-bf16.json
+++ b/benchmarks/config/omp/mlir-vector-bf16.json
@@ -3,28 +3,28 @@
   "gemm_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -34,28 +34,28 @@
   "gemm_bf16_dp2_mlir_vector_amx": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": ["(amx_bf16)"]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": ["(amx_bf16)"]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": ["(amx_bf16)"]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": ["(amx_bf16)"]
@@ -65,28 +65,28 @@
   "mlp_bf16_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -96,28 +96,28 @@
   "mlp_bf16_dp2_mlir_vector_amx": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": [ "(amx_bf16)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": [ "(amx_bf16)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8  --vector-to-kernels --registerBlocking=32,32,32 '" ],
       "extensions": [ "(amx_bf16)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8  --vector-to-kernels --registerBlocking=32,32,32'" ],
       "extensions": [ "(amx_bf16)" ]

--- a/benchmarks/config/omp/mlir-vector-fp32-avx2.json
+++ b/benchmarks/config/omp/mlir-vector-fp32-avx2.json
@@ -3,28 +3,28 @@
     "gemm_fp32_24x64_avx2": {
       "fp32_3x1024_omp_2_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
         "extensions": [ "(avx2)" ]
       },
       "fp32_3x1024_omp_4_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
         "extensions": [ "(avx2)" ]
       },
       "fp32_3x1024_omp_8_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
         "extensions": [ "(avx2)" ]
       },
       "fp32_3x1024_omp_16_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
         "extensions": [ "(avx2)" ]
@@ -34,28 +34,28 @@
   "gemm_fp32_mlir_vector_kernel_24x64_avx2": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --target-feature=avx2 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --target-feature=avx2 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --target-feature=avx2 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --target-feature=avx2 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
@@ -65,28 +65,28 @@
     "mlp_fp32_24x64_avx2": {
       "fp32_3x1024_omp_2_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
         "extensions": [ "(avx2)" ]
       },
       "fp32_3x1024_omp_4_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
         "extensions": [ "(avx2)" ]
       },
       "fp32_3x1024_omp_8_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
         "extensions": [ "(avx2)" ]
       },
       "fp32_3x1024_omp_16_mlir": {
         "type": "IR-GEN",
-        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+        "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
         "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
         "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
         "extensions": [ "(avx2)" ]
@@ -96,28 +96,28 @@
   "mlp_fp32_mlir_vector_kernel_24x64_avx2": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=96 --layers=1536,1536 --tiles=24,64,4" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=3,32,1 '" ],
       "extensions": [ "avx2" ]

--- a/benchmarks/config/omp/mlir-vector-fp32.json
+++ b/benchmarks/config/omp/mlir-vector-fp32.json
@@ -3,28 +3,28 @@
   "gemm_fp32_mlir_nano_kernel_32_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
@@ -34,28 +34,28 @@
   "mlp_fp32_mlir_nano_kernel_32_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --nano-kernels --registerBlocking=8,32,1 '" ],
       "extensions": [ "avx512.*" ]
@@ -65,28 +65,28 @@
   "gemm_fp32_mlir_vector_kernel_64_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
@@ -96,28 +96,28 @@
   "mlp_fp32_mlir_vector_kernel_64_avx512": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,4 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,4 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=64,64,64 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=1,4 --nano-kernels --registerBlocking=4,64,1 '" ],
       "extensions": [ "avx512.*" ]
@@ -127,28 +127,28 @@
   "gemm_fp32_mlir_nano_kernel_32_avx2_adl": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
@@ -158,28 +158,28 @@
   "mlp_fp32_mlir_nano_kernel_32_avx2_adl": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1  '" ],
       "extensions": [ "avx2" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --nano-kernels --target-feature=avx2 --registerBlocking=4,16,1 '" ],
       "extensions": [ "avx2" ]
@@ -189,28 +189,28 @@
   "gemm_fp32_mlir_vector_kernel_32_sve": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
@@ -220,28 +220,28 @@
   "mlp_fp32_mlir_vector_kernel_32_sve": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=4,32,1   -aarch64-sve-vector-bits-min=256 -aarch64-sve-vector-bits-max=256'" ],
       "extensions": [ "asimd" ]

--- a/benchmarks/config/omp/mlir-xsmm-bf16.json
+++ b/benchmarks/config/omp/mlir-xsmm-bf16.json
@@ -3,28 +3,28 @@
   "gemm_bf16_vnni_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -34,28 +34,28 @@
   "gemm_bf16_vnni_dp2_mlir_nano_kernel_avx512": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,16,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
@@ -65,28 +65,28 @@
   "gemm_bf16_vnni_dp2_mlir_vector_kernel_avx2_adl": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
@@ -96,28 +96,28 @@
   "gemm_bf16_splat_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -127,28 +127,28 @@
   "gemm_bf16_splat_dp2_mlir_nano_kernel_avx512": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,16,2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8 --nano-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
@@ -158,28 +158,28 @@
   "mlp_bf16_vnni_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -189,28 +189,28 @@
   "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx512": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "(avx512.*)" ]
@@ -220,28 +220,28 @@
   "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx2_adl": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "(avx2)" ]
@@ -251,28 +251,28 @@
   "mlp_bf16_splat_dp2_mlir": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2)" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2)" ]
@@ -282,28 +282,28 @@
   "mlp_bf16_splat_dp2_mlir_vector_kernel_avx512": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=8,32,2'" ],
       "extensions": [ "avx512_bf16" ]
@@ -313,21 +313,21 @@
   "gemm_bf16_vnni_dp2_mlir_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
@@ -337,21 +337,21 @@
     "gemm_bf16_vnni_dp2_mlir_nano_kernel_avx2_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
@@ -361,28 +361,28 @@
   "gemm_bf16_vnni_dp2_mlir_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "arl" ]
@@ -392,28 +392,28 @@
   "gemm_bf16_vnni_dp2_mlir_nano_kernel_avx2_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --nano-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
@@ -423,21 +423,21 @@
   "gemm_bf16_splat_dp2_mlir_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
@@ -447,21 +447,21 @@
   "gemm_bf16_splat_dp2_mlir_nano_kernel_avx2_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
@@ -471,28 +471,28 @@
   "gemm_bf16_splat_dp2_mlir_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "arl" ]
@@ -502,28 +502,28 @@
   "gemm_bf16_splat_dp2_mlir_nano_kernel_avx2_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0 --registerUnroll=1,8,1" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8 --nano-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
@@ -533,21 +533,21 @@
   "mlp_bf16_vnni_dp2_mlir_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
@@ -557,21 +557,21 @@
   "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx2_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
@@ -581,28 +581,28 @@
   "mlp_bf16_vnni_dp2_mlir_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "arl" ]
@@ -612,28 +612,28 @@
   "mlp_bf16_vnni_dp2_mlir_vector_kernel_avx2_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=2" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=2,32,2'" ],
       "extensions": [ "arl" ]
@@ -643,21 +643,21 @@
   "mlp_bf16_splat_dp2_mlir_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
@@ -667,21 +667,21 @@
   "mlp_bf16_splat_dp2_mlir_vector_kernel_avx2_arl_p_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
@@ -691,28 +691,28 @@
   "mlp_bf16_splat_dp2_mlir_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "arl" ]
@@ -722,28 +722,28 @@
   "mlp_bf16_splat_dp2_mlir_vector_kernel_avx2_arl_e_cores": {
     "bf16_dp2_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,16 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=8,8 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=4,8 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
     },
     "bf16_dp2_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=0" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--disable-vnni-packing --def-parallel --parallel-task-grid=2,8 --vector-to-kernels --registerBlocking=2,32,1'" ],
       "extensions": [ "arl" ]
@@ -753,28 +753,28 @@
   "gemm_bf16_dp4_mlir": {
     "bf16_dp4_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(svebf16)" ]
@@ -784,28 +784,28 @@
   "mlp_bf16_dp4_mlir": {
     "bf16_dp4_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(svebf16)" ]
     },
     "bf16_dp4_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf16 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(svebf16)" ]

--- a/benchmarks/config/omp/mlir-xsmm-fp32.json
+++ b/benchmarks/config/omp/mlir-xsmm-fp32.json
@@ -3,28 +3,28 @@
   "gemm_fp32_mlir": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -34,28 +34,28 @@
   "mlp_fp32_mlir": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "(avx2|asimd)" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,compact,1,0" }, 
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "(avx2|asimd)" ]
@@ -65,21 +65,21 @@
   "gemm_fp32_mlir_arl_p_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
@@ -89,21 +89,21 @@
   "gemm_fp32_mlir_vector_kernel_32_avx2_arl_p_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
@@ -113,28 +113,28 @@
   "gemm_fp32_mlir_arl_e_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "arl" ]
@@ -144,28 +144,28 @@
   "gemm_fp32_mlir_vector_kernel_32_avx2_arl_e_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
@@ -175,21 +175,21 @@
   "mlp_fp32_mlir_arl_p_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
@@ -199,21 +199,21 @@
   "mlp_fp32_mlir_vector_kernel_32_avx2_arl_p_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[0,1,2,3,4,5,6,7]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
@@ -223,28 +223,28 @@
   "mlp_fp32_mlir_arl_e_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8'" ],
       "extensions": [ "arl" ]
@@ -254,28 +254,28 @@
   "mlp_fp32_mlir_vector_kernel_32_avx2_arl_e_cores": {
     "fp32_3x1024_omp_2_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "2", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,16 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_4_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "4", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=8,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_8_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "8", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=4,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]
     },
     "fp32_3x1024_omp_16_mlir": {
       "type": "IR-GEN",
-      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --float-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=f32 --batch=512 --layers=1024,1024,1024,1024 --tiles=32,32,32" ],
       "environment": { "OMP_NUM_THREADS": "16", "KMP_AFFINITY": "granularity=fine,verbose,explicit,proclist=[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]" },
       "flags": [ "-n", "100", "-run-args='--def-parallel --parallel-task-grid=2,8 --vector-to-kernels --target-feature=avx2 --registerBlocking=4,16,1'" ],
       "extensions": [ "arl" ]

--- a/benchmarks/driver.py
+++ b/benchmarks/driver.py
@@ -36,7 +36,7 @@
              },
              "irgen": {
                  "type": "IR-GEN",
-                 "benchmark": [ "mlir-gen", "--kernel=const --float-type=bf16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
+                 "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf16 --vnni=2 --batch=64 --layers=64,64 --tiles=32,32,32" ],
                  "environment": { "OMP_NUM_THREADS": "32" },
                  "flags": [ "-n", "100" ],
                  "extensions": [ "(avx2|asimd)" ]

--- a/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm.sh
+++ b/benchmarks/mlir/sfc_ca_gemm/run_sfc_ca_gemm.sh
@@ -90,7 +90,7 @@ for M in "${SIZES[@]}"; do
       mlir_file="${OUT_DIR}/gemm_sfc_${M}_${N}_${K}_mx-bf16.mlir"
 
       echo "=== Generating M=${M} N=${N} K=${K} ==="
-      "${MLIR_GEN}" --kernel=args --float-type=bf16 \
+      "${MLIR_GEN}" --kernel=args --data-type=bf16 \
         --batch="${N}" --layers="${K},${M}" --tiles="${TILES}" --vnni=2 \
         > "${mlir_file}"
 

--- a/scripts/benchmarks/gen-sweep-config.py
+++ b/scripts/benchmarks/gen-sweep-config.py
@@ -26,7 +26,7 @@ DTYPES = {
         "group": "gemm_i8_f32_dequant_mlir_vector_large_amx",
         "name_fmt": "i8_f32_dequant_{M}x{N}x{K}_omp_64_mlir",
         "gen_flags": (
-            "--kernel=args --float-type=mx-i8-f32 --batch={M} "
+            "--kernel=args --data-type=mx-i8-f32 --batch={M} "
             "--layers={K},{N} --tiles=32,32,64 --vnni=4 "
             "--quant-type=dequantize"
         ),
@@ -41,7 +41,7 @@ DTYPES = {
         "group": "gemm_bf16_f32_dequant_mlir_vector_large_amx",
         "name_fmt": "bf16_f32_dequant_{M}x{N}x{K}_omp_64_mlir",
         "gen_flags": (
-            "--kernel=args --float-type=mx-bf16 --batch={M} "
+            "--kernel=args --data-type=mx-bf16 --batch={M} "
             "--layers={K},{N} --tiles=32,32,32 --vnni=2"
         ),
         "run_args": (

--- a/scripts/benchmarks/run-sweep.sh
+++ b/scripts/benchmarks/run-sweep.sh
@@ -130,8 +130,8 @@ if [[ "${SKIP_CORRECTNESS}" -eq 0 ]]; then
   # mlir-gen flag templates (must match gen-sweep-config.py).
   # Use --kernel=args (same as the perf config); tpp-run --splat-to-random
   # --seed=123 makes both baseline and test runs see identical inputs.
-  gen_args_i8="--kernel=args --float-type=mx-i8-f32 --tiles=32,32,64 --vnni=4 --quant-type=dequantize --seed=123"
-  gen_args_bf16="--kernel=args --float-type=mx-bf16 --tiles=32,32,32 --vnni=2 --seed=123"
+  gen_args_i8="--kernel=args --data-type=mx-i8-f32 --tiles=32,32,64 --vnni=4 --quant-type=dequantize --seed=123"
+  gen_args_bf16="--kernel=args --data-type=mx-bf16 --tiles=32,32,32 --vnni=2 --seed=123"
   vk_args_i8="--def-parallel --vector-to-kernels --registerBlocking=32,32,64 --sfc-order=true"
   vk_args_bf16="--def-parallel --vector-to-kernels --registerBlocking=32,32,32 --sfc-order=true"
 

--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -55,7 +55,7 @@ Examples:
 // Generates an MLP with `mlir-gen`, uses `meld`
 ./scripts/debug/debug_all_passes.sh \
   -b ./build/bin \
-  -m "--kernel=const --bias --relu --float-type=bf16 --batch=256 --layers=1024,1024,1024,1024" \
+  -m "--kernel=const --bias --relu --data-type=bf16 --batch=256 --layers=1024,1024,1024,1024" \
   -d meld
 
 // Default behaviour, runs `mlir-gen` & `tpp-opt` without args, uses `diff`

--- a/scripts/debug/testquant.sh
+++ b/scripts/debug/testquant.sh
@@ -6,9 +6,9 @@ for test in 3 8 16 32 64; do
   direct=direct-$test
   quantized=quant-$test
   echo "Running $direct and $quantized..."
-  ./bin/mlir-gen --seed=123 --kernel=const --float-type=f32 --batch=$test --layers=$test,$test > $direct.mlir
+  ./bin/mlir-gen --seed=123 --kernel=const --data-type=f32 --batch=$test --layers=$test,$test > $direct.mlir
   ./bin/tpp-run -e entry -entry-point-result=void -print --splat-to-random --seed=123 $direct.mlir > $direct.out
-  ./bin/mlir-gen --seed=123 --kernel=const --float-type=mx-f32-i8 --batch=$test --layers=$test,$test --quant-type=testquant > $quantized.mlir
+  ./bin/mlir-gen --seed=123 --kernel=const --data-type=mx-f32-i8 --batch=$test --layers=$test,$test --quant-type=testquant > $quantized.mlir
   ./bin/tpp-run -e entry -entry-point-result=void -print --splat-to-random --seed=123 $quantized.mlir > $quantized.out
   ./bin/fpcmp -a 0.02 -i $direct.out $quantized.out
   echo "Direct & Quantize have compatible results up to 0.002"

--- a/test/Integration/BF16/mlir-gen-bf16.mlir
+++ b/test/Integration/BF16/mlir-gen-bf16.mlir
@@ -1,24 +1,24 @@
 // MLP without softmax (can't print packed version for now)
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16,16 --float-type=bf16 | tpp-run -e entry -entry-point-result=void
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16,16 --float-type=bf16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16,16 --data-type=bf16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16,16 --data-type=bf16 | tpp-run -e entry -entry-point-result=void
 
 // Matmul only
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --float-type=bf16 | tpp-run -e entry -entry-point-result=void
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --float-type=bf16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --data-type=bf16 | tpp-run -e entry -entry-point-result=void
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --data-type=bf16 | tpp-run -e entry -entry-point-result=void
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=args --seed=123 --float-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
-// RUN: mlir-gen --output=named --kernel=args --seed=123 --float-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
+// RUN: mlir-gen --kernel=args --seed=123 --data-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
+// RUN: mlir-gen --output=named --kernel=args --seed=123 --data-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-BF16
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
-// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=123 --float-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
+// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --data-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=123 --data-type=bf16 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC-BF16
 
 // BF16/VNNI execution
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --float-type=bf16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --float-type=bf16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --float-type=bf16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --float-type=bf16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=bf16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=bf16 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=bf16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=bf16 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
 
 // GEN-MATMUL-BF16: ( 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17 )

--- a/test/Integration/BF16/mlir-gen-fc-bf16.mlir
+++ b/test/Integration/BF16/mlir-gen-fc-bf16.mlir
@@ -3,8 +3,6 @@
 // RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // RUN: not --crash mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=VNNI-TODO
-// RUN: mlir-gen --output=named --keep-generic-matmul --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=GENERIC
-
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void
@@ -66,7 +64,7 @@
 // DP4-NOT: dealloc
 
 
-// VNNI-TODO: Unsupported Lowering for VNNI, Try '--keep-generic-matmul'
+// VNNI-TODO: Unsupported Lowering for VNNI, Try 'generic' or 'contract' lowering
 // VNNI-TODO: UNREACHABLE executed
 
 // GENERIC: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>

--- a/test/Integration/BF16/mlir-gen-fc-bf16.mlir
+++ b/test/Integration/BF16/mlir-gen-fc-bf16.mlir
@@ -1,8 +1,8 @@
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
-// RUN: not --crash mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=VNNI-TODO
+// RUN: not --crash mlir-gen --output=named --kernel=args --bias --relu --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=VNNI-TODO
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/BF16/mlir-gen-matmul-bf16.mlir
+++ b/test/Integration/BF16/mlir-gen-matmul-bf16.mlir
@@ -3,7 +3,6 @@
 // RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
 // RUN: not --crash mlir-gen --output=named --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=VNNI-TODO
-// RUN: mlir-gen --output=named --keep-generic-matmul --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=GENERIC
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void
@@ -63,5 +62,5 @@
 // GENERIC:           return %[[VAL_3]] : tensor<2x16x64x48xbf16>
 // GENERIC:         }
 
-// VNNI-TODO: Unsupported Lowering for VNNI, Try '--keep-generic-matmul'
+// VNNI-TODO: Unsupported Lowering for VNNI, Try 'generic' or 'contract' lowering
 // VNNI-TODO: UNREACHABLE executed

--- a/test/Integration/BF16/mlir-gen-matmul-bf16.mlir
+++ b/test/Integration/BF16/mlir-gen-matmul-bf16.mlir
@@ -1,8 +1,8 @@
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=0 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=DP2
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=DP4
 
-// RUN: not --crash mlir-gen --output=named --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=VNNI-TODO
+// RUN: not --crash mlir-gen --output=named --kernel=args --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --vnni=2 2>&1 | FileCheck %s --check-prefix=VNNI-TODO
 
 // BF16: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // BF16: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/BF16/vnni-xsmm-vs-loops.mlir
+++ b/test/Integration/BF16/vnni-xsmm-vs-loops.mlir
@@ -1,11 +1,11 @@
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 \
-// RUN:  --tiles=16,16,16 --float-type=bf16 | \
+// RUN:  --tiles=16,16,16 --data-type=bf16 | \
 // RUN: tpp-opt --pack-vnni | \
 // RUN: tpp-run -print -seed 123 \
 // RUN:  -e entry -entry-point-result=void > %t.xsmm
 
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=16 --layers=16,16 \
-// RUN:  --tiles=16,16,16 --float-type=bf16 | \
+// RUN:  --tiles=16,16,16 --data-type=bf16 | \
 // RUN: tpp-opt --pack-vnni | \
 // RUN: tpp-run -print -seed 123 -linalg-to-loops \
 // RUN:  -e entry -entry-point-result=void > %t.loops

--- a/test/Integration/MLIRGen/mlir-gen-fc.mlir
+++ b/test/Integration/MLIRGen/mlir-gen-fc.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // FP32: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/MLIRGen/mlir-gen-flops.mlir
+++ b/test/Integration/MLIRGen/mlir-gen-flops.mlir
@@ -1,31 +1,31 @@
 // Unit sizes
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
-// RUN: mlir-gen --output=named --kernel=args --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT-NAMED
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
-// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT-NAMED
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT-NAMED
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT
+// RUN: mlir-gen --output=named --kernel=args --seed=0 --data-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MATMUL-UNIT-NAMED
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=FC-UNIT-NAMED
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=1 --layers=1,1 2>&1 | FileCheck %s --check-prefix=MLP-UNIT-NAMED
 // Small sizes
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
-// RUN: mlir-gen --output=named --kernel=args --seed=0 --float-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL-NAMED
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
-// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL-NAMED
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL-NAMED
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL
+// RUN: mlir-gen --output=named --kernel=args --seed=0 --data-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=MATMUL-SMALL-NAMED
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=8 --layers=4,16 2>&1 | FileCheck %s --check-prefix=FC-SMALL-NAMED
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=8 --layers=4,8,16 2>&1 | FileCheck %s --check-prefix=MLP-SMALL-NAMED
 // Large sizes + no tiling
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --output=named --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE-NAMED
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE-NAMED
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE-NAMED
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --output=named --kernel=args --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE-NAMED
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 2>&1 | FileCheck %s --check-prefix=FC-LARGE-NAMED
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,1024,1024 2>&1 | FileCheck %s --check-prefix=MLP-LARGE-NAMED
 // Large sizes + tiling
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
-// RUN: mlir-gen --output=named --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE-NAMED
-// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
-// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE-NAMED
-// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
-// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE-NAMED
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE
+// RUN: mlir-gen --output=named --kernel=args --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MATMUL-LARGE-NAMED
+// RUN: mlir-gen --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,4096 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=FC-LARGE-NAMED
+// RUN: mlir-gen --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE
+// RUN: mlir-gen --output=named --kernel=const --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=1024,1024,1024 --tiles=64,64,64 2>&1 | FileCheck %s --check-prefix=MLP-LARGE-NAMED
 
 // Validate that flops are computed correctly
 // MATMUL-UNIT: // BENCH_TOTAL_FLOPS: 2

--- a/test/Integration/MLIRGen/mlir-gen-matmul.mlir
+++ b/test/Integration/MLIRGen/mlir-gen-matmul.mlir
@@ -1,17 +1,17 @@
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=BF16
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=f16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP16
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=f32 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP32
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=f16 --batch=128 --layers=2304,768 --tiles=64,48,64 2>&1 | FileCheck %s --check-prefix=FP16
 
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXBF16-CONTRACT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXI8-CONTRACT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-f16 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXF16-CONTRACT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-bf16 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXBF16-CONTRACT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXI8-CONTRACT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-f16 --batch=128 --layers=2304,768 --tiles=64,48,64 --output=contract 2>&1 | FileCheck %s --check-prefix=MXF16-CONTRACT
 
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-bf16 --batch=128 --layers=2304,768 --quant-type=dequantize 2>&1 | FileCheck %s --check-prefix=MXBF16-DEQUANT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize 2>&1 | FileCheck %s --check-prefix=MXI8F32-DEQUANT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize --scale-type=f8E8M0FNU 2>&1 | FileCheck %s --check-prefix=MXI8-I8SCALE-DEQUANT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-f32-i8 --batch=128 --layers=2304,768 --quant-type=quantize 2>&1 | FileCheck %s --check-prefix=MXF32I8-QUANT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --quant-type=dequantize --output=generic --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8F32-PACKED-DEQUANT
-// RUN: mlir-gen --kernel=args --seed=0 --float-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize --scale-type=f8E8M0FNU --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8-I8SCALE-PACKED-DEQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-bf16 --batch=128 --layers=2304,768 --quant-type=dequantize 2>&1 | FileCheck %s --check-prefix=MXBF16-DEQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize 2>&1 | FileCheck %s --check-prefix=MXI8F32-DEQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize --scale-type=f8E8M0FNU 2>&1 | FileCheck %s --check-prefix=MXI8-I8SCALE-DEQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-f32-i8 --batch=128 --layers=2304,768 --quant-type=quantize 2>&1 | FileCheck %s --check-prefix=MXF32I8-QUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8-f32 --batch=4096 --layers=8192,4096 --quant-type=dequantize --output=generic --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8F32-PACKED-DEQUANT
+// RUN: mlir-gen --kernel=args --seed=0 --data-type=mx-i8-f32 --batch=128 --layers=2304,768 --quant-type=dequantize --scale-type=f8E8M0FNU --tiles=32,32,64 --vnni=4 2>&1 | FileCheck %s --check-prefix=MXI8-I8SCALE-PACKED-DEQUANT
 
 
 // FP32: // RUN{{.*}}tpp-run %s -n {{\d*}}

--- a/test/Integration/MLIRGen/mlir-gen-named.mlir
+++ b/test/Integration/MLIRGen/mlir-gen-named.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --float-type=f32 --batch=128 --layers=2304,768 2>&1 | FileCheck %s
+// RUN: mlir-gen --output=named --kernel=args --bias --relu --seed=0 --data-type=f32 --batch=128 --layers=2304,768 2>&1 | FileCheck %s
 
 // CHECK: // RUN{{.*}}tpp-run %s -n {{\d*}}
 // CHECK: // RUN{{.*}}-e entry -entry-point-result=void

--- a/test/Integration/MLIRGen/mlir-gen.mlir
+++ b/test/Integration/MLIRGen/mlir-gen.mlir
@@ -16,14 +16,12 @@
 // RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=generic | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
 // RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=contract | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
 // RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=named | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
-// RUN: mlir-gen --kernel=const --batch=10 --layers=10,10 --output=named --keep-generic-matmul | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=MATMUL
 
 // Constant values
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=generic | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=contract | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=named | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
-// RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=named --keep-generic-matmul | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 
 // Kernel - matmul
 // RUN: mlir-gen --kernel=args --seed=123 --float-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL

--- a/test/Integration/MLIRGen/mlir-gen.mlir
+++ b/test/Integration/MLIRGen/mlir-gen.mlir
@@ -24,18 +24,18 @@
 // RUN: mlir-gen --kernel=const --bias --relu --batch=10 --layers=10,10 --output=named | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=CONSTANT
 
 // Kernel - matmul
-// RUN: mlir-gen --kernel=args --seed=123 --float-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
+// RUN: mlir-gen --kernel=args --seed=123 --data-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL
 
 // Kernel - fc
-// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --float-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
+// RUN: mlir-gen --kernel=args --bias --relu --seed=123 --data-type=f32 --batch=10 --layers=10,10 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-FC
 
 // Packed versions
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 // RUN: mlir-gen --kernel=const --bias --relu --seed=123 --batch=10 --layers=10,10,10 --tiles=2,2,2 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
 
 // Use two Kernels, one matmul and other quantize-dequantize. That is, the result of matmul would be quantized and then dequantized.
-// RUN: mlir-gen --kernel=const --seed=0 --float-type=f32 --batch=3 --layers=3,3 --identity | tpp-run -e entry -entry-point-result=void -print --splat-to-random --init-type normal  -seed 123 > %t.1
-// RUN: mlir-gen --identity --kernel=const --seed=0 --float-type=mx-f32-i8 --batch=3 --layers=3,3 --quant-type=testquant | tpp-run -e entry -entry-point-result=void -print --splat-to-random --init-type normal  -seed 123 > %t.2
+// RUN: mlir-gen --kernel=const --seed=0 --data-type=f32 --batch=3 --layers=3,3 --identity | tpp-run -e entry -entry-point-result=void -print --splat-to-random --init-type normal  -seed 123 > %t.1
+// RUN: mlir-gen --identity --kernel=const --seed=0 --data-type=mx-f32-i8 --batch=3 --layers=3,3 --quant-type=testquant | tpp-run -e entry -entry-point-result=void -print --splat-to-random --init-type normal  -seed 123 > %t.2
 
 // Comparison is done between the result of matmul and the result of quantize-dequantize kernels.
 // RUN: fpcmp -a 0.01 -r 0.01 %t.1 %t.2

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -116,7 +116,7 @@ static Value createCastToFloat(OpBuilder &builder, Location loc, Value value,
 
 MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
                              unsigned batch, StringRef layersStr,
-                             StringRef tilesStr, StringRef registerUnrollStr, StringRef targetType,
+                             StringRef tilesStr, StringRef registerUnrollStr, StringRef dataType,
                              StringRef scaleType, StringRef quantizationTypeStr,
                              int seed, bool identity, bool enableBias,
                              bool enableRelu, bool enableSoftmax,
@@ -158,18 +158,17 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
   parseStringList(layersStr, layers);
   assert(layers.size() >= 2 && "Must have at least input/output layers");
 
-  // Parse tile sizes
+  // Parse matmul tile / unroll sizes
   parseStringList(tilesStr, tiles);
   assert((tiles.size() == 0 || tiles.size() == 3) &&
          "Must have 3 tile sizes (or none)");
-
   parseStringList(registerUnrollStr, registerUnroll);
-  assert((tiles.size() == 0 || tiles.size() == 3) &&
+  assert((registerUnroll.size() == 0 || registerUnroll.size() == 3) &&
          "Must have 3 register unrolling or none");
 
-  // Pick data type
+  // Pick data types
   auto elementType =
-      llvm::StringSwitch<std::optional<SmallVector<mlir::Type>>>(targetType)
+      llvm::StringSwitch<std::optional<SmallVector<mlir::Type>>>(dataType)
           .CaseLower("f32", SmallVector<Type>{builder.getF32Type(),
                                               builder.getF32Type()})
           .CaseLower("f16", SmallVector<Type>{builder.getF16Type(),
@@ -214,7 +213,7 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
   // If the target type contains "mx", it is a mixed precision type. If
   // quantization type is not explicitly specified, we will default to Mixed
   // quantization type for mixed precision target types.
-  bool hasMixedType = !targetType.empty() && targetType.contains("mx");
+  bool hasMixedType = !dataType.empty() && dataType.contains("mx");
   if (hasMixedType && quantType == QuantizationType::None)
     quantType = QuantizationType::Mixed;
 

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -87,7 +87,7 @@ static Value createExpandedScaleTensor(OpBuilder &builder, Location loc,
   return scale;
 }
 
-static Value createCastToType(OpBuilder &builder, Location loc, Value value,
+static Value createCastToFloat(OpBuilder &builder, Location loc, Value value,
                               mlir::Type dstType,
                               arith::FastMathFlagsAttr fmf = nullptr) {
   assert(dstType.isFloat() && "Unsupported target type for cast");
@@ -120,11 +120,11 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
                              StringRef scaleType, StringRef quantizationTypeStr,
                              int seed, bool identity, bool enableBias,
                              bool enableRelu, bool enableSoftmax,
-                             bool keepGenericMatmul, int vnniBlockingFactor)
+                             int vnniBlockingFactor)
     : builder(&context), loc(builder.getUnknownLoc()), batch(batch), seed(seed),
       identity(identity), flops(0), enableBias(enableBias),
       enableRelu(enableRelu), enableSoftmax(enableSoftmax),
-      keepGenericMatmul(keepGenericMatmul), vnniFactor(vnniBlockingFactor) {
+      vnniFactor(vnniBlockingFactor) {
 
   // Register all necessary dialects
   context
@@ -141,8 +141,6 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
           .CaseLower("named", OutputOpKind::NamedOp)
           .Default(std::nullopt);
   assert(optOutputOpKind && "Invalid output Op kind");
-  assert(!(optOutputOpKind == OutputOpKind::Contract && keepGenericMatmul) &&
-         "Can't keep generic matmul with contract");
   outputOpKind = *optOutputOpKind;
 
   // Parse kernel type
@@ -567,7 +565,7 @@ Value MLIRGenerator::lowerNamedMatmul(Value input, Value weight, Value output) {
   // tensor had been discussed and can be revisited as potential solution.
   if (vnniFactor != 0) {
     llvm_unreachable(
-        "Unsupported Lowering for VNNI, Try '--keep-generic-matmul'");
+        "Unsupported Lowering for VNNI, Try 'generic' or 'contract' lowering");
   }
 
   Value namedMatmul;
@@ -645,7 +643,7 @@ Value MLIRGenerator::lowerMatmul(LayerArgs &args, bool hasMixedType = false) {
                                                   reassociationIndices);
   }
 
-  if (outputOpKind == OutputOpKind::Generic || keepGenericMatmul) {
+  if (outputOpKind == OutputOpKind::Generic) {
     chain = lowerGenericMatmul(input, weight, output);
   } else if (outputOpKind == OutputOpKind::Contract) {
     chain = lowerContract(input, weight, output);
@@ -1007,15 +1005,15 @@ Value MLIRGenerator::dequantizeGemm(LayerArgs &args, Value chain) {
                                            ? arith::FastMathFlags::nnan
                                            : arith::FastMathFlags::none;
             arg1 =
-                createCastToType(nestedBuilder, nestedLoc, arg1, floatTy,
+                createCastToFloat(nestedBuilder, nestedLoc, arg1, floatTy,
                                  arith::FastMathFlagsAttr::get(&context, fmf));
             arg2 =
-                createCastToType(nestedBuilder, nestedLoc, arg2, floatTy,
+                createCastToFloat(nestedBuilder, nestedLoc, arg2, floatTy,
                                  arith::FastMathFlagsAttr::get(&context, fmf));
             Value alu = arith::MulFOp::create(nestedBuilder, loc, arg1, arg2)
                             ->getResult(0);
             Value castToFloat =
-                createCastToType(nestedBuilder, nestedLoc, arg0,
+                createCastToFloat(nestedBuilder, nestedLoc, arg0,
                                  outputShapedTy.getElementType());
             alu = arith::MulFOp::create(nestedBuilder, loc, castToFloat, alu)
                       ->getResult(0);

--- a/tools/mlir-gen/MLIRGen.h
+++ b/tools/mlir-gen/MLIRGen.h
@@ -86,9 +86,6 @@ class MLIRGenerator {
   /// Kind of linalg output Op to be generated
   OutputOpKind outputOpKind;
 
-  /// Allow emitting generic matmul when OutputOpKind is named op
-  bool keepGenericMatmul;
-
   /// List of supported kernel types that can be generated
   ///  * Const: Generates weights and biases as constant (RO).
   ///  * Args: Generates weights and biaseds as arguments (RW).
@@ -267,7 +264,7 @@ public:
   /// so should create new objects to not have to share / cleanup existing MLIR
   /// modules.
   MLIRGenerator(StringRef, StringRef, unsigned, StringRef, StringRef, StringRef, StringRef,
-                StringRef, StringRef, int, bool, bool, bool, bool, bool, int);
+                StringRef, StringRef, int, bool, bool, bool, bool, int);
 
   ~MLIRGenerator() { module->destroy(); }
 

--- a/tools/mlir-gen/generate.sh
+++ b/tools/mlir-gen/generate.sh
@@ -126,7 +126,7 @@ debug "Random seed: $SEED"
 # Defaults
 
 # Command line to extract and run
-MLIR_GEN_ARGS="--float-type=$FLOAT_TYPE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
+MLIR_GEN_ARGS="--data-type=$FLOAT_TYPE --seed=$SEED --batch=$MB --layers=$LAYER_SIZES --tiles=$TILE_SIZES"
 ORIG_MLIR="mlir-gen-original.mlir"
 debug "\nCreating the original MLIR model:"
 run "$MLIR_GEN $MLIR_GEN_ARGS" $ORIG_MLIR

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -36,13 +36,6 @@ llvm::cl::opt<std::string> outputOpKind(
     "output", llvm::cl::desc("Specifies linalg op kind generic, contract or named"),
     llvm::cl::value_desc("generic,contract,named"), llvm::cl::init("generic"));
 
-// Enable emission of generic matmul when outputKind is named op
-llvm::cl::opt<bool> keepGenericMatmul(
-    "keep-generic-matmul",
-    llvm::cl::desc("Enable emission of generic matmul when choosen "
-                   "outputKind is named op"),
-    llvm::cl::value_desc("bool"), llvm::cl::init(false));
-
 // Type of kernel to be generated
 llvm::cl::opt<std::string> kernel("kernel",
                                   llvm::cl::desc("Kernel type to be generated"),
@@ -143,6 +136,6 @@ int main(int argc, char **argv) {
 
   MLIRGenerator gen(outputOpKind, kernel, batch, layers, tiles, registerUnroll, floatType,
                     scaleType, quantizationType, seed, identity, enableBias,
-                    enableRelu, enableSoftmax, keepGenericMatmul, vnni);
+                    enableRelu, enableSoftmax, vnni);
   return gen.generate(filename, floatType.getValue().find("mx-", 0) == 0);
 }

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -64,12 +64,9 @@ llvm::cl::opt<std::string>
           llvm::cl::desc("Comma-separated values of size of each tile (N,K,C)"),
           llvm::cl::value_desc("1,1,1"), llvm::cl::init(""));
 
-// Float type flag to indicate input data type. It is being extended to further
-// indicate mixed precision types, source and destination types in case of
-// quantization using 'mx-' prefix. This may be changed further with clarity on
-// quantization ops.
+// Data type for the arguments
 llvm::cl::opt<std::string>
-    floatType("float-type", llvm::cl::desc("Float type and its bitsize"),
+    dataType("data-type", llvm::cl::desc("Data type for arguments"),
               llvm::cl::value_desc(
                   "f32|f16|bf16|mx-bf16|mx-f16|mx-i8|mx-i8-f32|mx-f32-i8"),
               llvm::cl::init("f32"));
@@ -134,8 +131,8 @@ int main(int argc, char **argv) {
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Generator");
 
-  MLIRGenerator gen(outputOpKind, kernel, batch, layers, tiles, registerUnroll, floatType,
+  MLIRGenerator gen(outputOpKind, kernel, batch, layers, tiles, registerUnroll, dataType,
                     scaleType, quantizationType, seed, identity, enableBias,
                     enableRelu, enableSoftmax, vnni);
-  return gen.generate(filename, floatType.getValue().find("mx-", 0) == 0);
+  return gen.generate(filename, dataType.getValue().find("mx-", 0) == 0);
 }


### PR DESCRIPTION
* Rename `float-type` to `data-type` (many test/bench changes)
* Fix copy-pasta on `gemmUnroll` that was using `tiles`
* Remove unnecessary `keep-generic-matmul` flag
* Rename `createCastToType` to `createCastToFloat` as that's all it does