### PR TITLE
added fp8 (E5M2, E4M3) support to xsmm lowering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(BENCH_CFGS
   ${CONFIG_DIR}/base/base.json
   ${CONFIG_DIR}/base/mha.json
   ${CONFIG_DIR}/base/named-ops.json
+  ${CONFIG_DIR}/base/fp8.json
 )
 string(JOIN ',' BENCH_CFGS_STR ${BENCH_CFGS})
 # Run a small set of benchmarks with small iterations to test the benchmarks and run locally on small machines

--- a/benchmarks/config/base/fp8.json
+++ b/benchmarks/config/base/fp8.json
@@ -1,0 +1,36 @@
+[
+  {
+  "gemm_fp8_vnni": {
+    "bf8_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=bf8 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "hf8_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --data-type=hf8 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }},
+  {
+  "mlp_fp8_vnni": {
+    "bf8_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=bf8 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    },
+    "hf8_3x1024_const_mlir": {
+      "type": "IR-GEN",
+      "benchmark": [ "mlir-gen", "--kernel=const --bias --relu --data-type=hf8 --batch=256 --layers=1024,1024,1024,1024 --tiles=32,32,32 --vnni=4" ],
+      "environment": {},
+      "flags": [ "-n", "100" ],
+      "extensions": [ "(avx2|asimd)" ]
+    }
+  }}
+]

--- a/include/TPP/Dialect/Xsmm/XsmmEnum.td
+++ b/include/TPP/Dialect/Xsmm/XsmmEnum.td
@@ -14,7 +14,10 @@ def Xsmm_DataType: I64EnumAttr<
     "DataType", "see: libxsmm_datatype",
     [
       I64EnumAttrCase<"F32",  1, "f32">,
-      I64EnumAttrCase<"BF16", 2, "bf16">
+      I64EnumAttrCase<"BF16", 2, "bf16">,
+      // FP8 data types. libxsmm names E5M2 as BF8 and E4M3 as HF8.
+      I64EnumAttrCase<"BF8",  4, "bf8">,
+      I64EnumAttrCase<"HF8",  5, "hf8">
     ]>{
    let cppNamespace = "mlir::xsmm";
 }
@@ -39,7 +42,8 @@ def Xsmm_UnaryKind : I64EnumAttr<
       I64EnumAttrCase<"ZERO", 2, "zero">,
       I64EnumAttrCase<"RELU", 5, "relu">,
       I64EnumAttrCase<"VNNI2", 28, "vnni_2">,
-      I64EnumAttrCase<"TRANSPOSE", 29, "transpose">
+      I64EnumAttrCase<"TRANSPOSE", 29, "transpose">,
+      I64EnumAttrCase<"VNNI4", 54, "vnni_4">
     ]> {
   let cppNamespace = "mlir::xsmm";
 }

--- a/include/TPP/Dialect/Xsmm/XsmmOps.td
+++ b/include/TPP/Dialect/Xsmm/XsmmOps.td
@@ -20,8 +20,8 @@ class StaticMemRefRankOf<list<Type> allowedTypes, list<int> ranks> :
          MemRefOf<allowedTypes>.summary,
          "::mlir::MemRefType">;
 
-def XsmmMemRef : AnyTypeOf<[StaticMemRefRankOf<[F32, BF16], [1, 2, 3, 4]>,
-                            F32, BF16, I64]>;
+def XsmmMemRef : AnyTypeOf<[StaticMemRefRankOf<[F32, BF16, F8E5M2, F8E4M3FN], [1, 2, 3, 4]>,
+                            F32, BF16, F8E5M2, F8E4M3FN, I64]>;
 
 //===----------------------------------------------------------------------===//
 // BinaryOp
