### PR TITLE
[nano-kernels] Update test for nano-kernels pipeline

### DIFF
--- a/lib/TPP/Transforms/VectorContractToNanoKernels.cpp
+++ b/lib/TPP/Transforms/VectorContractToNanoKernels.cpp
@@ -40,6 +40,7 @@ struct VectorContractToNanoKernels
     if (cpuName == "SRF") {
        x86::populateVectorContractBF16ToFMAPatterns(patterns);
        x86::populateShuffleVectorFMAOpsPatterns(patterns);
+       x86::populateVectorContractToPackedTypeDotProductPatterns(patterns);
     }
 
     if (cpuName == "CPX_SPR")

--- a/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
+++ b/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
@@ -1,3 +1,31 @@
+// RUN: tpp-run -e gemm64 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e gemm64 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: fpcmp -r 0.001 %t.1 %t.2
+
+func.func @gemm64(
+    %arg0: tensor<4x64x64xbf16>,
+    %arg1: tensor<4x64x64xbf16>,
+    %arg2: tensor<64x64xbf16>
+) -> tensor<64x64xbf16> {
+  %result = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>,
+        affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>,
+        affine_map<(d0, d2, d3, d4) -> (d2, d3)>
+      ],
+      iterator_types = ["reduction", "parallel", "parallel", "reduction"]
+    }
+    ins(%arg0, %arg1 : tensor<4x64x64xbf16>, tensor<4x64x64xbf16>)
+    outs(%arg2 : tensor<64x64xbf16>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+    %mul = arith.mulf %in, %in_1 : bf16
+    %add = arith.addf %out, %mul : bf16
+    linalg.yield %add : bf16
+  } -> tensor<64x64xbf16>
+
+  return %result : tensor<64x64xbf16>
+}
+
 // RUN: tpp-run -e gemm128 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
 // RUN: tpp-run -e gemm128 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
@@ -24,4 +52,35 @@ func.func @gemm128(
   } -> tensor<128x128xbf16>
 
   return %result : tensor<128x128xbf16>
+}
+
+// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
+func.func @mlp64(%arg0: tensor<8x2x64x64xbf16>, %arg1: tensor<2x2x64x64xbf16>, %arg2: tensor<2x64xbf16>, %arg3: tensor<8x2x64x64xbf16>) -> tensor<8x2x64x64xbf16> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x2x64x64xbf16>, tensor<2x2x64x64xbf16>) outs(%arg3 : tensor<8x2x64x64xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %3 = arith.mulf %in, %in_0 : bf16
+    %4 = arith.addf %out, %3 : bf16
+    linalg.yield %4 : bf16
+  } -> tensor<8x2x64x64xbf16>
+  %1 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2 : tensor<2x64xbf16>) outs(%0 : tensor<8x2x64x64xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %3 = arith.addf %in, %out : bf16
+    linalg.yield %3 : bf16
+  } -> tensor<8x2x64x64xbf16>
+  %cst = arith.constant 0.000000e+00 : bf16
+  %2 = linalg.generic {indexing_maps = [#map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%1 : tensor<8x2x64x64xbf16>) {
+  ^bb0(%out: bf16):
+    %3 = arith.maximumf %out, %cst : bf16
+    linalg.yield %3 : bf16
+  } -> tensor<8x2x64x64xbf16>
+  return %2 : tensor<8x2x64x64xbf16>
 }

--- a/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
+++ b/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
@@ -53,34 +53,3 @@ func.func @gemm128(
 
   return %result : tensor<128x128xbf16>
 }
-
-// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
-// RUN: fpcmp -r 0.01 %t.1 %t.2
-
-#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
-#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
-#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
-#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
-#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-
-func.func @mlp64(%arg0: tensor<8x2x64x64xbf16>, %arg1: tensor<2x2x64x64xbf16>, %arg2: tensor<2x64xbf16>, %arg3: tensor<8x2x64x64xbf16>) -> tensor<8x2x64x64xbf16> {
-  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x2x64x64xbf16>, tensor<2x2x64x64xbf16>) outs(%arg3 : tensor<8x2x64x64xbf16>) {
-  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
-    %3 = arith.mulf %in, %in_0 : bf16
-    %4 = arith.addf %out, %3 : bf16
-    linalg.yield %4 : bf16
-  } -> tensor<8x2x64x64xbf16>
-  %1 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2 : tensor<2x64xbf16>) outs(%0 : tensor<8x2x64x64xbf16>) {
-  ^bb0(%in: bf16, %out: bf16):
-    %3 = arith.addf %in, %out : bf16
-    linalg.yield %3 : bf16
-  } -> tensor<8x2x64x64xbf16>
-  %cst = arith.constant 0.000000e+00 : bf16
-  %2 = linalg.generic {indexing_maps = [#map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%1 : tensor<8x2x64x64xbf16>) {
-  ^bb0(%out: bf16):
-    %3 = arith.maximumf %out, %cst : bf16
-    linalg.yield %3 : bf16
-  } -> tensor<8x2x64x64xbf16>
-  return %2 : tensor<8x2x64x64xbf16>
-}

--- a/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
+++ b/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
@@ -1,36 +1,62 @@
 // RUN: tpp-run -e gemm32 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e gemm32 --entry-point-result=void --disable-vnni-packing --vector-to-kernels --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: tpp-run -e gemm32 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