@@ -95,7 +95,7 @@ def Xsmm_UnaryOp : Xsmm_Op<"unary", [MemoryEffects<[MemWrite, MemRead]>]> {
 // GemmOp
 //===----------------------------------------------------------------------===//
 
-def GemmMemRef : AnyTypeOf<[StaticMemRefRankOf<[F32, BF16], [2, 3]>, I64]>;
+def GemmMemRef : AnyTypeOf<[StaticMemRefRankOf<[F32, BF16, F8E5M2, F8E4M3FN], [2, 3]>, I64]>;
 
 def Xsmm_GemmOp : Xsmm_Op<"gemm", [MemoryEffects<[MemWrite, MemRead]>]> {
   let summary = "matmul call operation.";
@@ -123,7 +123,7 @@ def Xsmm_GemmOp : Xsmm_Op<"gemm", [MemoryEffects<[MemWrite, MemRead]>]> {
 // BrgemmOp
 //===----------------------------------------------------------------------===//
 
-def BrgemmMemRef : AnyTypeOf<[StaticMemRefRankOf<[F32, BF16], [2, 3, 4]>, I64]>;
+def BrgemmMemRef : AnyTypeOf<[StaticMemRefRankOf<[F32, BF16, F8E5M2, F8E4M3FN], [2, 3, 4]>, I64]>;
 
 def Xsmm_BrgemmOp : Xsmm_Op<"brgemm", [MemoryEffects<[MemWrite, MemRead]>]> {
   let summary = "brgemm call operation.";

--- a/include/TPP/Transforms/Utils/TensorInitFloat.h
+++ b/include/TPP/Transforms/Utils/TensorInitFloat.h
@@ -24,8 +24,9 @@
 
 // Base class for float values.
 struct TensorInitFloat : public TensorInit<llvm::APFloat> {
-  // Supported data types. (TODO: Support 8-bit data types)
-  enum class DataType { AUTO, FP16, FP32, FP64, BF16, F8E8M0FNU };
+  // Supported data types.
+  // FP8 pure types: F8E5M2 (libxsmm BF8) and F8E4M3FN (libxsmm HF8).
+  enum class DataType { AUTO, FP16, FP32, FP64, BF16, F8E8M0FNU, F8E5M2, F8E4M3FN };
 
   static bool isTypeSupported(const mlir::Type &type) {
     return type.isF16() || type.isF32() || type.isF64() || type.isBF16() ||
@@ -43,6 +44,20 @@ protected:
   static void toF8E8M0FNU(llvm::APFloat &value) {
     bool ignored;
     value.convert(llvm::APFloat::Float8E8M0FNU(),
+                  llvm::APFloat::rmNearestTiesToEven, &ignored);
+  }
+
+  // F8E5M2 (libxsmm BF8) conversion (by reference).
+  static void toF8E5M2(llvm::APFloat &value) {
+    bool ignored;
+    value.convert(llvm::APFloat::Float8E5M2(),
+                  llvm::APFloat::rmNearestTiesToEven, &ignored);
+  }
+
+  // F8E4M3FN (libxsmm HF8) conversion (by reference).
+  static void toF8E4M3FN(llvm::APFloat &value) {
+    bool ignored;
+    value.convert(llvm::APFloat::Float8E4M3FN(),
                   llvm::APFloat::rmNearestTiesToEven, &ignored);
   }
 

--- a/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
+++ b/lib/TPP/Conversion/ConvertLinalgToXsmm/ConvertLinalgToXsmm.cpp
@@ -1071,8 +1071,11 @@ struct ConvertVnniPacking : public OpRewritePattern<linalg::TransposeOp> {
     unaryInfo.ldo = stridesOnOutput->front() / vnniFactor;
     auto flags = rewriter.getArrayAttr(xsmm::UnaryFlagsAttr::get(
         rewriter.getContext(), xsmm::UnaryFlags::NONE));
-    xsmm::UnaryKindAttr kind =
-        xsmm::UnaryKindAttr::get(rewriter.getContext(), xsmm::UnaryKind::VNNI2);
+    // Select the norm-to-vnni transform based on the blocking factor:
+    // factor 2 -> VNNI2 (bf16), factor 4 -> VNNI4 (fp8).
+    xsmm::UnaryKindAttr kind = xsmm::UnaryKindAttr::get(
+        rewriter.getContext(),
+        vnniFactor == 4 ? xsmm::UnaryKind::VNNI4 : xsmm::UnaryKind::VNNI2);
     xsmm::utils::replaceOpWithUnary(rewriter, transposeOp, {source, out},
                                     unaryInfo, flags, kind);
     return success();

--- a/lib/TPP/DefaultPipeline.cpp
+++ b/lib/TPP/DefaultPipeline.cpp
@@ -218,6 +218,13 @@ private:
     if (defParallel)
       pm.addPass(createConvertSCFToOpenMPPass());
     pm.addPass(createConvertVectorToSCFPass());
+    // FP8 (E5M2/E4M3) has no native CPU arithmetic support. Emulate it by
+    // promoting operations to F32 around extf/truncf pairs.
+    mlir::arith::ArithEmulateUnsupportedFloatsOptions emulateFloatsOptions;
+    emulateFloatsOptions.sourceTypeStrs = {"f8E5M2", "f8E4M3FN"};
+    emulateFloatsOptions.targetTypeStr = "f32";
+    pm.addPass(
+        mlir::arith::createArithEmulateUnsupportedFloats(emulateFloatsOptions));
     mlir::arith::ArithExpandOpsPassOptions arithExpandOpsOptions;
     arithExpandOpsOptions.includeF8E8M0 = true;
     pm.addPass(arith::createArithExpandOpsPass(arithExpandOpsOptions));

--- a/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmOps.cpp
@@ -10,6 +10,7 @@
 #include "TPP/Dialect/Xsmm/XsmmEnum.h"
 #include "TPP/Transforms/Utils/VNNIUtils.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/TypeUtilities.h"
 
@@ -289,13 +290,15 @@ static LogicalResult verifyGemmFlags(ArrayAttr flags, DataType dataType,
   for (auto flag : flags) {
     flagsAsInt.push_back(cast<IntegerAttr>(flag).getInt());
   }
-  // VNNI flags must be specified only for bf16 type
-  if (dataType != DataType::BF16 && llvm::any_of(flagsAsInt, [](int64_t flag) {
+  // VNNI flags must be specified only for low-precision types (bf16 or fp8).
+  bool isVnniType = dataType == DataType::BF16 || dataType == DataType::BF8 ||
+                    dataType == DataType::HF8;
+  if (!isVnniType && llvm::any_of(flagsAsInt, [](int64_t flag) {
         return (flag == static_cast<int64_t>(GemmFlags::VNNI_B) ||
                 flag == static_cast<int64_t>(GemmFlags::VNNI_A) ||
                 flag == static_cast<int64_t>(GemmFlags::VNNI_C));
       })) {
-    return op->emitOpError() << "VNNI flags but type is not bf16";
+    return op->emitOpError() << "VNNI flags but type is not bf16 or fp8";
   }
 
   return success();
@@ -423,6 +426,11 @@ static LogicalResult verifyXsmmCommon(OpTy invokeOp,
   auto isCompatible = [](xsmm::DataType dataType, Type type) {
     if (dataType == xsmm::DataType::F32)
       return type.isF32();
+    // libxsmm names E5M2 as BF8 and E4M3 as HF8.
+    if (dataType == xsmm::DataType::BF8)
+      return llvm::isa<Float8E5M2Type>(type);
+    if (dataType == xsmm::DataType::HF8)
+      return llvm::isa<Float8E4M3FNType>(type);
     return type.isBF16();
   };
 

--- a/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
+++ b/lib/TPP/Dialect/Xsmm/XsmmUtils.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
 
 #include "TPP/Transforms/Utils/BuilderUtils.h"
@@ -66,6 +67,11 @@ DataTypeAttr getDataType(RewriterBase &rewriter, Type type) {
   auto elemType = getElementTypeOrSelf(type);
   if (elemType.isBF16())
     return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::BF16);
+  // libxsmm names E5M2 as BF8 and E4M3 as HF8.
+  if (llvm::isa<Float8E5M2Type>(elemType))
+    return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::BF8);
+  if (llvm::isa<Float8E4M3FNType>(elemType))
+    return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::HF8);
   return xsmm::DataTypeAttr::get(rewriter.getContext(), xsmm::DataType::F32);
 }
 

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -421,17 +421,54 @@ void MLIRBench::printVector(Value vector) {
     auto i8VecType = VectorType::get(shape, i8Type);
     Value i8Vec = arith::BitcastOp::create(builder, unkLoc, i8VecType, vector);
     auto f32VecType = VectorType::get(shape, f32Type);
-    Value f32Vec = arith::ConstantOp::create(
+    Value initVec = arith::ConstantOp::create(
         builder, unkLoc, builder.getZeroAttr(f32VecType));
-    for (int64_t i = 0; i < numElems; i++) {
+
+    // Convert one FP8 lane at position `idx` of `i8Vec` to f32 and insert it
+    // into `f32Vec`, returning the updated accumulator vector.
+    auto convertLane = [&](Value f32Vec, OpFoldResult idx) -> Value {
       Value lane = vector::ExtractOp::create(builder, unkLoc, i8Vec,
-                                             ArrayRef<int64_t>{i});
+                                             ArrayRef<OpFoldResult>{idx});
       Value converted =
           func::CallOp::create(builder, unkLoc, fnDecl, ValueRange{lane})
               .getResult(0);
-      f32Vec = vector::InsertOp::create(builder, unkLoc, converted, f32Vec,
-                                        ArrayRef<int64_t>{i});
+      return vector::InsertOp::create(builder, unkLoc, converted, f32Vec,
+                                      ArrayRef<OpFoldResult>{idx});
+    };
+
+    // Emitting one extract/call/insert per lane fully unrolled at compile time
+    // would explode the IR for large vectors. Instead emit an scf.for loop
+    // blocked by `unrollFactor`: the outer loop iterates over blocks of
+    // `unrollFactor` lanes (unrolled here in the loop body), and a
+    // compile-time-unrolled tail handles the leftover lanes. This keeps the
+    // generated IR size bounded regardless of the vector length.
+    constexpr int64_t unrollFactor = 128;
+    Value f32Vec = initVec;
+    int64_t numBlocks = numElems / unrollFactor;
+    if (numBlocks > 0) {
+      auto lb = getConstIndex(builder, 0);
+      auto ub = getConstIndex(builder, numBlocks * unrollFactor);
+      auto step = getConstIndex(builder, unrollFactor);
+      auto loop = scf::ForOp::create(builder, unkLoc, lb, ub, step,
+                                     ValueRange{f32Vec});
+      {
+        OpBuilder::InsertionGuard g(builder);
+        builder.setInsertionPointToStart(loop.getBody());
+        Value iv = loop.getInductionVar();
+        Value acc = loop.getRegionIterArg(0);
+        for (int64_t k = 0; k < unrollFactor; k++) {
+          Value idx = k == 0 ? iv
+                             : arith::AddIOp::create(builder, unkLoc, iv,
+                                                     getConstIndex(builder, k));
+          acc = convertLane(acc, idx);
+        }
+        scf::YieldOp::create(builder, unkLoc, ValueRange{acc});
+      }
+      f32Vec = loop.getResult(0);
     }
+    // Compile-time-unrolled tail for the remaining (< unrollFactor) lanes.
+    for (int64_t i = numBlocks * unrollFactor; i < numElems; i++)
+      f32Vec = convertLane(f32Vec, builder.getIndexAttr(i));
     op = f32Vec;
   } else if (elemType.isBF16()) {
     VectorType vecType =

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -421,8 +421,6 @@ void MLIRBench::printVector(Value vector) {
     auto i8VecType = VectorType::get(shape, i8Type);
     Value i8Vec = arith::BitcastOp::create(builder, unkLoc, i8VecType, vector);
     auto f32VecType = VectorType::get(shape, f32Type);
-    Value initVec = arith::ConstantOp::create(
-        builder, unkLoc, builder.getZeroAttr(f32VecType));
 
     // Convert one FP8 lane at position `idx` of `i8Vec` to f32 and insert it
     // into `f32Vec`, returning the updated accumulator vector.
@@ -443,7 +441,8 @@ void MLIRBench::printVector(Value vector) {
     // compile-time-unrolled tail handles the leftover lanes. This keeps the
     // generated IR size bounded regardless of the vector length.
     constexpr int64_t unrollFactor = 128;
-    Value f32Vec = initVec;
+    Value f32Vec = arith::ConstantOp::create(
+        builder, unkLoc, builder.getZeroAttr(f32VecType));
     int64_t numBlocks = numElems / unrollFactor;
     if (numBlocks > 0) {
       auto lb = getConstIndex(builder, 0);

--- a/lib/TPP/Runner/MLIRBench.cpp
+++ b/lib/TPP/Runner/MLIRBench.cpp
@@ -396,7 +396,44 @@ void MLIRBench::printMean(Value mean) {
 void MLIRBench::printVector(Value vector) {
   auto op = vector;
   auto vectorValue = dyn_cast<VectorType>(vector.getType());
-  if (vectorValue.getElementType().isBF16()) {
+  auto elemType = vectorValue.getElementType();
+  // vector.print does not support low-precision types; up-cast to f32.
+  if (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(elemType)) {
+    // FP8 (E5M2/E4M3) has no native arithmetic on the target, so we cannot use
+    // arith.extf here. Convert each lane to f32 using the libxsmm converters
+    // exposed by the runtime (E5M2 = BF8, E4M3 = HF8).
+    StringRef fnName = llvm::isa<Float8E5M2Type>(elemType)
+                           ? "xsmm_convert_bf8_to_f32"
+                           : "xsmm_convert_hf8_to_f32";
+    Type i8Type = builder.getI8Type();
+    Type f32Type = builder.getF32Type();
+    // Declare the runtime converter once at module scope.
+    auto fnDecl = dyn_cast_or_null<func::FuncOp>(module.lookupSymbol(fnName));
+    if (!fnDecl) {
+      OpBuilder::InsertionGuard g(builder);
+      builder.setInsertionPointToStart(&getModuleBlock());
+      auto fnType = builder.getFunctionType({i8Type}, {f32Type});
+      fnDecl = func::FuncOp::create(builder, unkLoc, fnName, fnType);
+      fnDecl.setPrivate();
+    }
+    auto shape = vectorValue.getShape();
+    int64_t numElems = vectorValue.getNumElements();
+    auto i8VecType = VectorType::get(shape, i8Type);
+    Value i8Vec = arith::BitcastOp::create(builder, unkLoc, i8VecType, vector);
+    auto f32VecType = VectorType::get(shape, f32Type);
+    Value f32Vec = arith::ConstantOp::create(
+        builder, unkLoc, builder.getZeroAttr(f32VecType));
+    for (int64_t i = 0; i < numElems; i++) {
+      Value lane = vector::ExtractOp::create(builder, unkLoc, i8Vec,
+                                             ArrayRef<int64_t>{i});
+      Value converted =
+          func::CallOp::create(builder, unkLoc, fnDecl, ValueRange{lane})
+              .getResult(0);
+      f32Vec = vector::InsertOp::create(builder, unkLoc, converted, f32Vec,
+                                        ArrayRef<int64_t>{i});
+    }
+    op = f32Vec;
+  } else if (elemType.isBF16()) {
     VectorType vecType =
         VectorType::get(vectorValue.getShape(), builder.getF32Type());
     op = arith::ExtFOp::create(builder, unkLoc, vecType, vector, arith::FastMathFlagsAttr{});

--- a/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/Transforms/ToBlockLayoutAndBack.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/Traits.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/Support/MathExtras.h"
@@ -107,8 +108,11 @@ mlir::linalgx::packVNNIMatmulOp(RewriterBase &rewriter,
                                 linalg::GenericOp matmulOp) {
   if (matmulOp.getInputs().size() > 0) {
     auto elementType = getElementTypeOrSelf(matmulOp.getInputs()[0].getType());
-    if (!elementType.isBF16() && !elementType.isInteger(8))
-      return rewriter.notifyMatchFailure(matmulOp, "require int8/bf16 type");
+    // libxsmm names E5M2 as BF8 and E4M3 as HF8.
+    if (!elementType.isBF16() && !elementType.isInteger(8) &&
+        !llvm::isa<Float8E5M2Type, Float8E4M3FNType>(elementType))
+      return rewriter.notifyMatchFailure(matmulOp,
+                                         "require int8/bf16/fp8 type");
   }
 
   if (matmulOp.hasDynamicShape())
@@ -189,8 +193,10 @@ FailureOr<linalg::GenericOp>
 mlir::linalgx::packVNNIBRGemmOp(RewriterBase &rewriter,
                                 linalg::BatchReduceMatmulOp brgemmOp) {
   auto elementType = getElementTypeOrSelf(brgemmOp.getInputs()[0].getType());
-  if (!elementType.isBF16())
-    return rewriter.notifyMatchFailure(brgemmOp, "require bf16 type");
+  // libxsmm names E5M2 as BF8 and E4M3 as HF8.
+  if (!elementType.isBF16() &&
+      !llvm::isa<Float8E5M2Type, Float8E4M3FNType>(elementType))
+    return rewriter.notifyMatchFailure(brgemmOp, "require bf16/fp8 type");
 
   if (brgemmOp.hasDynamicShape())
     return rewriter.notifyMatchFailure(brgemmOp, "require static shape");

--- a/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
+++ b/lib/TPP/Transforms/Utils/TensorInitFloat.cpp
@@ -7,11 +7,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "TPP/Transforms/Utils/TensorInitFloat.h"
+#include "mlir/IR/BuiltinTypes.h"
 
 using namespace mlir;
 
 TensorInitFloat::DataType
 TensorInitFloat::getTensorInitDataType(mlir::Type type) {
+  // FP8 pure types. libxsmm names E5M2 as BF8 and E4M3 as HF8.
+  if (llvm::isa<mlir::Float8E5M2Type>(type))
+    return DataType::F8E5M2;
+  if (llvm::isa<mlir::Float8E4M3FNType>(type))
+    return DataType::F8E4M3FN;
   if (type.isFloat(8))
     return DataType::F8E8M0FNU;
   if (type.isBF16())
@@ -37,6 +43,12 @@ void TensorInitFloat::convertType(llvm::APFloat &value) {
   switch (type) {
   case DataType::F8E8M0FNU:
     toF8E8M0FNU(value);
+    break;
+  case DataType::F8E5M2:
+    toF8E5M2(value);
+    break;
+  case DataType::F8E4M3FN:
+    toF8E4M3FN(value);
     break;
   case DataType::FP16:
     toFP16(value);

--- a/lib/TPP/Transforms/Utils/VNNIUtils.cpp
+++ b/lib/TPP/Transforms/Utils/VNNIUtils.cpp
@@ -69,12 +69,19 @@ unsigned getVnniBlockingFactor(Type type, Operation *op) {
   unsigned blockingFactor = 0;
 
   auto elementType = getElementTypeOrSelf(type);
-  if (elementType.isBF16() || elementType.isInteger(8)) {
+  // libxsmm names E5M2 as BF8 and E4M3 as HF8.
+  bool isFp8 =
+      llvm::isa<Float8E5M2Type, Float8E4M3FNType>(elementType);
+  if (elementType.isBF16() || elementType.isInteger(8) || isFp8) {
     // Check if a VNNI factor hint is associated to the IR via DLTI.
     auto vnniValue = dlti::utils::query(op, {"CPU", "vnni"});
     if (succeeded(vnniValue)) {
       if (auto intAttr = llvm::dyn_cast<IntegerAttr>(*vnniValue))
         blockingFactor = intAttr.getInt();
+    } else if (isFp8) {
+      blockingFactor = llvm::isa<Float8E5M2Type>(elementType)
+                           ? libxsmm_cpuid_dot_pack_factor(LIBXSMM_DATATYPE_BF8)
+                           : libxsmm_cpuid_dot_pack_factor(LIBXSMM_DATATYPE_HF8);
     } else {
       blockingFactor =
           elementType.isBF16()
@@ -192,8 +199,11 @@ bool isInVnniLayout(VnniOperandRank expectedRank, ShapedType shape,
 
 bool isInVnniLayout(int64_t expectedRank, ShapedType shape,
                     std::optional<unsigned> blockingFactor) {
-  if (shape.getRank() != expectedRank ||
-      !(shape.getElementType().isBF16() || shape.getElementType().isInteger(8)))
+  auto elementType = shape.getElementType();
+  // libxsmm names E5M2 as BF8 and E4M3 as HF8.
+  bool isVnniType = elementType.isBF16() || elementType.isInteger(8) ||
+                    llvm::isa<Float8E5M2Type, Float8E4M3FNType>(elementType);
+  if (shape.getRank() != expectedRank || !isVnniType)
     return false;
 
   auto vnniDim = shape.getShape().back();

--- a/runtime/Xsmm/XsmmRunnerUtils.cpp
+++ b/runtime/Xsmm/XsmmRunnerUtils.cpp
@@ -68,10 +68,39 @@ void *get_base_ptr(const libxsmm_datatype dType, void *alignedPtr,
   } else if (dType == LIBXSMM_DATATYPE_BF16) {
     bf16 *base_ptr = (bf16 *)alignedPtr + offset;
     return (void *)base_ptr;
+  } else if (dType == LIBXSMM_DATATYPE_BF8) {
+    // E5M2. libxsmm_bfloat8 is a single byte.
+    libxsmm_bfloat8 *base_ptr = (libxsmm_bfloat8 *)alignedPtr + offset;
+    return (void *)base_ptr;
+  } else if (dType == LIBXSMM_DATATYPE_HF8) {
+    // E4M3. libxsmm_hfloat8 is a single byte.
+    libxsmm_hfloat8 *base_ptr = (libxsmm_hfloat8 *)alignedPtr + offset;
+    return (void *)base_ptr;
   }
   fprintf(stderr, "Unhandled data type in get_data_pointer_from_memref_desc:%d",
           dType);
   return nullptr;
+}
+
+// BF16 and FP8 (E5M2/BF8, E4M3/HF8) have no native accumulate support, so the
+// computation must be retargeted to F32.
+bool needsFp32Compute(const libxsmm_datatype dtype) {
+  return dtype == LIBXSMM_DATATYPE_BF16 || dtype == LIBXSMM_DATATYPE_BF8 ||
+         dtype == LIBXSMM_DATATYPE_HF8;
+}
+
+// Return the compute data type for a given input/output data type.
+libxsmm_datatype getCompDataType(const libxsmm_datatype dtype) {
+  return needsFp32Compute(dtype) ? LIBXSMM_DATATYPE_F32 : dtype;
+}
+
+// Return the size in bytes of a single element of the given data type.
+size_t getDataTypeSize(const libxsmm_datatype dtype) {
+  if (dtype == LIBXSMM_DATATYPE_F32)
+    return sizeof(float);
+  if (dtype == LIBXSMM_DATATYPE_BF8 || dtype == LIBXSMM_DATATYPE_HF8)
+    return sizeof(libxsmm_bfloat8);
+  return sizeof(bf16);
 }
 
 } // namespace
@@ -130,9 +159,9 @@ extern "C" int64_t xsmm_gemm_dispatch(const libxsmm_datatype dtype, int64_t m,
   l_shape.a_in_type = dtype;
   l_shape.b_in_type = dtype;
   l_shape.out_type = dtype;
-  // Retarget computation type from bf16 to f32 due to missing hardware support.
-  l_shape.comp_type =
-      dtype == LIBXSMM_DATATYPE_BF16 ? LIBXSMM_DATATYPE_F32 : dtype;
+  // Retarget computation type from bf16/fp8 to f32 due to missing hardware
+  // support.
+  l_shape.comp_type = getCompDataType(dtype);
 
   auto sgemm = libxsmm_dispatch_gemm(l_shape, l_flags, l_prefetch_flags);
   if (!sgemm) {
@@ -162,10 +191,11 @@ xsmm_unary_dispatch(const libxsmm_meltw_unary_type op_type,
   unary_shape.m = static_cast<libxsmm_blasint>(n);
   unary_shape.n = static_cast<libxsmm_blasint>(m);
   unary_shape.in0_type = dtype;
-  // Retarget computation type from bf16 to f32 due to missing hardware support.
-  // Copy and Zero should remain in BF16 to avoid useless up/down casts
-  auto force_fp32 = (dtype == LIBXSMM_DATATYPE_BF16 &&
-                     !hasImplicitComputeDtypeUnary(op_type));
+  // Retarget computation type from bf16/fp8 to f32 due to missing hardware
+  // support. Copy and Zero should remain in the low-precision type to avoid
+  // useless up/down casts.
+  auto force_fp32 =
+      (needsFp32Compute(dtype) && !hasImplicitComputeDtypeUnary(op_type));
   unary_shape.comp_type = force_fp32 ? LIBXSMM_DATATYPE_F32 : dtype;
   unary_shape.out_type = dtype;
   unary_shape.ldi = static_cast<libxsmm_blasint>(ldi);
@@ -195,9 +225,9 @@ xsmm_binary_dispatch(const libxsmm_meltw_binary_type op_type,
   binary_shape.n = static_cast<libxsmm_blasint>(m);
   binary_shape.in0_type = dtype;
   binary_shape.in1_type = dtype;
-  // Retarget computation type from bf16 to f32 due to missing hardware support.
-  binary_shape.comp_type =
-      dtype == LIBXSMM_DATATYPE_BF16 ? LIBXSMM_DATATYPE_F32 : dtype;
+  // Retarget computation type from bf16/fp8 to f32 due to missing hardware
+  // support.
+  binary_shape.comp_type = getCompDataType(dtype);
   binary_shape.out_type = dtype;
   binary_shape.ldi = static_cast<libxsmm_blasint>(ldiLhs);
   binary_shape.ldi2 = static_cast<libxsmm_blasint>(ldiRhs);
@@ -236,8 +266,7 @@ extern "C" int64_t xsmm_intel_amx_tile_config_dispatch(
   l_shape.a_in_type = dtype;
   l_shape.b_in_type = dtype;
   l_shape.out_type = dtype;
-  l_shape.comp_type =
-      dtype == LIBXSMM_DATATYPE_BF16 ? LIBXSMM_DATATYPE_F32 : dtype;
+  l_shape.comp_type = getCompDataType(dtype);
 
   auto sgemm = libxsmm_dispatch_tilecfg_gemm(l_shape, l_cfg_flags);
   if (!sgemm) {
@@ -344,11 +373,11 @@ extern "C" int64_t xsmm_brgemm_dispatch(const libxsmm_datatype dtype, int64_t m,
   l_shape.a_in_type = dtype;
   l_shape.b_in_type = dtype;
   l_shape.out_type = dtype;
-  // Retarget computation type from bf16 to f32 due to missing hardware support.
-  l_shape.comp_type =
-      dtype == LIBXSMM_DATATYPE_BF16 ? LIBXSMM_DATATYPE_F32 : dtype;
+  // Retarget computation type from bf16/fp8 to f32 due to missing hardware
+  // support.
+  l_shape.comp_type = getCompDataType(dtype);
   l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_STRIDE;
-  auto typeSize = dtype == LIBXSMM_DATATYPE_F32 ? sizeof(float) : sizeof(bf16);
+  auto typeSize = getDataTypeSize(dtype);
   l_brconfig.br_stride_a_hint = stride_b * typeSize;
   l_brconfig.br_stride_b_hint = stride_a * typeSize;
   l_brconfig.br_unroll_hint = 0;
@@ -423,14 +452,13 @@ xsmm_fused_brgemm_dispatch(const libxsmm_datatype data_type, int64_t m,
   l_shape.a_in_type = data_type;
   l_shape.b_in_type = data_type;
   l_shape.out_type = data_type;
-  // Retarget computation type from bf16 to f32 due to missing hardware support.
-  l_shape.comp_type =
-      data_type == LIBXSMM_DATATYPE_BF16 ? LIBXSMM_DATATYPE_F32 : data_type;
+  // Retarget computation type from bf16/fp8 to f32 due to missing hardware
+  // support.
+  l_shape.comp_type = getCompDataType(data_type);
 
   libxsmm_gemm_batch_reduce_config l_brconfig;
   l_brconfig.br_type = LIBXSMM_GEMM_BATCH_REDUCE_STRIDE;
-  auto typeSize =
-      data_type == LIBXSMM_DATATYPE_F32 ? sizeof(float) : sizeof(bf16);
+  auto typeSize = getDataTypeSize(data_type);
   l_brconfig.br_stride_a_hint = stride_b * typeSize;
   l_brconfig.br_stride_b_hint = stride_a * typeSize;
   l_brconfig.br_unroll_hint = 0;
@@ -472,6 +500,17 @@ xsmm_intel_amx_tile_config_invoke(const libxsmm_datatype dType, int64_t addr,
 
   cfg_tr.tilecfg = reinterpret_cast<libxsmm_tilecfgfunction>(addr);
   cfg_tr.tilecfg(l_tilestate);
+}
+
+// FP8 -> F32 scalar converters. These are used to print/verify pure fp8 results
+// since the target has no native fp8 arithmetic. libxsmm names E5M2 as BF8 and
+// E4M3 as HF8. The 8-bit datum is passed as an i8 to match the MLIR ABI.
+extern "C" MLIR_RUNNERUTILS_EXPORT float xsmm_convert_bf8_to_f32(uint8_t in) {
+  return libxsmm_convert_bf8_to_f32(static_cast<libxsmm_bfloat8>(in));
+}
+
+extern "C" MLIR_RUNNERUTILS_EXPORT float xsmm_convert_hf8_to_f32(uint8_t in) {
+  return libxsmm_convert_hf8_to_f32(static_cast<libxsmm_hfloat8>(in));
 }
 
 static void printXsmmStruct(const libxsmm_gemm_shape &gemmShape,

--- a/runtime/Xsmm/XsmmRunnerUtils.h
+++ b/runtime/Xsmm/XsmmRunnerUtils.h
@@ -84,4 +84,10 @@ extern "C" MLIR_RUNNERUTILS_EXPORT void
 xsmm_intel_amx_tile_config_invoke(const libxsmm_datatype dType, int64_t addr,
                                   void *alignedPtrA, int64_t offset);
 
+// FP8 -> F32 scalar converters (E5M2 = BF8, E4M3 = HF8). The 8-bit datum is
+// passed as an i8 to match the MLIR ABI.
+extern "C" MLIR_RUNNERUTILS_EXPORT float xsmm_convert_bf8_to_f32(uint8_t in);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT float xsmm_convert_hf8_to_f32(uint8_t in);
+
 #endif // TPP_EXECUTIONENGINE_CRUNNERUTILS_H

--- a/test/Conversion/LinalgToXsmm/linalg-to-gemm-fp8.mlir
+++ b/test/Conversion/LinalgToXsmm/linalg-to-gemm-fp8.mlir
@@ -1,0 +1,62 @@
+// RUN: tpp-opt %s -convert-linalg-to-xsmm -split-input-file | FileCheck %s
+
+// FP8 uses a VNNI blocking factor of 4. libxsmm names E5M2 as BF8 and E4M3 as
+// HF8.
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3, d0)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+// Fix VNNI blocking factor for lit testing.
+// Prevent mismatches due to target specific VNNI factors.
+module attributes {
+  "#dlti.sys_spec" = #dlti.target_system_spec<"CPU"
+    = #dlti.target_device_spec<"vnni" = 4 : i32>>
+} {
+  func.func @square_vnni_gemm_e5m2(%arg0: memref<64x16x4xf8E5M2, strided<[64, 4, 1], offset: ?>>,
+    %arg1: memref<16x64x4xf8E5M2>, %arg2: memref<64x64xf8E5M2, strided<[64, 1], offset: ?>>) {
+    linalg.generic {
+      indexing_maps = [#map, #map1, #map2],
+      iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+      ins(%arg0, %arg1 : memref<64x16x4xf8E5M2, strided<[64, 4, 1], offset: ?>>, memref<16x64x4xf8E5M2>)
+      outs(%arg2 : memref<64x64xf8E5M2, strided<[64, 1], offset: ?>>) {
+        ^bb0(%in: f8E5M2, %in_2: f8E5M2, %out: f8E5M2):
+          %1 = arith.mulf %in, %in_2 : f8E5M2
+          %2 = arith.addf %out, %1 : f8E5M2
+          linalg.yield %2 : f8E5M2
+      }
+    return
+  }
+}
+
+// CHECK-LABEL: square_vnni_gemm_e5m2
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [64, 64, 64, 64, 64, 64] flags = (vnni_b) data_type = bf8
+// CHECK: xsmm.gemm(data_type = bf8, %[[DIS]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3, d0)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d3, d2, d0)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
+module attributes {
+  "#dlti.sys_spec" = #dlti.target_system_spec<"CPU"
+    = #dlti.target_device_spec<"vnni" = 4 : i32>>
+} {
+  func.func @square_vnni_gemm_e4m3(%arg0: memref<64x16x4xf8E4M3FN, strided<[64, 4, 1], offset: ?>>,
+    %arg1: memref<16x64x4xf8E4M3FN>, %arg2: memref<64x64xf8E4M3FN, strided<[64, 1], offset: ?>>) {
+    linalg.generic {
+      indexing_maps = [#map, #map1, #map2],
+      iterator_types = ["reduction", "parallel", "parallel", "reduction"]}
+      ins(%arg0, %arg1 : memref<64x16x4xf8E4M3FN, strided<[64, 4, 1], offset: ?>>, memref<16x64x4xf8E4M3FN>)
+      outs(%arg2 : memref<64x64xf8E4M3FN, strided<[64, 1], offset: ?>>) {
+        ^bb0(%in: f8E4M3FN, %in_2: f8E4M3FN, %out: f8E4M3FN):
+          %1 = arith.mulf %in, %in_2 : f8E4M3FN
+          %2 = arith.addf %out, %1 : f8E4M3FN
+          linalg.yield %2 : f8E4M3FN
+      }
+    return
+  }
+}
+
+// CHECK-LABEL: square_vnni_gemm_e4m3
+// CHECK: %[[DIS:.+]] = xsmm.gemm.dispatch [64, 64, 64, 64, 64, 64] flags = (vnni_b) data_type = hf8
+// CHECK: xsmm.gemm(data_type = hf8, %[[DIS]]

--- a/test/Dialect/Xsmm/xsmm-fp8.mlir
+++ b/test/Dialect/Xsmm/xsmm-fp8.mlir
@@ -1,0 +1,33 @@
+// RUN: tpp-opt %s | tpp-opt | FileCheck %s
+
+// FP8 support: libxsmm names E5M2 as BF8 and E4M3 as HF8. FP8 uses a VNNI
+// blocking factor of 4 (vnni_4 unary transform).
+
+// CHECK-LABEL: @xsmm_fp8_dialect
+func.func @xsmm_fp8_dialect(%arg0: memref<2x2xf8E5M2>, %arg1: memref<2x2xf8E5M2>,
+                            %arg2: memref<2x2xf8E5M2>, %arg3: memref<2x2xf8E4M3FN>,
+                            %arg4: memref<2x2xf8E4M3FN>, %arg5: memref<2x2xf8E4M3FN>) {
+  %d = arith.constant 0 : i64
+
+  // CHECK: xsmm.gemm(data_type = bf8
+  xsmm.gemm (data_type = bf8, %d, %arg0, %arg1, %arg2)
+    : (i64, memref<2x2xf8E5M2>, memref<2x2xf8E5M2>, memref<2x2xf8E5M2>) -> ()
+
+  // CHECK: xsmm.gemm(data_type = hf8
+  xsmm.gemm (data_type = hf8, %d, %arg3, %arg4, %arg5)
+    : (i64, memref<2x2xf8E4M3FN>, memref<2x2xf8E4M3FN>, memref<2x2xf8E4M3FN>) -> ()
+
+  // CHECK: xsmm.gemm.dispatch [2, 2, 2, 2, 2, 2] flags = (vnni_b) data_type = bf8
+  %0 = xsmm.gemm.dispatch [2, 2, 2, 2, 2, 2] flags = (vnni_b) data_type = bf8
+
+  // CHECK: xsmm.gemm.dispatch [2, 2, 2, 2, 2, 2] flags = (vnni_b) data_type = hf8
+  %1 = xsmm.gemm.dispatch [2, 2, 2, 2, 2, 2] flags = (vnni_b) data_type = hf8
+
+  // CHECK: xsmm.unary.dispatch vnni_4 [32, 32, 512, 32] flags = (none) data_type = bf8
+  %2 = xsmm.unary.dispatch vnni_4 [32, 32, 512, 32] flags = (none) data_type = bf8
+
+  // CHECK: xsmm.unary.dispatch vnni_4 [32, 32, 512, 32] flags = (none) data_type = hf8
+  %3 = xsmm.unary.dispatch vnni_4 [32, 32, 512, 32] flags = (none) data_type = hf8
+
+  return
+}

--- a/test/Dialect/Xsmm/xsmm-invalid.mlir
+++ b/test/Dialect/Xsmm/xsmm-invalid.mlir
@@ -273,7 +273,7 @@ func.func @gemm_invoke(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>, %arg2: me
 
 func.func @gemm_invoke(%arg0: f32, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32>,
                        %arg3: memref<3x3xf32>) {
-  // expected-error@+1 {{op operand #0 must be variadic of 2D/3D static memref of 32-bit float or bfloat16 type values or 64-bit signless integer, but got 'f32'}}
+  // expected-error@+1 {{op operand #0 must be variadic of 2D/3D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 64-bit signless integer, but got 'f32'}}
   xsmm.gemm(data_type = f32, %arg0, %arg1, %arg2, %arg3)
     : (f32, memref<3x3xf32>, memref<3x3xf32>, memref<3x3xf32>) -> ()
   return
@@ -283,7 +283,7 @@ func.func @gemm_invoke(%arg0: f32, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf32
 
 func.func @gemm_invoke(%arg0: i64, %arg1: memref<1x1x3x3xf32>, %arg2: memref<3x3xf32>,
                        %arg3: memref<3x3xf32>) {
-  // expected-error@+1 {{op operand #1 must be variadic of 2D/3D static memref of 32-bit float or bfloat16 type values or 64-bit signless integer, but got 'memref<1x1x3x3xf32>'}}
+  // expected-error@+1 {{op operand #1 must be variadic of 2D/3D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 64-bit signless integer, but got 'memref<1x1x3x3xf32>'}}
   xsmm.gemm(data_type = f32, %arg0, %arg1, %arg2, %arg3)
     : (i64, memref<1x1x3x3xf32>, memref<3x3xf32>, memref<3x3xf32>) -> ()
   return
@@ -321,7 +321,7 @@ func.func @brgemm_invoke(%arg0: i64, %arg1: memref<3x3xf32>, %arg2: memref<3x3xf
 
 func.func @brgemm_invoke(%arg0: i64, %arg1: memref<3x3xf32>, %arg2: memref<2x3x3xf32>,
                          %arg3: memref<3x3xf32>, %arg4: memref<2xf32>) {
-  // expected-error@+1 {{operand #4 must be variadic of 2D/3D/4D static memref of 32-bit float or bfloat16 type values or 64-bit signless integer, but got 'memref<2xf32>'}}
+  // expected-error@+1 {{operand #4 must be variadic of 2D/3D/4D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 64-bit signless integer, but got 'memref<2xf32>'}}
   xsmm.brgemm(data_type = f32, %arg0, %arg1, %arg2, %arg3, %arg4)
     : (i64, memref<3x3xf32>, memref<2x3x3xf32>, memref<3x3xf32>, memref<2xf32>) -> ()
   return
@@ -339,7 +339,7 @@ func.func @brgemm_invoke(%arg0: i64, %arg1: memref<2x3x3xf32>, %arg2: memref<2x3
 // -----
 
 func.func @gemm_invoke(%arg0: i64, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32>) {
-  // expected-error@+1 {{operand #1 must be variadic of 2D/3D static memref of 32-bit float or bfloat16 type values or 64-bit signless integer, but got 'memref<?x?xf32>'}}
+  // expected-error@+1 {{operand #1 must be variadic of 2D/3D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 64-bit signless integer, but got 'memref<?x?xf32>'}}
   xsmm.gemm(data_type = f32, %arg0, %arg1, %arg2, %arg2)
     : (i64, memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
   return
@@ -348,7 +348,7 @@ func.func @gemm_invoke(%arg0: i64, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32
 // -----
 
 func.func @gemm_invoke(%arg0: i64, %arg1: memref<?x?x?xf32>, %arg2: memref<?x?x?xf32>, %arg3: memref<?x?xf32>) {
-  // expected-error@+1 {{operand #1 must be variadic of 2D/3D/4D static memref of 32-bit float or bfloat16 type values or 64-bit signless integer, but got 'memref<?x?x?xf32>'}}
+  // expected-error@+1 {{operand #1 must be variadic of 2D/3D/4D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 64-bit signless integer, but got 'memref<?x?x?xf32>'}}
   xsmm.brgemm(data_type = f32, %arg0, %arg1, %arg2, %arg3, %arg0)
     : (i64, memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?xf32>, i64) -> ()
   return
@@ -357,7 +357,7 @@ func.func @gemm_invoke(%arg0: i64, %arg1: memref<?x?x?xf32>, %arg2: memref<?x?x?
 // -----
 
 func.func @unary_invoke(%arg0: memref<?x?xf32>, %arg1: memref<3x3xf32>, %disp: i64) {
-  // expected-error@+1 {{operand #1 must be variadic of 1D/2D/3D/4D static memref of 32-bit float or bfloat16 type values or 32-bit float or bfloat16 type or 64-bit signless integer, but got 'memref<?x?xf32>'}}
+  // expected-error@+1 {{operand #1 must be variadic of 1D/2D/3D/4D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type or 64-bit signless integer, but got 'memref<?x?xf32>'}}
   xsmm.unary relu(data_type = f32, %disp, %arg0, %arg1) : (i64, memref<?x?xf32>, memref<3x3xf32>) -> ()
   return
 }
@@ -365,7 +365,7 @@ func.func @unary_invoke(%arg0: memref<?x?xf32>, %arg1: memref<3x3xf32>, %disp: i
 // -----
 
 func.func @unary_invoke(%arg0: memref<?x?xf32>, %arg1: memref<3x3xf32>, %disp: i64) {
-  // expected-error@+1 {{operand #1 must be variadic of 1D/2D/3D/4D static memref of 32-bit float or bfloat16 type values or 32-bit float or bfloat16 type or 64-bit signless integer, but got 'memref<?x?xf32>'}}
+  // expected-error@+1 {{operand #1 must be variadic of 1D/2D/3D/4D static memref of 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type values or 32-bit float or bfloat16 type or f8E5M2 type or f8E4M3FN type or 64-bit signless integer, but got 'memref<?x?xf32>'}}
   xsmm.binary add(data_type = f32, %disp, %arg0, %arg0, %arg1)
     : (i64, memref<?x?xf32>, memref<?x?xf32>, memref<3x3xf32>) -> ()
   return

--- a/test/Integration/FP8/lit.local.cfg
+++ b/test/Integration/FP8/lit.local.cfg
@@ -36,7 +36,7 @@ def is_arch(target):
     return target in out
 
 
-# AVX512 and SVE should have BF16 support
+# in pre AVX2 and SVE targets we skip the tests since they are not supported
 if not has_support('avx512') and not has_support('avx2') and not has_support('sve'):
     config.unsupported = True
 

--- a/test/Integration/FP8/lit.local.cfg
+++ b/test/Integration/FP8/lit.local.cfg
@@ -1,0 +1,47 @@
+import subprocess
+
+def has_support(feature):
+    # uArch detection not working on Windows
+    if sys.platform in ['win32']:
+        return False
+
+    try:
+        cmd = subprocess.Popen(
+            ['grep', feature, '/proc/cpuinfo'], stdout=subprocess.PIPE)
+    except OSError:
+        return False
+
+    out = cmd.stdout.read().decode('ascii')
+    cmd.wait()
+
+    if out == "":
+        return False
+
+    return True
+
+def is_arch(target):
+    # Arch detection not working on Windows
+    if sys.platform in ['win32']:
+        return False
+
+    try:
+        cmd = subprocess.Popen(
+            ['uname', '-m'], stdout=subprocess.PIPE)
+    except OSError:
+        return False
+
+    out = cmd.stdout.read().decode('ascii')
+    cmd.wait()
+
+    return target in out
+
+
+# AVX512 and SVE should have BF16 support
+if not has_support('avx512') and not has_support('avx2') and not has_support('sve'):
+    config.unsupported = True
+
+# Enable only on x86
+# Other targets may use different VNNI blocking scheme that is not compatible with
+# prepacked shapes in some of the tests
+if not is_arch('x86'):
+    config.unsupported = True

--- a/test/Integration/FP8/mlir-gen-fp8.mlir
+++ b/test/Integration/FP8/mlir-gen-fp8.mlir
@@ -1,0 +1,17 @@
+// FP8 code generation and execution. libxsmm names E5M2 as BF8 and E4M3 as HF8.
+// FP8 uses a VNNI blocking factor of 4.
+
+// Kernel - matmul. Inputs are auto-initialized to 1.0 and the reduction size is
+// 16, so every output element is 16 (accumulation happens in F32).
+// RUN: mlir-gen --kernel=args --seed=123 --data-type=bf8 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-FP8
+// RUN: mlir-gen --kernel=args --seed=123 --data-type=hf8 --batch=16 --layers=16,16 | tpp-run -e entry -entry-point-result=void -print | FileCheck %s --check-prefix=GEN-MATMUL-FP8
+
+// FP8/VNNI execution
+// RUN: mlir-gen --kernel=const --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=bf8 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=hf8 | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=bf8 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+// RUN: mlir-gen --kernel=const --seed=123 --batch=16 --layers=16,16 --tiles=8,8,8 --data-type=hf8 | tpp-opt --pack-vnni | tpp-run -e entry -entry-point-result=void -n 10 | FileCheck %s --check-prefix=PERF
+
+// GEN-MATMUL-FP8: ( 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16 )
+
+// PERF: {{[0-9]+}}{{.?}}{{[0-9e-]+}}

--- a/test/Integration/FP8/xsmm-gemm-bf8.mlir
+++ b/test/Integration/FP8/xsmm-gemm-bf8.mlir
@@ -1,0 +1,21 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// FP8 GEMM with a VNNI blocking factor of 4. libxsmm names E5M2 as BF8.
+// Weights are in VNNI4 layout: [K/4][N][4]. K = 4, N = 6.
+// Inputs and the accumulator are auto-initialized to 1.0, so each output
+// element is: sum_{k=0..3}(1 * 1) + 1 = 5.
+
+memref.global "private" constant @wt : memref<1x6x4xf8E5M2> = dense<1.0> {alignment = 64 : i64}
+
+func.func @entry(%arg0: memref<6x4xf8E5M2>, %arg1: memref<6x6xf8E5M2>) -> memref<6x6xf8E5M2> {
+  %0 = memref.get_global @wt : memref<1x6x4xf8E5M2>
+  %1 = xsmm.gemm.dispatch [6, 6, 4, 4, 6, 6] flags = (vnni_b) data_type = bf8
+  xsmm.gemm(data_type = bf8, %1, %arg0, %0, %arg1)
+    : (i64, memref<6x4xf8E5M2>, memref<1x6x4xf8E5M2>, memref<6x6xf8E5M2>) -> ()
+
+  return %arg1: memref<6x6xf8E5M2>
+}
+
+// CHECK-COUNT-6: ( 5, 5, 5, 5, 5, 5 )

--- a/test/Integration/FP8/xsmm-gemm-hf8.mlir
+++ b/test/Integration/FP8/xsmm-gemm-hf8.mlir
@@ -1,0 +1,21 @@
+// RUN: tpp-run %s -print \
+// RUN:  -e entry -entry-point-result=void | \
+// RUN: FileCheck %s
+
+// FP8 GEMM with a VNNI blocking factor of 4. libxsmm names E4M3 as HF8.
+// Weights are in VNNI4 layout: [K/4][N][4]. K = 4, N = 6.
+// Inputs and the accumulator are auto-initialized to 1.0, so each output
+// element is: sum_{k=0..3}(1 * 1) + 1 = 5.
+
+memref.global "private" constant @wt : memref<1x6x4xf8E4M3FN> = dense<1.0> {alignment = 64 : i64}
+
+func.func @entry(%arg0: memref<6x4xf8E4M3FN>, %arg1: memref<6x6xf8E4M3FN>) -> memref<6x6xf8E4M3FN> {
+  %0 = memref.get_global @wt : memref<1x6x4xf8E4M3FN>
+  %1 = xsmm.gemm.dispatch [6, 6, 4, 4, 6, 6] flags = (vnni_b) data_type = hf8
+  xsmm.gemm(data_type = hf8, %1, %arg0, %0, %arg1)
+    : (i64, memref<6x4xf8E4M3FN>, memref<1x6x4xf8E4M3FN>, memref<6x6xf8E4M3FN>) -> ()
+
+  return %arg1: memref<6x6xf8E4M3FN>
+}
+
+// CHECK-COUNT-6: ( 5, 5, 5, 5, 5, 5 )

--- a/tools/mlir-gen/MLIRGen.cpp
+++ b/tools/mlir-gen/MLIRGen.cpp
@@ -175,6 +175,11 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
                                               builder.getF16Type()})
           .CaseLower("bf16", SmallVector<Type>{builder.getBF16Type(),
                                                builder.getBF16Type()})
+          // FP8 pure types. E5M2 is named bf8 and E4M3 is named hf8 by libxsmm.
+          .CaseLower("bf8", SmallVector<Type>{builder.getF8E5M2Type(),
+                                              builder.getF8E5M2Type()})
+          .CaseLower("hf8", SmallVector<Type>{builder.getF8E4M3FNType(),
+                                              builder.getF8E4M3FNType()})
           .CaseLower("mx-bf16", SmallVector<Type>{builder.getBF16Type(),
                                                   builder.getF32Type()})
           .CaseLower("mx-f16", SmallVector<Type>{builder.getF16Type(),
@@ -226,9 +231,10 @@ MLIRGenerator::MLIRGenerator(StringRef outputOpKindStr, StringRef kernelStr,
   if (quantType != QuantizationType::None)
     outputOpKind = OutputOpKind::Contract;
 
-  // Disable VNNI packing if it is not a F16/BF16/I8 data type
+  // Disable VNNI packing if it is not a F16/BF16/I8/FP8 data type
   if (!dataTypes[0].isBF16() && !dataTypes[0].isF16() &&
-      !dataTypes[0].isInteger(8))
+      !dataTypes[0].isInteger(8) &&
+      !llvm::isa<Float8E5M2Type, Float8E4M3FNType>(dataTypes[0]))
     vnniFactor = 0;
   assert(((vnniFactor >= 0) && (vnniFactor % 2 == 0)) &&
          "Invalid VNNI packing factor");

--- a/tools/mlir-gen/mlir-gen.cpp
+++ b/tools/mlir-gen/mlir-gen.cpp
@@ -68,7 +68,7 @@ llvm::cl::opt<std::string>
 llvm::cl::opt<std::string>
     dataType("data-type", llvm::cl::desc("Data type for arguments"),
               llvm::cl::value_desc(
-                  "f32|f16|bf16|mx-bf16|mx-f16|mx-i8|mx-i8-f32|mx-f32-i8"),
+                  "f32|f16|bf16|bf8|hf8|mx-bf16|mx-f16|mx-i8|mx-i8-f32|mx-f32-i8"),
               llvm::cl::init("f32"));
 
 // Scale type flag to chose data type of scaling factor.For now it is kind of a


### PR DESCRIPTION
## What changed

**Dialect & core (types + VNNI-4):**
- XsmmEnum.td — added `BF8`=4, `HF8`=5 datatypes and the `VNNI4`=54 unary transform (matching libxsmm's enum values).
- XsmmOps.td — added `F8E5M2`/`F8E4M3FN` to the `XsmmMemRef`/`GemmMemRef`/`BrgemmMemRef` type constraints.
- XsmmUtils.cpp — `getDataType` maps E5M2→`bf8`, E4M3FN→`hf8`.
- XsmmOps.cpp — verifiers accept fp8 (operand-type check + VNNI-flag check).
- VNNIUtils.cpp — `getVnniBlockingFactor` returns the libxsmm pack factor (4) for fp8; `isInVnniLayout` accepts fp8.
- ConvertLinalgToXsmm.cpp — VNNI packing emits `vnni_2` vs `vnni_4` by factor.
- ToBlockLayoutAndBack.cpp — `-pack-vnni` accepts fp8.

**Tools & runtime:**
- mlir-gen — `--data-type=bf8|hf8` (pure fp8), VNNI enabled for fp8.
- XsmmRunnerUtils.cpp — fp8 pointers, f32 compute retargeting, 1-byte sizing; plus `xsmm_convert_bf8_to_f32`/`xsmm_convert_hf8_to_f32` wrappers around libxsmm's converters.
- MLIRBench.cpp — prints pure-fp8 results by converting per-lane via those libxsmm converters.
- TensorInitFloat — E5M2/E4M3 init.
- DefaultPipeline.cpp — added `arith-emulate-unsupported-floats` for fp8.

**Tests & benchmarks:** conversion + dialect FileCheck tests, FP8 execution tests (bf8/hf8 GEMM + mlir-gen), and fp8.json.

## One caveat worth flagging
The `linalg-to-xsmm` path works end-to-end (compute **and** numeric print, via libxsmm). The pure `linalg-to-loops` path for fp8 does **not** execute on CPU because upstream MLIR/LLVM has no lowering for E5M2/E4M3 `arith.extf`/`truncf` (they map f8→i8 and there's no software-conversion expansion like there is for bf16/f8E8M0). The emulate-floats pass is wired in so it will work automatically once that upstream gap is filled. All XSMM-path functionality is fully working and tested.