-func.func @gemm32(%arg0: memref<4x32x32xbf16>, %arg1: memref<4x32x32xbf16>, %arg2: memref<32x32xbf16>) -> memref<32x32xbf16> {
-    linalg.generic {indexing_maps = [affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>, affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>, affine_map<(d0, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : memref<4x32x32xbf16>, memref<4x32x32xbf16>) outs(%arg2 : memref<32x32xbf16>) {
-    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-      %1 = arith.mulf %in, %in_1 : bf16
-      %2 = arith.addf %out, %1 : bf16
-      linalg.yield %2 : bf16
+func.func @gemm32(
+    %arg0: tensor<4x32x32xbf16>,
+    %arg1: tensor<4x32x32xbf16>,
+    %arg2: tensor<32x32xbf16>
+) -> tensor<32x32xbf16> {
+  %result = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>,
+        affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>,
+        affine_map<(d0, d2, d3, d4) -> (d2, d3)>
+      ],
+      iterator_types = ["reduction", "parallel", "parallel", "reduction"]
     }
-  return %arg2 : memref<32x32xbf16>
+    ins(%arg0, %arg1 : tensor<4x32x32xbf16>, tensor<4x32x32xbf16>)
+    outs(%arg2 : tensor<32x32xbf16>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+    %mul = arith.mulf %in, %in_1 : bf16
+    %add = arith.addf %out, %mul : bf16
+    linalg.yield %add : bf16
+  } -> tensor<32x32xbf16>
+
+  return %result : tensor<32x32xbf16>
 }
 
-// RUN: tpp-run -e gemm96 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e gemm96 --entry-point-result=void --disable-vnni-packing --vector-to-kernels --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: tpp-run -e gemm128 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e gemm128 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
-func.func @gemm96(%arg0: memref<4x96x96xbf16>, %arg1: memref<4x96x96xbf16>, %arg2: memref<96x96xbf16>) -> memref<96x96xbf16> {
-    linalg.generic {indexing_maps = [affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>, affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>, affine_map<(d0, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : memref<4x96x96xbf16>, memref<4x96x96xbf16>) outs(%arg2 : memref<96x96xbf16>) {
-    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-      %1 = arith.mulf %in, %in_1 : bf16
-      %2 = arith.addf %out, %1 : bf16
-      linalg.yield %2 : bf16
+func.func @gemm128(
+    %arg0: tensor<4x128x128xbf16>,
+    %arg1: tensor<4x128x128xbf16>,
+    %arg2: tensor<128x128xbf16>
+) -> tensor<128x128xbf16> {
+  %result = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>,
+        affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>,
+        affine_map<(d0, d2, d3, d4) -> (d2, d3)>
+      ],
+      iterator_types = ["reduction", "parallel", "parallel", "reduction"]
     }
-  return %arg2 : memref<96x96xbf16>
+    ins(%arg0, %arg1 : tensor<4x128x128xbf16>, tensor<4x128x128xbf16>)
+    outs(%arg2 : tensor<128x128xbf16>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+    %mul = arith.mulf %in, %in_1 : bf16
+    %add = arith.addf %out, %mul : bf16
+    linalg.yield %add : bf16
+  } -> tensor<128x128xbf16>
+
+  return %result : tensor<128x128xbf16>
 }
 
 // RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing --vector-to-kernels --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
-// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing --vector-to-kernels --registerBlocking=32,64,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.3
-// RUN: fpcmp -r 0.001 %t.1 %t.2
-// RUN: fpcmp -r 0.001 %t.1 %t.3
+// RUN: tpp-run -e mlp64 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>

--- a/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
+++ b/test/Integration/BF16/AMX/vector-contract-to-amx-flat.mlir
@@ -1,31 +1,3 @@
-// RUN: tpp-run -e gemm32 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e gemm32 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
-// RUN: fpcmp -r 0.001 %t.1 %t.2
-
-func.func @gemm32(
-    %arg0: tensor<4x32x32xbf16>,
-    %arg1: tensor<4x32x32xbf16>,
-    %arg2: tensor<32x32xbf16>
-) -> tensor<32x32xbf16> {
-  %result = linalg.generic {
-      indexing_maps = [
-        affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>,
-        affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>,
-        affine_map<(d0, d2, d3, d4) -> (d2, d3)>
-      ],
-      iterator_types = ["reduction", "parallel", "parallel", "reduction"]
-    }
-    ins(%arg0, %arg1 : tensor<4x32x32xbf16>, tensor<4x32x32xbf16>)
-    outs(%arg2 : tensor<32x32xbf16>) {
-  ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-    %mul = arith.mulf %in, %in_1 : bf16
-    %add = arith.addf %out, %mul : bf16
-    linalg.yield %add : bf16
-  } -> tensor<32x32xbf16>
-
-  return %result : tensor<32x32xbf16>
-}
-
 // RUN: tpp-run -e gemm128 --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
 // RUN: tpp-run -e gemm128 --entry-point-result=void --disable-vnni-packing --nano-kernels --gemm-unroll=16,16,32 --registerBlocking=32,32,32 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2

--- a/test/Integration/BF16/AVX2/vector-contract-to-fma-avx2.mlir
+++ b/test/Integration/BF16/AVX2/vector-contract-to-fma-avx2.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-run -e gemm_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e gemm_splat --entry-point-result=void -print --disable-vnni-packing --vector-to-kernels --registerBlocking=4,16,1  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: tpp-run -e gemm_splat --entry-point-result=void -print --disable-vnni-packing --nano-kernels --gemm-unroll=1,8,1 --registerBlocking=4,16,1  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 
 func.func @gemm_splat(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>, %arg2: tensor<8x32x32x32xbf16>) -> tensor<8x32x32x32xbf16> {
@@ -15,7 +15,7 @@ func.func @gemm_splat(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32x
 // -----
 
 // RUN: tpp-run -e mlp_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e mlp_splat --entry-point-result=void -print --disable-vnni-packing --vector-to-kernels --registerBlocking=4,16,1  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: tpp-run -e mlp_splat --entry-point-result=void -print --disable-vnni-packing --nano-kernels --gemm-unroll=1,8,1 --registerBlocking=4,16,1  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>

--- a/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16-splat.mlir
+++ b/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16-splat.mlir
@@ -1,0 +1,47 @@
+// RUN: tpp-run -e gemm_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e gemm_splat --entry-point-result=void -print --disable-vnni-packing --nano-kernels --gemm-unroll=1,16,2 --registerBlocking=8,32,2  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+#map_sp = affine_map<(d0,  d2, d3, d4) -> (d0, d2, d4)>
+#map1_sp = affine_map<(d0,  d2, d3, d4) -> (d0, d4, d3)>
+#map2_sp = affine_map<(d0,  d2, d3, d4) -> (d2, d3)>
+
+func.func @gemm_splat(%arg0: tensor<16x128x128xbf16>, %arg1: tensor<16x128x128xbf16>, %arg2: tensor<128x128xbf16>) -> tensor<128x128xbf16> {
+  %0 = linalg.generic {indexing_maps = [#map_sp, #map1_sp, #map2_sp], iterator_types = ["reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<16x128x128xbf16>, tensor<16x128x128xbf16>) outs(%arg2 : tensor<128x128xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %1 = arith.mulf %in, %in_0 : bf16
+    %2 = arith.addf %out, %1 : bf16
+    linalg.yield %2 : bf16
+  } -> tensor<128x128xbf16>
+  return %0 : tensor<128x128xbf16>
+}
+
+// RUN: tpp-run -e mlp_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e mlp_splat --entry-point-result=void -print --disable-vnni-packing --nano-kernels --gemm-unroll=1,16,2 --registerBlocking=8,32,2  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+#mlp_map = affine_map<(d0, d2, d3, d4) -> (d0, d2, d4)>
+#mlp_map1 = affine_map<(d0, d2, d3, d4) -> (d0, d4, d3)>
+#mlp_map2 = affine_map<(d0, d2, d3, d4) -> (d2, d3)>
+#mlp_map3 = affine_map<(d1, d2) -> (d1, d2)>
+func.func @mlp_splat(%arg0: tensor<4x128x128xbf16>, %arg1: tensor<4x128x128xbf16>, %arg2: tensor<128x128xbf16>, %arg3: tensor<128x128xbf16>) -> tensor<128x128xbf16>  {
+  %0 = linalg.generic {indexing_maps = [#mlp_map, #mlp_map1, #mlp_map2], iterator_types = ["reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x128x128xbf16>, tensor<4x128x128xbf16>) outs(%arg2 : tensor<128x128xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %1 = arith.mulf %in, %in_0 : bf16
+    %2 = arith.addf %out, %1 : bf16
+    linalg.yield %2 : bf16
+  } -> tensor<128x128xbf16>
+
+  %1 = linalg.generic {indexing_maps = [#mlp_map3, #mlp_map3], iterator_types = ["parallel", "parallel"]} ins(%arg3 : tensor<128x128xbf16>) outs(%0 : tensor<128x128xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %3 = arith.addf %in, %out : bf16
+    linalg.yield %3 : bf16
+  } -> tensor<128x128xbf16>
+
+ %cst = arith.constant 0.000000e+00 : bf16
+  %2 = linalg.generic {indexing_maps = [#mlp_map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<128x128xbf16>) {
+  ^bb0(%out: bf16):
+    %3 = arith.maximumf %out, %cst : bf16
+    linalg.yield %3 : bf16
+  } -> tensor<128x128xbf16>
+
+  return %2 : tensor<128x128xbf16>
+}

--- a/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16.mlir
+++ b/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16.mlir
@@ -46,3 +46,48 @@ func.func @mlp(%arg0: tensor<16x128x64x2xbf16>, %arg1: tensor<16x64x128x2xbf16>,
 
     return %2 : tensor<128x128xbf16>
 }
+
+// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --nano-kernels --gemm-unroll=1,16,1 --registerBlocking=6,64,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --nano-kernels --gemm-unroll=1,16,1 --registerBlocking=3,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.3
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.3
+func.func @optimal_register_blocking(
+    %arg0: tensor<2x24x16x2xbf16>) -> tensor<24x128xbf16> {
+  %weights = arith.constant
+      dense<1.000000e+00> : tensor<2x16x128x2xbf16>
+  %empty = tensor.empty() : tensor<24x128xbf16>
+  %zero = arith.constant 0.000000e+00 : bf16
+
+  %init = linalg.fill
+      ins(%zero : bf16)
+      outs(%empty : tensor<24x128xbf16>)
+      -> tensor<24x128xbf16>
+
+  %result = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>,
+        affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>,
+        affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+      ],
+      iterator_types = [
+        "reduction",
+        "reduction",
+        "parallel",
+        "parallel",
+        "reduction"
+      ]
+    }
+    ins(%arg0, %weights
+        : tensor<2x24x16x2xbf16>,
+          tensor<2x16x128x2xbf16>)
+    outs(%init : tensor<24x128xbf16>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
+    %mul = arith.mulf %in, %in_1 : bf16
+    %sum = arith.addf %out, %mul : bf16
+    linalg.yield %sum : bf16
+  } -> tensor<24x128xbf16>
+
+  return %result : tensor<24x128xbf16>
+}
+

--- a/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16.mlir
+++ b/test/Integration/BF16/uKernels/vector-contract-to-ukernels-bf16.mlir
@@ -1,141 +1,48 @@
-// RUN: tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run  -e gemm_bf16_dp_random_AB --entry-point-result=void --vector-to-kernels --registerBlocking=8,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s > %t.2
-// RUN: fpcmp -r 0.001 %t.1 %t.2
-
-memref.global "private" constant @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-func.func @gemm_bf16_dp_random_AB(%arg0: memref<8x2x32x32xbf16>) -> memref<8x2x32x32xbf16> {
-  %cst = arith.constant 0.000000e+00 : bf16
-  %0 = memref.get_global @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x2x32x32xbf16>
-  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 2, 32, 16, 2] : memref<8x2x32x32xbf16> into memref<8x2x32x16x2xbf16>
-  scf.forall (%arg1, %arg2) in (8, 2) {
-    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x2x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
-    linalg.fill ins(%cst : bf16) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
-    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 2, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x2x32x16x2xbf16> to memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %0 : memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<2x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
-    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-      %1 = arith.mulf %in, %in_1 : bf16
-      %2 = arith.addf %out, %1 : bf16
-      linalg.yield %2 : bf16
-    }
-  }
-  return %alloc : memref<8x2x32x32xbf16>
-}
-
-
-// RUN: tpp-run -e gemm_bf16_args --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e gemm_bf16_args --entry-point-result=void  --vector-to-kernels --registerBlocking=8,32,2 -print  --splat-to-random --init-type normal  -seed 123  %s > %t.2
+// RUN: tpp-run -e gemm --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e gemm --entry-point-result=void -print --nano-kernels --gemm-unroll=1,16,1 --registerBlocking=8,32,2  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
 // RUN: fpcmp -r 0.01 %t.1 %t.2
+#map = affine_map<(d0,  d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#map1 = affine_map<(d0,  d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#map2 = affine_map<(d0,  d1, d2, d3, d4) -> (d2, d3)>
 
-func.func @gemm_bf16_args(%arg0: memref<4x2x64x64xbf16>, %arg1: memref<2x2x32x64x2xbf16>, %arg2: memref<4x2x64x64xbf16>) -> memref<4x2x64x64xbf16> {
-  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [4, 2, 64, 32, 2] : memref<4x2x64x64xbf16> into memref<4x2x64x32x2xbf16>
-  scf.forall (%arg3, %arg4) in (4, 2) {
-    %subview = memref.subview %expand_shape[%arg3, 0, 0, 0, 0] [1, 2, 64, 32, 2] [1, 1, 1, 1, 1] : memref<4x2x64x32x2xbf16> to memref<2x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>
-    %subview_0 = memref.subview %arg1[%arg4, 0, 0, 0, 0] [1, 2, 32, 64, 2] [1, 1, 1, 1, 1] : memref<2x2x32x64x2xbf16> to memref<2x32x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>
-    %subview_1 = memref.subview %arg2[%arg3, %arg4, 0, 0] [1, 1, 64, 64] [1, 1, 1, 1] : memref<4x2x64x64xbf16> to memref<64x64xbf16, strided<[64, 1], offset: ?>>
-    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview, %subview_0 : memref<2x64x32x2xbf16, strided<[4096, 64, 2, 1], offset: ?>>, memref<2x32x64x2xbf16, strided<[4096, 128, 2, 1], offset: ?>>) outs(%subview_1 : memref<64x64xbf16, strided<[64, 1], offset: ?>>) {
-    ^bb0(%in: bf16, %in_2: bf16, %out: bf16):
-      %0 = arith.mulf %in, %in_2 : bf16
-      %1 = arith.addf %out, %0 : bf16
-      linalg.yield %1 : bf16
-    }
-  }
-  %alloc = memref.alloc() : memref<4x2x64x64xbf16>
-  memref.copy %arg2, %alloc : memref<4x2x64x64xbf16> to memref<4x2x64x64xbf16>
-  return %alloc : memref<4x2x64x64xbf16>
-}
-
-
-// RUN: tpp-run -e mlp_bf16 --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e  mlp_bf16 --entry-point-result=void --vector-to-kernels --registerBlocking=4,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
-// RUN: fpcmp -r 0.01 %t.1 %t.2
-
-memref.global "private" constant @__constant_32xbf16 : memref<32xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-func.func @mlp_bf16(%arg0: memref<8x2x32x32xbf16>) -> memref<8x2x32x32xbf16> {
-  %cst = arith.constant 0.000000e+00 : bf16
-  %0 = memref.get_global @__constant_32xbf16 : memref<32xbf16>
-  %1 = memref.get_global @__constant_2x16x32x2xbf16 : memref<2x16x32x2xbf16>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x2x32x32xbf16>
-  %expand_shape = memref.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [8, 2, 32, 16, 2] : memref<8x2x32x32xbf16> into memref<8x2x32x16x2xbf16>
-  scf.forall (%arg1, %arg2) in (8, 2) {
-    %subview = memref.subview %alloc[%arg1, %arg2, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<8x2x32x32xbf16> to memref<32x32xbf16, strided<[32, 1], offset: ?>>
-    linalg.fill ins(%cst : bf16) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>)
-    %subview_0 = memref.subview %expand_shape[%arg1, 0, 0, 0, 0] [1, 2, 32, 16, 2] [1, 1, 1, 1, 1] : memref<8x2x32x16x2xbf16> to memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>
-    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%subview_0, %1 : memref<2x32x16x2xbf16, strided<[1024, 32, 2, 1], offset: ?>>, memref<2x16x32x2xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
-    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-      %2 = arith.mulf %in, %in_1 : bf16
-      %3 = arith.addf %out, %2 : bf16
-      linalg.yield %3 : bf16
-    }
-    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : memref<32xbf16>) outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
-    ^bb0(%in: bf16, %out: bf16):
-      %2 = arith.addf %in, %out : bf16
-      linalg.yield %2 : bf16
-    }
-    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} outs(%subview : memref<32x32xbf16, strided<[32, 1], offset: ?>>) {
-    ^bb0(%out: bf16):
-      %2 = arith.maximumf %out, %cst : bf16
-      linalg.yield %2 : bf16
-    }
-  }
-  return %alloc : memref<8x2x32x32xbf16>
-}
-
-// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --vector-to-kernels --registerBlocking=6,64,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
-// RUN: tpp-run -e optimal_register_blocking --entry-point-result=void --vector-to-kernels --registerBlocking=3,32,2 -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.3
-// RUN: fpcmp -r 0.01 %t.1 %t.2
-// RUN: fpcmp -r 0.01 %t.1 %t.3
-
-memref.global "private" constant @__constant_2x16x128x2xbf16 : memref<2x16x128x2xbf16> = dense<1.000000e+00> {alignment = 64 : i64}
-func.func @optimal_register_blocking(%arg0: memref<2x24x16x2xbf16>) -> memref<24x128xbf16> {
-  %0 = memref.get_global @__constant_2x16x128x2xbf16 : memref<2x16x128x2xbf16>
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<24x128xbf16>
-  %cst = arith.constant 0.000000e+00 : bf16
-  linalg.fill ins(%cst : bf16) outs(%alloc : memref<24x128xbf16>)
-
-    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %0 : memref<2x24x16x2xbf16>, memref<2x16x128x2xbf16>) outs(%alloc : memref<24x128xbf16>) {
-    ^bb0(%in: bf16, %in_1: bf16, %out: bf16):
-      %1 = arith.mulf %in, %in_1 : bf16
-      %2 = arith.addf %out, %1 : bf16
-      linalg.yield %2 : bf16
-    }
-  return %alloc : memref<24x128xbf16>
-}
-
-// RUN: tpp-run -e gemm_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-opt --tile-brgemm-linalg="registerBlocking=9,48,2"  --loop-invariant-code-motion --vectorization-pass --hoist-vector-transfer -vector-contract-to-micro-kernels | tpp-run -e gemm_splat --entry-point-result=void -print  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
-// RUN: fpcmp -r 0.01 %t.1 %t.2
-func.func @gemm_splat(%arg0: memref<1x9x32xbf16>, %arg1: memref<1x32x48xbf16>, %arg2: memref<9x48xbf16>) -> memref<9x48xbf16> {
-      linalg.batch_reduce_matmul ins(%arg0, %arg1 : memref<1x9x32xbf16>, memref<1x32x48xbf16>) outs(%arg2 : memref<9x48xbf16>)
-      return %arg2 : memref<9x48xbf16>
-}
-
-// RUN: tpp-run -e mlp_splat --entry-point-result=void --disable-vnni-packing -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run -e mlp_splat --entry-point-result=void -print --disable-vnni-packing --vector-to-kernels --registerBlocking=2,32,2  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
-// RUN: fpcmp -r 0.01 %t.1 %t.2
-#map_splat = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
-#map_splat1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
-#map_splat2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
-#map_splat3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
-#map_splat4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-func.func @mlp_splat(%arg0: tensor<8x32x32x32xbf16>, %arg1: tensor<32x32x32x32xbf16>, %arg2: tensor<32x32xbf16>, %arg3: tensor<8x32x32x32xbf16>) -> tensor<8x32x32x32xbf16> {
-  %0 = linalg.generic {indexing_maps = [#map_splat, #map_splat1, #map_splat2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<8x32x32x32xbf16>, tensor<32x32x32x32xbf16>) outs(%arg3 : tensor<8x32x32x32xbf16>) {
+func.func @gemm(%arg0: tensor<16x128x64x2xbf16>, %arg1: tensor<16x64x128x2xbf16>, %arg2: tensor<128x128xbf16>) -> tensor<128x128xbf16> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<16x128x64x2xbf16>, tensor<16x64x128x2xbf16>) outs(%arg2 : tensor<128x128xbf16>) {
   ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
-    %3 = arith.mulf %in, %in_0 : bf16
-    %4 = arith.addf %out, %3 : bf16
-    linalg.yield %4 : bf16
-  } -> tensor<8x32x32x32xbf16>
-  %1 = linalg.generic {indexing_maps = [#map_splat3, #map_splat4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg2 : tensor<32x32xbf16>) outs(%0 : tensor<8x32x32x32xbf16>) {
-  ^bb0(%in: bf16, %out: bf16):
-    %3 = arith.addf %in, %out : bf16
-    linalg.yield %3 : bf16
-  } -> tensor<8x32x32x32xbf16>
-  %cst = arith.constant 0.000000e+00 : bf16
-  %2 = linalg.generic {indexing_maps = [#map_splat4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%1 : tensor<8x32x32x32xbf16>) {
-  ^bb0(%out: bf16):
-    %3 = arith.maximumf %out, %cst : bf16
-    linalg.yield %3 : bf16
-  } -> tensor<8x32x32x32xbf16>
-  return %2 : tensor<8x32x32x32xbf16>
+    %1 = arith.mulf %in, %in_0 : bf16
+    %2 = arith.addf %out, %1 : bf16
+    linalg.yield %2 : bf16
+  } -> tensor<128x128xbf16>
+  return %0 : tensor<128x128xbf16>
+}
+
+
+// RUN: tpp-run -e mlp --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
+// RUN: tpp-run -e mlp --entry-point-result=void -print --nano-kernels --gemm-unroll=1,16,1 --registerBlocking=8,32,2  --splat-to-random --init-type normal  -seed 123 %s  > %t.2
+// RUN: fpcmp -r 0.01 %t.1 %t.2
+#mlp_map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>
+#mlp_map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>
+#mlp_map2 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+#mlp_map3 = affine_map<(d1, d2) -> (d1, d2)>
+func.func @mlp(%arg0: tensor<16x128x64x2xbf16>, %arg1: tensor<16x64x128x2xbf16>, %arg2: tensor<128x128xbf16>, %arg3 : tensor<128x128xbf16>) -> tensor<128x128xbf16> {
+  %0 = linalg.generic {indexing_maps = [#mlp_map, #mlp_map1, #mlp_map2], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<16x128x64x2xbf16>, tensor<16x64x128x2xbf16>) outs(%arg2 : tensor<128x128xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %1 = arith.mulf %in, %in_0 : bf16
+    %2 = arith.addf %out, %1 : bf16
+    linalg.yield %2 : bf16
+  } -> tensor<128x128xbf16>
+
+    %1 = linalg.generic {indexing_maps = [#mlp_map3, #mlp_map3], iterator_types = ["parallel", "parallel"]} ins(%arg3 : tensor<128x128xbf16>) outs(%0 : tensor<128x128xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %3 = arith.addf %in, %out : bf16
+      linalg.yield %3 : bf16
+    } -> tensor<128x128xbf16>
+
+   %cst = arith.constant 0.000000e+00 : bf16
+    %2 = linalg.generic {indexing_maps = [#mlp_map3], iterator_types = ["parallel", "parallel"]} outs(%1 : tensor<128x128xbf16>) {
+    ^bb0(%out: bf16):
+      %3 = arith.maximumf %out, %cst : bf16
+      linalg.yield %3 : bf16
+    } -> tensor<128x128xbf16>
+
+    return %2 : tensor<128x128xbf16>
 }

--- a/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32-i8-scale.mlir
@@ -1,7 +1,7 @@
 // RUN: tpp-opt --default-tpp-passes="vector-to-kernel registerBlocking=32,32,64" %s | FileCheck %s -check-prefix=IR
 
 // RUN: tpp-run -e entry --entry-point-result=void --linalg-to-loops -print --splat-to-random --init-type quant -seed 123  %s > %t.1
-// RUN: tpp-run -e entry --entry-point-result=void -print --vector-to-kernels --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
+// RUN: tpp-run -e entry --entry-point-result=void -print --nano-kernels --gemm-unroll=16,16,16 --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
 // IR-COUNT-4: amx.tile_muli
@@ -16,22 +16,66 @@
 // IR:     arith.sitofp
 // IR:     arith.mulf
 // IR:     vector.transfer_write
+
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6, d3)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6, d5, d3)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
 #map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
+
 module {
-  func.func @entry(%arg0: tensor<4x36x32x64xi8>, %arg1: tensor<128xf8E8M0FNU>, %arg2: tensor<24x36x16x32x4xi8>, %arg3: tensor<768xf8E8M0FNU>, %arg4: tensor<4x24x32x32xf32>) -> tensor<4x24x32x32xf32> {
+  func.func @entry(
+      %arg0: tensor<4x36x64x64xi8>,
+      %arg1: tensor<256xf8E8M0FNU>,
+      %arg2: tensor<24x36x16x64x4xi8>,
+      %arg3: tensor<1536xf8E8M0FNU>,
+      %arg4: tensor<4x24x64x64xf32>) -> tensor<4x24x64x64xf32> {
+
     %c0_i32 = arith.constant 0 : i32
-    %0 = tensor.empty() : tensor<4x24x32x32xi32>
-    %1 = linalg.fill ins(%c0_i32 : i32) outs(%0 : tensor<4x24x32x32xi32>) -> tensor<4x24x32x32xi32>
-    %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [4, 36, 32, 16, 4] : tensor<4x36x32x64xi8> into tensor<4x36x32x16x4xi8>
-    %2 = linalg.contract indexing_maps = [#map, #map1, #map2] ins(%expanded, %arg2 : tensor<4x36x32x16x4xi8>, tensor<24x36x16x32x4xi8>) outs(%1 : tensor<4x24x32x32xi32>) -> tensor<4x24x32x32xi32>
-    %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [4, 1, 32, 1] : tensor<128xf8E8M0FNU> into tensor<4x1x32x1xf8E8M0FNU>
-    %expanded_1 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [24, 1, 32, 1] : tensor<768xf8E8M0FNU> into tensor<24x1x32x1xf8E8M0FNU>
-    %3 = linalg.generic {indexing_maps = [#map3, #map4, #map5, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %expanded_0, %expanded_1 : tensor<4x24x32x32xi32>, tensor<4x1x32x1xf8E8M0FNU>, tensor<24x1x32x1xf8E8M0FNU>) outs(%arg4 : tensor<4x24x32x32xf32>) {
+
+    %0 = tensor.empty() : tensor<4x24x64x64xi32>
+
+    %1 = linalg.fill
+        ins(%c0_i32 : i32)
+        outs(%0 : tensor<4x24x64x64xi32>)
+        -> tensor<4x24x64x64xi32>
+
+    %expanded = tensor.expand_shape %arg0
+        [[0], [1], [2], [3, 4]]
+        output_shape [4, 36, 64, 16, 4]
+        : tensor<4x36x64x64xi8>
+       into tensor<4x36x64x16x4xi8>
+
+    %2 = linalg.contract
+        indexing_maps = [#map, #map1, #map2]
+        ins(%expanded, %arg2
+            : tensor<4x36x64x16x4xi8>,
+              tensor<24x36x16x64x4xi8>)
+        outs(%1 : tensor<4x24x64x64xi32>)
+        -> tensor<4x24x64x64xi32>
+
+    %expanded_0 = tensor.expand_shape %arg1
+        [[0, 1, 2, 3]]
+        output_shape [4, 1, 64, 1]
+        : tensor<256xf8E8M0FNU>
+       into tensor<4x1x64x1xf8E8M0FNU>
+
+    %expanded_1 = tensor.expand_shape %arg3
+        [[0, 1, 2, 3]]
+        output_shape [24, 1, 64, 1]
+        : tensor<1536xf8E8M0FNU>
+       into tensor<24x1x64x1xf8E8M0FNU>
+
+    %3 = linalg.generic {
+        indexing_maps = [#map3, #map4, #map5, #map3],
+        iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+      }
+      ins(%2, %expanded_0, %expanded_1
+          : tensor<4x24x64x64xi32>,
+            tensor<4x1x64x1xf8E8M0FNU>,
+            tensor<24x1x64x1xf8E8M0FNU>)
+      outs(%arg4 : tensor<4x24x64x64xf32>) {
     ^bb0(%in: i32, %in_2: f8E8M0FNU, %in_3: f8E8M0FNU, %out: f32):
       %4 = arith.extf %in_2 fastmath<nnan> : f8E8M0FNU to f32
       %5 = arith.extf %in_3 fastmath<nnan> : f8E8M0FNU to f32
@@ -39,7 +83,8 @@ module {
       %7 = arith.sitofp %in : i32 to f32
       %8 = arith.mulf %7, %6 : f32
       linalg.yield %8 : f32
-    } -> tensor<4x24x32x32xf32>
-    return %3 : tensor<4x24x32x32xf32>
+    } -> tensor<4x24x64x64xf32>
+
+    return %3 : tensor<4x24x64x64xf32>
   }
 }

--- a/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32.mlir
+++ b/test/Integration/I8/AMX/tpp-run-gemm-dequantize-correctness-i8-f32.mlir
@@ -1,7 +1,7 @@
 // RUN: tpp-opt --default-tpp-passes="vector-to-kernel registerBlocking=32,32,64" %s | FileCheck %s -check-prefix=IR
 
 // RUN: tpp-run -e entry --entry-point-result=void --linalg-to-loops -print --splat-to-random --init-type quant -seed 123  %s > %t.1
-// RUN: tpp-run -e entry --entry-point-result=void -print --vector-to-kernels --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
+// RUN: tpp-run -e entry --entry-point-result=void -print --nano-kernels --gemm-unroll=16,16,16 --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
 // IR-COUNT-4: amx.tile_muli
@@ -12,27 +12,69 @@
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
 #map5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
 
-  func.func @entry(%arg0: tensor<2x2x32x64xi8>, %arg1: tensor<64xf32>, %arg2: tensor<2x2x16x32x4xi8>, %arg3: tensor<64xf32>, %arg4: tensor<2x2x32x32xf32>) -> tensor<2x2x32x32xf32> {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tensor.empty() : tensor<2x2x32x32xi32>
-    %1 = linalg.fill ins(%c0_i32 : i32) outs(%0 : tensor<2x2x32x32xi32>) -> tensor<2x2x32x32xi32>
-    %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [2, 2, 32, 16, 4] : tensor<2x2x32x64xi8> into tensor<2x2x32x16x4xi8>
-    %2 = linalg.contract indexing_maps = [#map, #map1, #map2] ins(%expanded, %arg2 : tensor<2x2x32x16x4xi8>, tensor<2x2x16x32x4xi8>) outs(%1 : tensor<2x2x32x32xi32>) -> tensor<2x2x32x32xi32>
-    %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 1, 32, 1] : tensor<64xf32> into tensor<2x1x32x1xf32>
-    %expanded_1 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [2, 1, 32, 1] : tensor<64xf32> into tensor<2x1x32x1xf32>
-    %3 = linalg.generic {indexing_maps = [#map3, #map4, #map5, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %expanded_0, %expanded_1 : tensor<2x2x32x32xi32>, tensor<2x1x32x1xf32>, tensor<2x1x32x1xf32>) outs(%arg4 : tensor<2x2x32x32xf32>) {
-    ^bb0(%in: i32, %in_2: f32, %in_3: f32, %out: f32):
-      %4 = arith.mulf %in_2, %in_3 : f32
-      %5 = arith.sitofp %in : i32 to f32
-      %6 = arith.mulf %5, %4 : f32
-      linalg.yield %6 : f32
-    } -> tensor<2x2x32x32xf32>
-    return %3 : tensor<2x2x32x32xf32>
-  }
+func.func @entry(
+    %arg0: tensor<2x2x64x64xi8>,
+    %arg1: tensor<128xf32>,
+    %arg2: tensor<2x2x16x64x4xi8>,
+    %arg3: tensor<128xf32>,
+    %arg4: tensor<2x2x64x64xf32>) -> tensor<2x2x64x64xf32> {
 
+  %c0_i32 = arith.constant 0 : i32
+
+  %0 = tensor.empty() : tensor<2x2x64x64xi32>
+
+  %1 = linalg.fill
+      ins(%c0_i32 : i32)
+      outs(%0 : tensor<2x2x64x64xi32>)
+      -> tensor<2x2x64x64xi32>
+
+  %expanded = tensor.expand_shape %arg0
+      [[0], [1], [2], [3, 4]]
+      output_shape [2, 2, 64, 16, 4]
+      : tensor<2x2x64x64xi8>
+     into tensor<2x2x64x16x4xi8>
+
+  %2 = linalg.contract
+      indexing_maps = [#map, #map1, #map2]
+      ins(%expanded, %arg2
+          : tensor<2x2x64x16x4xi8>,
+            tensor<2x2x16x64x4xi8>)
+      outs(%1 : tensor<2x2x64x64xi32>)
+      -> tensor<2x2x64x64xi32>
+
+  %expanded_0 = tensor.expand_shape %arg1
+      [[0, 1, 2, 3]]
+      output_shape [2, 1, 64, 1]
+      : tensor<128xf32>
+     into tensor<2x1x64x1xf32>
+
+  %expanded_1 = tensor.expand_shape %arg3
+      [[0, 1, 2, 3]]
+      output_shape [2, 1, 64, 1]
+      : tensor<128xf32>
+     into tensor<2x1x64x1xf32>
+
+  %3 = linalg.generic {
+      indexing_maps = [#map3, #map4, #map5, #map3],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+    }
+    ins(%2, %expanded_0, %expanded_1
+        : tensor<2x2x64x64xi32>,
+          tensor<2x1x64x1xf32>,
+          tensor<2x1x64x1xf32>)
+    outs(%arg4 : tensor<2x2x64x64xf32>) {
+  ^bb0(%in: i32, %in_2: f32, %in_3: f32, %out: f32):
+    %4 = arith.mulf %in_2, %in_3 : f32
+    %5 = arith.sitofp %in : i32 to f32
+    %6 = arith.mulf %5, %4 : f32
+    linalg.yield %6 : f32
+  } -> tensor<2x2x64x64xf32>
+
+  return %3 : tensor<2x2x64x64xf32>
+}
 
 // RUN: tpp-run -e diff_scale --entry-point-result=void --linalg-to-loops -print --splat-to-random --init-type quant -seed 123  %s > %t.1
-// RUN: tpp-run -e diff_scale --entry-point-result=void -print --vector-to-kernels --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
+// RUN: tpp-run -e diff_scale --entry-point-result=void -print --nano-kernels --gemm-unroll=16,16,16 --registerBlocking=32,32,64 --splat-to-random -seed 123 --init-type quant %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
 // IR-COUNT-4: amx.tile_muli
@@ -53,20 +95,63 @@
 #afmap4 = affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, 0)>
 #afmap5 = affine_map<(d0, d1, d2, d3) -> (d1, 0, d3, 0)>
 
-  func.func @diff_scale(%arg0: tensor<2x2x32x64xi8>, %arg1: tensor<64xf32>, %arg2: tensor<4x2x16x32x4xi8>, %arg3: tensor<128xf32>, %arg4: tensor<2x4x32x32xf32>) -> tensor<2x4x32x32xf32> {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tensor.empty() : tensor<2x4x32x32xi32>
-    %1 = linalg.fill ins(%c0_i32 : i32) outs(%0 : tensor<2x4x32x32xi32>) -> tensor<2x4x32x32xi32>
-    %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [2, 2, 32, 16, 4] : tensor<2x2x32x64xi8> into tensor<2x2x32x16x4xi8>
-    %2 = linalg.contract indexing_maps = [#afmap, #afmap1, #afmap2] ins(%expanded, %arg2 : tensor<2x2x32x16x4xi8>, tensor<4x2x16x32x4xi8>) outs(%1 : tensor<2x4x32x32xi32>) -> tensor<2x4x32x32xi32>
-    %expanded_0 = tensor.expand_shape %arg1 [[0, 1, 2, 3]] output_shape [2, 1, 32, 1] : tensor<64xf32> into tensor<2x1x32x1xf32>
-    %expanded_1 = tensor.expand_shape %arg3 [[0, 1, 2, 3]] output_shape [4, 1, 32, 1] : tensor<128xf32> into tensor<4x1x32x1xf32>
-    %3 = linalg.generic {indexing_maps = [#afmap3, #afmap4, #afmap5, #afmap3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2, %expanded_0, %expanded_1 : tensor<2x4x32x32xi32>, tensor<2x1x32x1xf32>, tensor<4x1x32x1xf32>) outs(%arg4 : tensor<2x4x32x32xf32>) {
-    ^bb0(%in: i32, %in_2: f32, %in_3: f32, %out: f32):
-      %4 = arith.mulf %in_2, %in_3 : f32
-      %5 = arith.sitofp %in : i32 to f32
-      %6 = arith.mulf %5, %4 : f32
-      linalg.yield %6 : f32
-    } -> tensor<2x4x32x32xf32>
-    return %3 : tensor<2x4x32x32xf32>
-  }
+func.func @diff_scale(
+    %arg0: tensor<2x2x64x64xi8>,
+    %arg1: tensor<128xf32>,
+    %arg2: tensor<4x2x16x64x4xi8>,
+    %arg3: tensor<256xf32>,
+    %arg4: tensor<2x4x64x64xf32>) -> tensor<2x4x64x64xf32> {
+
+  %c0_i32 = arith.constant 0 : i32
+
+  %0 = tensor.empty() : tensor<2x4x64x64xi32>
+
+  %1 = linalg.fill
+      ins(%c0_i32 : i32)
+      outs(%0 : tensor<2x4x64x64xi32>)
+      -> tensor<2x4x64x64xi32>
+
+  %expanded = tensor.expand_shape %arg0
+      [[0], [1], [2], [3, 4]]
+      output_shape [2, 2, 64, 16, 4]
+      : tensor<2x2x64x64xi8>
+     into tensor<2x2x64x16x4xi8>
+
+  %2 = linalg.contract
+      indexing_maps = [#afmap, #afmap1, #afmap2]
+      ins(%expanded, %arg2
+          : tensor<2x2x64x16x4xi8>,
+            tensor<4x2x16x64x4xi8>)
+      outs(%1 : tensor<2x4x64x64xi32>)
+      -> tensor<2x4x64x64xi32>
+
+  %expanded_0 = tensor.expand_shape %arg1
+      [[0, 1, 2, 3]]
+      output_shape [2, 1, 64, 1]
+      : tensor<128xf32>
+     into tensor<2x1x64x1xf32>
+
+  %expanded_1 = tensor.expand_shape %arg3
+      [[0, 1, 2, 3]]
+      output_shape [4, 1, 64, 1]
+      : tensor<256xf32>
+     into tensor<4x1x64x1xf32>
+
+  %3 = linalg.generic {
+      indexing_maps = [#afmap3, #afmap4, #afmap5, #afmap3],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+    }
+    ins(%2, %expanded_0, %expanded_1
+        : tensor<2x4x64x64xi32>,
+          tensor<2x1x64x1xf32>,
+          tensor<4x1x64x1xf32>)
+    outs(%arg4 : tensor<2x4x64x64xf32>) {
+  ^bb0(%in: i32, %in_2: f32, %in_3: f32, %out: f32):
+    %4 = arith.mulf %in_2, %in_3 : f32
+    %5 = arith.sitofp %in : i32 to f32
+    %6 = arith.mulf %5, %4 : f32
+    linalg.yield %6 : f32
+  } -> tensor<2x4x64x64xf32>
+
+  return %3 : tensor<2x4x64x64xf32>
+}

--- a/test/Integration/I8/vector-contract-to-ukernels-i8.mlir
+++ b/test/Integration/I8/vector-contract-to-ukernels-i8.mlir
@@ -1,15 +1,37 @@
 // RUN: tpp-run  -e gemm_i8 --entry-point-result=void -print --splat-to-random --init-type normal  -seed 123  %s > %t.1
-// RUN: tpp-run  -e gemm_i8 --entry-point-result=void --vector-to-kernels --registerBlocking=3,32,4 -print  --splat-to-random --init-type normal  -seed 123 %s > %t.2
+// RUN: tpp-run  -e gemm_i8 --entry-point-result=void --nano-kernels --registerBlocking=3,32,4 --gemm-unroll=1,8,1 -print  --splat-to-random --init-type normal  -seed 123 %s > %t.2
 // RUN: fpcmp -r 0.001 %t.1 %t.2
 
-func.func @gemm_i8(%arg0: memref<2x24x8x4xi8>, %arg1: memref<2x8x128x4xi8>, %arg2: memref<24x128xi32>) -> memref<24x128xi32> {
-    linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>, affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>], iterator_types = ["reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : memref<2x24x8x4xi8>, memref<2x8x128x4xi8>) outs(%arg2 : memref<24x128xi32>) {
-    ^bb0(%in: i8, %in_1: i8, %out: i32):
-        %0 = arith.extsi %in : i8 to i32
-        %1 = arith.extsi %in_1 : i8 to i32
-        %2 = arith.muli %0, %1 : i32
-        %3 = arith.addi %out, %2 : i32
-        linalg.yield %3 : i32
+func.func @gemm_i8(
+    %arg0: tensor<2x24x8x4xi8>,
+    %arg1: tensor<2x8x128x4xi8>,
+    %arg2: tensor<24x128xi32>
+) -> tensor<24x128xi32> {
+  %result = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4, d1)>,
+        affine_map<(d0, d1, d2, d3, d4) -> (d0, d4, d3, d1)>,
+        affine_map<(d0, d1, d2, d3, d4) -> (d2, d3)>
+      ],
+      iterator_types = [
+        "reduction",
+        "reduction",
+        "parallel",
+        "parallel",
+        "reduction"
+      ]
     }
-  return %arg2 : memref<24x128xi32>
+    ins(%arg0, %arg1
+      : tensor<2x24x8x4xi8>,
+        tensor<2x8x128x4xi8>)
+    outs(%arg2 : tensor<24x128xi32>) {
+  ^bb0(%in: i8, %in_1: i8, %out: i32):
+    %0 = arith.extsi %in : i8 to i32
+    %1 = arith.extsi %in_1 : i8 to i32
+    %2 = arith.muli %0, %1 : i32
+    %3 = arith.addi %out, %2 : i32
+    linalg.yield %3 : i32
+  } -> tensor<24x128xi32>
+
+  return %result : tensor<24x128xi32>
 }


### PR DESCRIPTION
This patch updates the exiting `vector-to-kernels` pipeline tests regards to `nano-kernel` pipeline like `tensor` inputs, `--gemm-unroll` parameters, etc.,.